### PR TITLE
Inline is_integer(), which is not needed as we require Python 3

### DIFF
--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -1,14 +1,5 @@
 from ._ffi import *
-from ctypes import *
 from wasmtime import ValType
-import sys
-
-
-def is_integer(val):
-    if sys.version_info >= (3, 0):
-        return isinstance(val, int)
-    else:
-        return isinstance(val, (int, long))
 
 
 class Val:
@@ -17,7 +8,7 @@ class Val:
         """
         Create a new 32-bit integer value
         """
-        if not is_integer(val):
+        if not isinstance(val, int):
             raise TypeError("expected an integer")
         ffi = wasm_val_t(WASM_I32)
         ffi.of.i32 = val
@@ -28,7 +19,7 @@ class Val:
         """
         Create a new 64-bit integer value
         """
-        if not is_integer(val):
+        if not isinstance(val, int):
             raise TypeError("expected an integer")
         ffi = wasm_val_t(WASM_I64)
         ffi.of.i64 = val


### PR DESCRIPTION
The use of the `long` (with no `# noqa`) was failing the `flake8` CI test.