### PR TITLE
Remove Python 2-isms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     },
     packages=['wasmtime'],
     include_package_data=True,
-    python_requires='>=2.7',
+    python_requires='>=3.5',
     test_suite="tests",
     extras_require={
         'testing': [

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -16,7 +16,7 @@ def setter_property(fset):
     return prop
 
 
-class Config(object):
+class Config:
     """
     Global configuration, used to create an `Engine`.
 

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -6,7 +6,7 @@ dll.wasm_engine_new.restype = P_wasm_engine_t
 dll.wasm_engine_new_with_config.restype = P_wasm_engine_t
 
 
-class Engine(object):
+class Engine:
     def __init__(self, config=None):
         if config is None:
             self.__ptr__ = dll.wasm_engine_new()

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -48,7 +48,7 @@ def get_extern_ptr(item):
         raise TypeError("expected a Func, Global, Memory, or Table")
 
 
-class Extern(object):
+class Extern:
     def __init__(self, ptr):
         self.ptr = ptr
 

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -15,7 +15,7 @@ dll.wasm_func_as_extern.restype = P_wasm_extern_t
 dll.wasmtime_caller_export_get.restype = P_wasm_extern_t
 
 
-class Func(object):
+class Func:
     def __init__(self, store, ty, func, access_caller=False):
         """
         Creates a new func in `store` with the given `ty` which calls the closure
@@ -137,7 +137,7 @@ class Func(object):
             dll.wasm_func_delete(self.__ptr__)
 
 
-class Caller(object):
+class Caller:
     def __init__(self, ptr):
         self.__ptr__ = ptr
 
@@ -244,7 +244,7 @@ def finalize(idx):
     pass
 
 
-class Slab(object):
+class Slab:
     def __init__(self):
         self.list = []
         self.next = 0

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -8,7 +8,7 @@ dll.wasm_global_as_extern.restype = P_wasm_extern_t
 dll.wasmtime_global_set.restype = P_wasmtime_error_t
 
 
-class Global(object):
+class Global:
     def __init__(self, store, ty, val):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -6,7 +6,7 @@ from ._extern import wrap_extern, get_extern_ptr
 dll.wasmtime_instance_new.restype = P_wasmtime_error_t
 
 
-class Instance(object):
+class Instance:
     def __init__(self, module, imports):
         """
         Creates a new instance by instantiating the `module` given with the
@@ -75,7 +75,7 @@ class Instance(object):
             dll.wasm_instance_delete(self.__ptr__)
 
 
-class InstanceExports(object):
+class InstanceExports:
     def __init__(self, extern_list, module):
         self._extern_list = extern_list
         self._extern_map = {}
@@ -106,7 +106,7 @@ class InstanceExports(object):
         return None
 
 
-class ExternTypeList(object):
+class ExternTypeList:
     def __init__(self):
         self.vec = wasm_extern_vec_t(0, None)
 

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -12,7 +12,7 @@ dll.wasmtime_linker_define_wasi.restype = P_wasmtime_error_t
 dll.wasmtime_linker_instantiate.restype = P_wasmtime_error_t
 
 
-class Linker(object):
+class Linker:
     def __init__(self, store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -10,7 +10,7 @@ dll.wasm_memory_as_extern.restype = P_wasm_extern_t
 dll.wasm_memory_grow.restype = c_bool
 
 
-class Memory(object):
+class Memory:
     def __init__(self, store, ty):
         """
         Creates a new memory in `store` with the given `ty`

--- a/wasmtime/_module.py
+++ b/wasmtime/_module.py
@@ -6,7 +6,7 @@ dll.wasmtime_module_new.restype = P_wasmtime_error_t
 dll.wasmtime_module_validate.restype = P_wasmtime_error_t
 
 
-class Module(object):
+class Module:
     @classmethod
     def from_file(cls, store, path):
         """
@@ -98,7 +98,7 @@ class Module(object):
             dll.wasm_module_delete(self.__ptr__)
 
 
-class ImportTypeList(object):
+class ImportTypeList:
     def __init__(self):
         self.vec = wasm_importtype_vec_t(0, None)
 
@@ -106,7 +106,7 @@ class ImportTypeList(object):
         dll.wasm_importtype_vec_delete(byref(self.vec))
 
 
-class ExportTypeList(object):
+class ExportTypeList:
     def __init__(self):
         self.vec = wasm_exporttype_vec_t(0, None)
 

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -6,7 +6,7 @@ dll.wasm_store_new.restype = P_wasm_store_t
 dll.wasmtime_interrupt_handle_new.restype = P_wasmtime_interrupt_handle_t
 
 
-class Store(object):
+class Store:
     def __init__(self, engine=None):
         if engine is None:
             engine = Engine()
@@ -34,7 +34,7 @@ class Store(object):
             dll.wasm_store_delete(self.__ptr__)
 
 
-class InterruptHandle(object):
+class InterruptHandle:
     """
     A handle which can be used to interrupt executing WebAssembly code, forcing
     it to trap.

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -20,7 +20,7 @@ def get_func_ptr(init):
         raise TypeError("expected a `Func` or `None`")
 
 
-class Table(object):
+class Table:
     def __init__(self, store, ty, init):
         """
         Creates a new table within `store` with the specified `ty`.

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -75,7 +75,7 @@ class Trap(Exception):
             dll.wasm_trap_delete(self.__ptr__)
 
 
-class Frame(object):
+class Frame:
     @classmethod
     def __from_ptr__(cls, ptr, owner):
         ty = cls.__new__(cls)
@@ -144,7 +144,7 @@ class Frame(object):
             dll.wasm_frame_delete(self.__ptr__)
 
 
-class FrameList(object):
+class FrameList:
     def __init__(self):
         self.vec = wasm_frame_vec_t(0, None)
 

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -30,7 +30,7 @@ dll.wasm_valtype_kind.restype = c_uint8
 dll.wasm_globaltype_mutability.restype = c_uint8
 
 
-class ValType(object):
+class ValType:
     @classmethod
     def i32(cls):
         ptr = dll.wasm_valtype_new(WASM_I32)
@@ -132,7 +132,7 @@ def take_owned_valtype(ty):
     return dll.wasm_valtype_new(dll.wasm_valtype_kind(ty.__ptr__))
 
 
-class FuncType(object):
+class FuncType:
     def __init__(self, params, results):
         for param in params:
             if not isinstance(param, ValType):
@@ -193,7 +193,7 @@ class FuncType(object):
             dll.wasm_functype_delete(self.__ptr__)
 
 
-class GlobalType(object):
+class GlobalType:
     def __init__(self, valtype, mutable):
         if mutable:
             mutability = WASM_VAR
@@ -240,7 +240,7 @@ class GlobalType(object):
             dll.wasm_globaltype_delete(self.__ptr__)
 
 
-class Limits(object):
+class Limits:
     def __init__(self, min, max):
         self.min = min
         self.max = max
@@ -263,7 +263,7 @@ class Limits(object):
         return Limits(min, max)
 
 
-class TableType(object):
+class TableType:
     def __init__(self, valtype, limits):
         if not isinstance(limits, Limits):
             raise TypeError("expected Limits")
@@ -307,7 +307,7 @@ class TableType(object):
             dll.wasm_tabletype_delete(self.__ptr__)
 
 
-class MemoryType(object):
+class MemoryType:
     def __init__(self, limits):
         if not isinstance(limits, Limits):
             raise TypeError("expected Limits")
@@ -359,7 +359,7 @@ def wrap_externtype(ptr, owner):
     return MemoryType.__from_ptr__(val, owner)
 
 
-class ImportType(object):
+class ImportType:
     @classmethod
     def __from_ptr__(cls, ptr, owner):
         ty = cls.__new__(cls)
@@ -397,7 +397,7 @@ class ImportType(object):
             dll.wasm_importtype_delete(self.__ptr__)
 
 
-class ExportType(object):
+class ExportType:
     @classmethod
     def __from_ptr__(cls, ptr, owner):
         ty = cls.__new__(cls)

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -11,7 +11,7 @@ def is_integer(val):
         return isinstance(val, (int, long))
 
 
-class Val(object):
+class Val:
     @classmethod
     def i32(cls, val):
         """

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -9,7 +9,7 @@ dll.wasi_instance_new.restype = P_wasi_instance_t
 dll.wasi_instance_bind_import.restype = P_wasm_extern_t
 
 
-class WasiConfig(object):
+class WasiConfig:
     def __init__(self):
         self.__ptr__ = dll.wasi_config_new()
 
@@ -87,7 +87,7 @@ def to_char_array(strings):
     return ptrs
 
 
-class WasiInstance(object):
+class WasiInstance:
     def __init__(self, store, name, config):
         if not isinstance(store, Store):
             raise TypeError("expected a `Store`")


### PR DESCRIPTION
This fixes `python_requires` in `setup.py` to be `>= 3.5` since that's what's tested and supported. I don't know how this fix affects things, but it might cause problems when someone with Python 2 tries to install wasmtime-py and it might cause problems with wheel names.

In Python 3, classes don't need to subclass object--all classes are new-style now. This is cosmetic and doesn't change the behavior of anything.