### PR TITLE
Update how wheels are produced

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [master, wheel-updates]
     tags-ignore: [dev]
   pull_request:
     branches: [master]
@@ -24,26 +24,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
-      - run: python download-wasmtime.py
-      - uses: actions/setup-python@v1
-        with:
           python-version: ${{ matrix.python-version }}
+      - run: python download-wasmtime.py
       - run: pip install pytest
       - run: pytest
 
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-        - os: ubuntu-latest
-          plat: manylinux1-x86_64
-        - os: macos-latest
-          plat: macosx-10-13-x86_64
-        - os: windows-latest
-          plat: win-amd64
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
@@ -55,11 +42,38 @@ jobs:
     # If this is a tagged build use real version numbers
     - run: echo "::set-env name=PROD::true"
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    - run: python download-wasmtime.py
-    - run: python setup.py bdist_wheel --plat-name ${{ matrix.plat }}
+    - run: |
+        git clean -fdx wasmtime build
+        python download-wasmtime.py linux x86_64
+        python setup.py bdist_wheel --plat-name manylinux1-x86_64
+    - run: |
+        git clean -fdx wasmtime build
+        python download-wasmtime.py darwin x86_64
+        python setup.py bdist_wheel --plat-name macosx-10-13-x86_64
+    - run: |
+        git clean -fdx wasmtime build
+        python download-wasmtime.py win32 x86_64
+        python setup.py bdist_wheel --plat-name win-amd64
+
+    # Build an "any" wheel with:
+    #
+    #   * MinGW
+    #   * Linux AArch64
+    #
+    # because at this time I don't know what the `--plat-name` tags supported on
+    # PyPI are for these platforms. Our hope is that any platform not matching
+    # the above `--plat-name` arguments will install this `any` wheel instead,
+    # and then when the wheel runs it'll dynamically select from the available
+    # shared libraries.
+    - run: |
+        git clean -fdx wasmtime build
+        python download-wasmtime.py win32 x86_64
+        python download-wasmtime.py linux aarch64
+        python setup.py bdist_wheel
+
     - uses: actions/upload-artifact@v1
       with:
-        name: wheel-${{ matrix.os }}
+        name: wheels
         path: dist
 
   flake8:
@@ -134,16 +148,9 @@ jobs:
         python-version: '3.x'
     - uses: actions/download-artifact@v1
       with:
-        name: wheel-ubuntu-latest
-    - uses: actions/download-artifact@v1
-      with:
-        name: wheel-macos-latest
-    - uses: actions/download-artifact@v1
-      with:
-        name: wheel-windows-latest
+        name: wheels
     - run: find .
-
-    - run: mkdir dist && mv wheel-*-latest/* dist
+    - run: mv wheels dist
 
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, wheel-updates]
+    branches: [master]
     tags-ignore: [dev]
   pull_request:
     branches: [master]

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 *.pyd
 .coverage
 htmlcov
+wasmtime/linux-*
+wasmtime/darwin-*
+wasmtime/win32-*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-recursive-include wasmtime *.pyd
+recursive-include wasmtime *.so
+recursive-include wasmtime *.dll
+recursive-include wasmtime *.dylib

--- a/download-wasmtime.py
+++ b/download-wasmtime.py
@@ -17,14 +17,14 @@ def main(platform, arch):
         arch = 'x86_64'
     if platform == 'linux':
         filename = 'wasmtime-dev-{}-linux-c-api.tar.xz'.format(arch)
-        libname = 'libwasmtime.so'
+        libname = '_libwasmtime.so'
     elif platform == 'win32':
         filename = 'wasmtime-dev-{}-windows-c-api.zip'.format(arch)
         is_zip = True
-        libname = 'wasmtime.dll'
+        libname = '_wasmtime.dll'
     elif platform == 'darwin':
         filename = 'wasmtime-dev-{}-macos-c-api.tar.xz'.format(arch)
-        libname = 'libwasmtime.dylib'
+        libname = '_libwasmtime.dylib'
     else:
         raise RuntimeError("unknown platform: " + sys.platform)
 

--- a/download-wasmtime.py
+++ b/download-wasmtime.py
@@ -13,6 +13,8 @@ import zipfile
 
 def main(platform, arch):
     is_zip = False
+    if arch == 'AMD64':
+        arch = 'x86_64'
     if platform == 'linux':
         filename = 'wasmtime-dev-{}-linux-c-api.tar.xz'.format(arch)
         libname = 'libwasmtime.so'
@@ -33,7 +35,7 @@ def main(platform, arch):
     dst = os.path.join('wasmtime', dirname, libname)
     try:
         shutil.rmtree(os.path.dirname(dst))
-    except:
+    except Exception:
         pass
     os.makedirs(os.path.dirname(dst))
 
@@ -65,4 +67,7 @@ def main(platform, arch):
 
 
 if __name__ == '__main__':
-    main(sys.platform, platform.machine())
+    if len(sys.argv) > 2:
+        main(sys.argv[1], sys.argv[2])
+    else:
+        main(sys.platform, platform.machine())

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -1,13 +1,29 @@
 from ctypes import *
 import os
 import sys
+import platform
 
 from wasmtime import WasmtimeError
 
 if sys.maxsize <= 2**32:
     raise WasmtimeError("wasmtime only works on 64-bit platforms right now")
 
-filename = os.path.join(os.path.dirname(__file__), 'wasmtime.pyd')
+if sys.platform == 'linux':
+    libname = 'libwasmtime.so'
+elif sys.platform == 'win32':
+    libname = 'wasmtime.dll'
+elif sys.platform == 'darwin':
+    libname = 'libwasmtime.dylib'
+else:
+    raise RuntimeError("unsupported platform `{}` for wasmtime".format(sys.platform))
+
+machine = platform.machine()
+if machine != 'x86_64' and machine != 'aarch64':
+    raise RuntimeError("unsupported architecture for wasmtime: {}".format(machine))
+
+filename = os.path.join(os.path.dirname(__file__), sys.platform + '-' + machine, libname)
+if not os.path.exists(filename):
+    raise RuntimeError("precompiled wasmtime binary not found at `{}`".format(filename))
 dll = cdll.LoadLibrary(filename)
 
 WASM_I32 = c_uint8(0)

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -9,11 +9,11 @@ if sys.maxsize <= 2**32:
     raise WasmtimeError("wasmtime only works on 64-bit platforms right now")
 
 if sys.platform == 'linux':
-    libname = 'libwasmtime.so'
+    libname = '_libwasmtime.so'
 elif sys.platform == 'win32':
-    libname = 'wasmtime.dll'
+    libname = '_wasmtime.dll'
 elif sys.platform == 'darwin':
-    libname = 'libwasmtime.dylib'
+    libname = '_libwasmtime.dylib'
 else:
     raise RuntimeError("unsupported platform `{}` for wasmtime".format(sys.platform))
 

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -18,6 +18,8 @@ else:
     raise RuntimeError("unsupported platform `{}` for wasmtime".format(sys.platform))
 
 machine = platform.machine()
+if machine == 'AMD64':
+    machine = 'x86_64'
 if machine != 'x86_64' and machine != 'aarch64':
     raise RuntimeError("unsupported architecture for wasmtime: {}".format(machine))
 


### PR DESCRIPTION
* Produce all wheels on one builder
* Produce an "any" wheel as a catch-all platform
* Rename where libraries are located - allows the "catch-all wheel" to have multiple precompiled libraries
* Fixup CI in a number of ways