### PR TITLE
Fold `get_export` into `exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def say_hello():
 hello = Func(store, FuncType([], []), say_hello)
 
 instance = Instance(module, [hello])
-run = instance.get_export("run")
+run = instance.exports["run"]
 run()
 ```
 

--- a/examples/gcd.py
+++ b/examples/gcd.py
@@ -5,6 +5,6 @@ from wasmtime import Store, Module, Instance
 store = Store()
 module = Module.from_file(store, './examples/gcd.wat')
 instance = Instance(module, [])
-gcd = instance.get_export("gcd")
+gcd = instance.exports["gcd"]
 
 print("gcd(6, 27) = %d" % gcd(6, 27))

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -19,4 +19,4 @@ hello = Func(store, FuncType([], []), say_hello)
 
 # And with all that we can instantiate our module and call the export!
 instance = Instance(module, [hello])
-instance.get_export("run")()
+instance.exports["run"]()

--- a/examples/linking.py
+++ b/examples/linking.py
@@ -21,5 +21,5 @@ linker.define_instance("linking2", linking2)
 
 # And with that we can perform the final link and the execute the module.
 linking1 = linker.instantiate(linking1)
-run = linking1.get_export("run")
+run = linking1.exports["run"]
 run()

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -13,10 +13,10 @@ module = Module.from_file(wasmtime_store, "examples/memory.wat")
 instance = Instance(module, [])
 
 # Load up our exports from the instance
-memory = instance.get_export("memory")
-size = instance.get_export("size")
-load = instance.get_export("load")
-store = instance.get_export("store")
+memory = instance.exports["memory"]
+size = instance.exports["size"]
+load = instance.exports["load"]
+store = instance.exports["store"]
 
 print("Checking memory...")
 assert(memory.size == 2)

--- a/examples/multi.py
+++ b/examples/multi.py
@@ -27,7 +27,7 @@ print("Instantiating module...")
 instance = Instance(module, [callback_func])
 
 print("Extracting export...")
-g = instance.get_export("g")
+g = instance.exports["g"]
 
 print("Calling export \"g\"...")
 results = g(1, 3)
@@ -37,7 +37,7 @@ assert(results[0] == 4)
 assert(results[1] == 2)
 
 print("Calling export \"round_trip_many\"...")
-round_trip_many = instance.get_export("round_trip_many")
+round_trip_many = instance.exports["round_trip_many"]
 results = round_trip_many(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 print("Printing result...")

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -97,9 +97,9 @@ class TestFunc(unittest.TestCase):
         store = Store()
 
         def runtest(caller):
-            self.assertEqual(caller.get_export(''), None)
-            self.assertEqual(caller.get_export('x'), None)
-            self.assertEqual(caller.get_export('y'), None)
+            self.assertEqual(caller.get(''), None)
+            self.assertEqual(caller.get('x'), None)
+            self.assertEqual(caller.get('y'), None)
 
         Func(store, FuncType([], []), runtest, access_caller=True)()
 
@@ -110,8 +110,8 @@ class TestFunc(unittest.TestCase):
             hit['yes'] = True
             hit['caller'] = caller
 
-            self.assertTrue(caller.get_export('bar') is None)
-            mem = caller.get_export('foo')
+            self.assertTrue(caller.get('bar') is None)
+            mem = caller.get('foo')
             self.assertTrue(isinstance(mem, Memory))
 
             self.assertEqual(mem.data_ptr[0], ord('f'))
@@ -130,17 +130,17 @@ class TestFunc(unittest.TestCase):
         func = Func(store, FuncType([], []), runtest2, access_caller=True)
         Instance(module, [func])
         self.assertTrue(hit['yes'])
-        self.assertTrue(hit['caller'].get_export('foo') is None)
+        self.assertTrue(hit['caller'].get('foo') is None)
 
         # Test that `Caller` is invalidated even on exceptions
         hit2 = {}
 
         def runtest3(caller):
             hit2['caller'] = caller
-            self.assertTrue(caller.get_export('foo') is not None)
+            self.assertTrue(caller['foo'] is not None)
             raise WasmtimeError('foo')
 
         func = Func(store, FuncType([], []), runtest3, access_caller=True)
         with self.assertRaises(Trap):
             Instance(module, [func])
-        self.assertTrue(hit2['caller'].get_export('foo') is None)
+        self.assertTrue(hit2['caller'].get('foo') is None)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -18,6 +18,14 @@ class TestInstance(unittest.TestCase):
 
         extern()
 
+        self.assertTrue(instance.exports[''] is not None)
+        with self.assertRaises(KeyError):
+            instance.exports['x']
+        with self.assertRaises(IndexError):
+            instance.exports[100]
+        self.assertTrue(instance.exports.get('x') is None)
+        self.assertTrue(instance.exports.get(2) is None)
+
     def test_export_global(self):
         module = Module(
             Store(), '(module (global (export "") i32 (i32.const 3)))')

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -141,7 +141,22 @@ class Caller(object):
     def __init__(self, ptr):
         self.__ptr__ = ptr
 
-    def get_export(self, name):
+    def __getitem__(self, name):
+        """
+        Looks up an export with `name` on the calling module.
+
+        If `name` isn't defined on the calling module, or if the caller has gone
+        away for some reason, then this will raise a `KeyError`. For more
+        information about when this could fail see the `get` method which
+        returns `None` on failure.
+        """
+
+        ret = self.get(name)
+        if ret is None:
+            raise KeyError("failed to find export {}".format(name))
+        return ret
+
+    def get(self, name):
         """
         Looks up an export with `name` on the calling module.
 


### PR DESCRIPTION
Remove `Instance.get_export` as well as `Caller.get_export`. The former
is replaced with string indexing on `Instance.exports` and the latter is
replaced with string indexing on `Caller`

Closes #4