### PR TITLE
Require Python 3.6 (not 3.5), as this is the lowest version the CI tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     },
     packages=['wasmtime'],
     include_package_data=True,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     test_suite="tests",
     extras_require={
         'testing': [
@@ -41,7 +41,6 @@ setuptools.setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Also. Python 3.6 gave us [f-strings](https://www.python.org/downloads/release/python-360/)!

