### PR TITLE
Add type annotations almost everywhere

### DIFF
--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -1,6 +1,7 @@
 from ._ffi import *
 from ctypes import *
 from wasmtime import WasmtimeError
+import typing
 
 dll.wasm_config_new.restype = P_wasm_config_t
 dll.wasmtime_config_strategy_set.restype = P_wasmtime_error_t
@@ -8,7 +9,7 @@ dll.wasmtime_config_profiler_set.restype = P_wasmtime_error_t
 dll.wasmtime_config_cache_config_load.restype = P_wasmtime_error_t
 
 
-def setter_property(fset):
+def setter_property(fset: typing.Callable) -> property:
     prop = property(fset=fset)
     if fset.__doc__:
         prop.__doc__ = fset.__doc__
@@ -28,7 +29,7 @@ class Config:
         self.__ptr__ = dll.wasm_config_new()
 
     @setter_property
-    def debug_info(self, enable):
+    def debug_info(self, enable: bool):
         """
         Configures whether DWARF debug information is emitted for the generated
         code. This can improve profiling and the debugging experience.
@@ -39,7 +40,7 @@ class Config:
         dll.wasmtime_config_debug_info_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_threads(self, enable):
+    def wasm_threads(self, enable: bool):
         """
         Configures whether the wasm [threads proposal] is enabled.
 
@@ -51,7 +52,7 @@ class Config:
         dll.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_reference_types(self, enable):
+    def wasm_reference_types(self, enable: bool):
         """
         Configures whether the wasm [reference types proposal] is enabled.
 
@@ -63,7 +64,7 @@ class Config:
         dll.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_simd(self, enable):
+    def wasm_simd(self, enable: bool):
         """
         Configures whether the wasm [SIMD proposal] is enabled.
 
@@ -75,7 +76,7 @@ class Config:
         dll.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_bulk_memory(self, enable):
+    def wasm_bulk_memory(self, enable: bool):
         """
         Configures whether the wasm [bulk memory proposal] is enabled.
 
@@ -87,7 +88,7 @@ class Config:
         dll.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_multi_value(self, enable):
+    def wasm_multi_value(self, enable: bool):
         """
         Configures whether the wasm [multi value proposal] is enabled.
 
@@ -99,7 +100,7 @@ class Config:
         dll.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
 
     @setter_property
-    def strategy(self, strategy):
+    def strategy(self, strategy: str):
         """
         Configures the compilation strategy used for wasm code.
 
@@ -122,13 +123,13 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def cranelift_debug_verifier(self, enable):
+    def cranelift_debug_verifier(self, enable: bool):
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
         dll.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
 
     @setter_property
-    def cranelift_opt_level(self, opt_level):
+    def cranelift_opt_level(self, opt_level: str):
         if opt_level == "none":
             dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
         elif opt_level == "speed":
@@ -139,7 +140,7 @@ class Config:
             raise WasmtimeError("unknown opt level: " + str(opt_level))
 
     @setter_property
-    def profiler(self, profiler):
+    def profiler(self, profiler: str):
         if profiler == "none":
             error = dll.wasmtime_config_profiler_set(self.__ptr__, 0)
         elif profiler == "jitdump":
@@ -150,7 +151,7 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def cache(self, enabled):
+    def cache(self, enabled: bool):
         """
         Configures whether code caching is enabled for this `Config`.
 
@@ -175,7 +176,7 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def interruptable(self, enabled):
+    def interruptable(self, enabled: bool):
         """
         Configures whether wasm execution can be interrupted via interrupt
         handles.

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -7,7 +7,7 @@ dll.wasm_engine_new_with_config.restype = P_wasm_engine_t
 
 
 class Engine:
-    def __init__(self, config=None):
+    def __init__(self, config: Config = None):
         if config is None:
             self.__ptr__ = dll.wasm_engine_new()
         elif not isinstance(config, Config):

--- a/wasmtime/_error.py
+++ b/wasmtime/_error.py
@@ -1,4 +1,8 @@
 from ctypes import byref
+import typing
+
+if typing.TYPE_CHECKING:
+    from ._ffi import P_wasmtime_error_t
 
 
 class WasmtimeError(Exception):
@@ -6,7 +10,7 @@ class WasmtimeError(Exception):
         self.message = message
 
     @classmethod
-    def __from_ptr__(cls, ptr):
+    def __from_ptr__(cls, ptr: "P_wasmtime_error_t") -> "WasmtimeError":
         from ._ffi import P_wasmtime_error_t, wasm_byte_vec_t, dll  # Avoid circular import
         if not isinstance(ptr, P_wasmtime_error_t):
             raise TypeError("wrong pointer type")

--- a/wasmtime/_exportable.py
+++ b/wasmtime/_exportable.py
@@ -1,0 +1,12 @@
+__all__ = (
+    "Exportable",
+)
+
+import typing
+
+from ._func import Func
+from ._globals import Global
+from ._memory import Memory
+from ._table import Table
+
+Exportable = typing.Union[Func, Table, Memory, Global]

--- a/wasmtime/_exportable.py
+++ b/wasmtime/_exportable.py
@@ -1,7 +1,3 @@
-__all__ = (
-    "Exportable",
-)
-
 import typing
 
 from ._func import Func

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -1,5 +1,10 @@
 from ._ffi import *
+
 from ctypes import *
+import typing
+
+if typing.TYPE_CHECKING:
+    from ._exportable import Exportable
 
 dll.wasm_extern_as_func.restype = P_wasm_func_t
 dll.wasm_extern_as_table.restype = P_wasm_table_t
@@ -8,7 +13,7 @@ dll.wasm_extern_as_memory.restype = P_wasm_memory_t
 dll.wasm_extern_type.restype = P_wasm_externtype_t
 
 
-def wrap_extern(ptr, owner):
+def wrap_extern(ptr: P_wasm_extern_t, owner) -> "Exportable":
     from wasmtime import Func, Table, Global, Memory
 
     if not isinstance(ptr, P_wasm_extern_t):
@@ -33,7 +38,7 @@ def wrap_extern(ptr, owner):
     return Memory.__from_ptr__(val, owner)
 
 
-def get_extern_ptr(item):
+def get_extern_ptr(item: "Exportable") -> P_wasm_extern_t:
     from wasmtime import Func, Table, Global, Memory
 
     if isinstance(item, Func):
@@ -49,7 +54,7 @@ def get_extern_ptr(item):
 
 
 class Extern:
-    def __init__(self, ptr):
+    def __init__(self, ptr: P_wasm_extern_t):
         self.ptr = ptr
 
     def __del__(self):

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -225,18 +225,24 @@ class wasm_valtype_vec_t(Structure):
     _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_valtype_t))]
 
 
+P_wasm_valtype_vec_t = POINTER(wasm_valtype_vec_t)
+
+
 class wasm_limits_t(Structure):
     _fields_ = [("min", c_uint32), ("max", c_uint32)]
+
+
+P_wasm_limits_t = POINTER(wasm_limits_t)
 
 
 class wasm_byte_vec_t(Structure):
     _fields_ = [("size", c_size_t), ("data", POINTER(c_uint8))]
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytearray:
         ty = c_uint8 * self.size
         return bytearray(ty.from_address(addressof(self.data.contents)))
 
-    def to_str(self):
+    def to_str(self) -> str:
         return self.to_bytes().decode("utf-8")
 
 
@@ -272,7 +278,10 @@ class wasm_val_t(Structure):
     _fields_ = [("kind", c_uint8), ("of", wasm_val_union)]
 
 
-def str_to_name(s, trailing_nul=False):
+P_wasm_val_t = POINTER(wasm_val_t)
+
+
+def str_to_name(s: str, trailing_nul: bool = False) -> wasm_byte_vec_t:
     if not isinstance(s, str):
         raise TypeError("expected a string")
     s = s.encode('utf8')

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -9,7 +9,7 @@ dll.wasmtime_global_set.restype = P_wasmtime_error_t
 
 
 class Global:
-    def __init__(self, store, ty, val):
+    def __init__(self, store: Store, ty: GlobalType, val):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
         if not isinstance(ty, GlobalType):
@@ -27,7 +27,7 @@ class Global:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr, owner):
+    def __from_ptr__(cls, ptr: P_wasm_global_t, owner) -> "Global":
         ty = cls.__new__(cls)
         if not isinstance(ptr, P_wasm_global_t):
             raise TypeError("wrong pointer type")
@@ -36,7 +36,7 @@ class Global:
         return ty
 
     @property
-    def type(self):
+    def type(self) -> GlobalType:
         """
         Gets the type of this global as a `GlobalType`
         """
@@ -65,7 +65,7 @@ class Global:
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
-    def _as_extern(self):
+    def _as_extern(self) -> P_wasm_extern_t:
         return dll.wasm_global_as_extern(self.__ptr__)
 
     def __del__(self):

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -11,7 +11,7 @@ dll.wasmtime_instance_new.restype = P_wasmtime_error_t
 
 
 class Instance:
-    def __init__(self, module: Module, imports: typing.Iterable[typing.Union["Exportable", Extern]]):
+    def __init__(self, module: Module, imports: typing.Sequence[typing.Union["Exportable", Extern]]):
         """
         Creates a new instance by instantiating the `module` given with the
         `imports` provided.
@@ -87,7 +87,7 @@ class InstanceExports:
         for i, extern in enumerate(extern_list):
             self._extern_map[exports[i].name] = extern
 
-    def __getitem__(self, idx: int):
+    def __getitem__(self, idx: typing.Union[int, str]):
         ret = self.get(idx)
         if ret is None:
             msg = "failed to find export {}".format(idx)
@@ -102,7 +102,7 @@ class InstanceExports:
     def __iter__(self):
         return iter(self._extern_list)
 
-    def get(self, idx: int) -> typing.Optional["Exportable"]:
+    def get(self, idx: typing.Union[int, str]) -> typing.Optional["Exportable"]:
         if isinstance(idx, str):
             return self._extern_map.get(idx)
         if idx < len(self._extern_list):

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -1,13 +1,17 @@
 from ._ffi import *
 from ctypes import *
 from wasmtime import Module, Trap, WasmtimeError
-from ._extern import wrap_extern, get_extern_ptr
+from ._extern import wrap_extern, get_extern_ptr, Extern
+import typing
+
+if typing.TYPE_CHECKING:
+    from ._exportable import Exportable
 
 dll.wasmtime_instance_new.restype = P_wasmtime_error_t
 
 
 class Instance:
-    def __init__(self, module, imports):
+    def __init__(self, module: Module, imports: typing.Iterable[typing.Union["Exportable", Extern]]):
         """
         Creates a new instance by instantiating the `module` given with the
         `imports` provided.
@@ -44,7 +48,7 @@ class Instance:
         self._exports = None
 
     @classmethod
-    def __from_ptr__(cls, ptr, module):
+    def __from_ptr__(cls, ptr: P_wasm_instance_t, module: Module) -> "Instance":
         ty = cls.__new__(cls)
         if not isinstance(ptr, P_wasm_instance_t):
             raise TypeError("wrong pointer type")
@@ -54,7 +58,7 @@ class Instance:
         return ty
 
     @property
-    def exports(self):
+    def exports(self) -> "InstanceExports":
         """
         Returns the exports of this module
 
@@ -76,14 +80,14 @@ class Instance:
 
 
 class InstanceExports:
-    def __init__(self, extern_list, module):
+    def __init__(self, extern_list, module: Module):
         self._extern_list = extern_list
         self._extern_map = {}
         exports = module.exports
         for i, extern in enumerate(extern_list):
             self._extern_map[exports[i].name] = extern
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int):
         ret = self.get(idx)
         if ret is None:
             msg = "failed to find export {}".format(idx)
@@ -98,7 +102,7 @@ class InstanceExports:
     def __iter__(self):
         return iter(self._extern_list)
 
-    def get(self, idx):
+    def get(self, idx: int) -> typing.Optional["Exportable"]:
         if isinstance(idx, str):
             return self._extern_map.get(idx)
         if idx < len(self._extern_list):

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -1,9 +1,15 @@
+
 from ._ffi import *
 from ctypes import *
 from wasmtime import Store, Instance
 from wasmtime import Module, Trap, WasiInstance, WasmtimeError
 from ._extern import get_extern_ptr
 from ._config import setter_property
+import typing
+
+if typing.TYPE_CHECKING:
+    from ._exportable import Exportable
+
 
 dll.wasmtime_linker_new.restype = P_wasmtime_linker_t
 dll.wasmtime_linker_define.restype = P_wasmtime_error_t
@@ -13,14 +19,14 @@ dll.wasmtime_linker_instantiate.restype = P_wasmtime_error_t
 
 
 class Linker:
-    def __init__(self, store):
+    def __init__(self, store: Store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
         self.__ptr__ = dll.wasmtime_linker_new(store.__ptr__)
         self.store = store
 
     @setter_property
-    def allow_shadowing(self, allow):
+    def allow_shadowing(self, allow: bool):
         """
         Configures whether definitions are allowed to shadow one another within
         this linker
@@ -29,7 +35,7 @@ class Linker:
             raise TypeError("expected a boolean")
         dll.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
 
-    def define(self, module, name, item):
+    def define(self, module: str, name: str, item: "Exportable") -> None:
         raw_item = get_extern_ptr(item)
         module_raw = str_to_name(module)
         name_raw = str_to_name(name)
@@ -41,7 +47,7 @@ class Linker:
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
-    def define_instance(self, name, instance):
+    def define_instance(self, name: str, instance: Instance) -> None:
         if not isinstance(instance, Instance):
             raise TypeError("expected an `Instance`")
         name_raw = str_to_name(name)
@@ -50,14 +56,14 @@ class Linker:
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
-    def define_wasi(self, instance):
+    def define_wasi(self, instance: WasiInstance) -> None:
         if not isinstance(instance, WasiInstance):
             raise TypeError("expected an `WasiInstance`")
         error = dll.wasmtime_linker_define_wasi(self.__ptr__, instance.__ptr__)
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
-    def instantiate(self, module):
+    def instantiate(self, module: Module) -> Instance:
         if not isinstance(module, Module):
             raise TypeError("expected a `Module`")
         trap = P_wasm_trap_t()

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -11,7 +11,7 @@ dll.wasm_memory_grow.restype = c_bool
 
 
 class Memory:
-    def __init__(self, store, ty):
+    def __init__(self, store: Store, ty: MemoryType):
         """
         Creates a new memory in `store` with the given `ty`
         """
@@ -27,7 +27,7 @@ class Memory:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr, owner):
+    def __from_ptr__(cls, ptr: P_wasm_memory_t, owner) -> "Memory":
         ty = cls.__new__(cls)
         if not isinstance(ptr, P_wasm_memory_t):
             raise TypeError("wrong pointer type")
@@ -36,7 +36,7 @@ class Memory:
         return ty
 
     @property
-    def type(self):
+    def type(self) -> MemoryType:
         """
         Gets the type of this memory as a `MemoryType`
         """
@@ -44,7 +44,7 @@ class Memory:
         ptr = dll.wasm_memory_type(self.__ptr__)
         return MemoryType.__from_ptr__(ptr, None)
 
-    def grow(self, delta):
+    def grow(self, delta: int) -> bool:
         """
         Grows this memory by the given number of pages
         """
@@ -60,7 +60,7 @@ class Memory:
             return False
 
     @property
-    def size(self):
+    def size(self) -> int:
         """
         Returns the size, in WebAssembly pages, of this memory.
         """
@@ -68,7 +68,7 @@ class Memory:
         return dll.wasm_memory_size(self.__ptr__)
 
     @property
-    def data_ptr(self):
+    def data_ptr(self) -> POINTER(c_ubyte):
         """
         Returns the raw pointer in memory where this wasm memory lives.
 
@@ -78,14 +78,14 @@ class Memory:
         return dll.wasm_memory_data(self.__ptr__)
 
     @property
-    def data_len(self):
+    def data_len(self) -> int:
         """
         Returns the raw byte length of this memory.
         """
 
         return dll.wasm_memory_data_size(self.__ptr__)
 
-    def _as_extern(self):
+    def _as_extern(self) -> P_wasm_extern_t:
         return dll.wasm_memory_as_extern(self.__ptr__)
 
     def __del__(self):

--- a/wasmtime/_module.py
+++ b/wasmtime/_module.py
@@ -1,6 +1,7 @@
 from ._ffi import *
 from ctypes import *
 from wasmtime import Store, wat2wasm, ImportType, ExportType, WasmtimeError
+import typing
 
 dll.wasmtime_module_new.restype = P_wasmtime_error_t
 dll.wasmtime_module_validate.restype = P_wasmtime_error_t
@@ -8,7 +9,7 @@ dll.wasmtime_module_validate.restype = P_wasmtime_error_t
 
 class Module:
     @classmethod
-    def from_file(cls, store, path):
+    def from_file(cls, store: Store, path):
         """
         Compiles and creates a new `Module` by reading the file at `path` and
         then delegating to the `Module` constructor.
@@ -18,7 +19,7 @@ class Module:
             contents = f.read()
         return cls(store, contents)
 
-    def __init__(self, store, wasm):
+    def __init__(self, store: Store, wasm: typing.Union[str, bytes]):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
 
@@ -46,7 +47,7 @@ class Module:
         self.store = store
 
     @classmethod
-    def validate(cls, store, wasm):
+    def validate(cls, store: Store, wasm: typing.Union[bytes, bytearray]) -> None:
         """
         Validates whether the list of bytes `wasm` provided is a valid
         WebAssembly binary given the configuration in `store`
@@ -68,7 +69,7 @@ class Module:
             raise WasmtimeError.__from_ptr__(error)
 
     @property
-    def imports(self):
+    def imports(self) -> typing.List[ImportType]:
         """
         Returns the types of imports that this module has
         """
@@ -81,7 +82,7 @@ class Module:
         return ret
 
     @property
-    def exports(self):
+    def exports(self) -> typing.List[ExportType]:
         """
         Returns the types of the exports that this module has
         """

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -7,7 +7,8 @@ dll.wasmtime_interrupt_handle_new.restype = P_wasmtime_interrupt_handle_t
 
 
 class Store:
-    def __init__(self, engine=None):
+
+    def __init__(self, engine: Engine = None):
         if engine is None:
             engine = Engine()
         elif not isinstance(engine, Engine):
@@ -15,7 +16,7 @@ class Store:
         self.__ptr__ = dll.wasm_store_new(engine.__ptr__)
         self.engine = engine
 
-    def interrupt_handle(self):
+    def interrupt_handle(self) -> "InterruptHandle":
         """
         Creates a new interrupt handle through which execution of wasm can be
         interrupted.
@@ -43,7 +44,7 @@ class InterruptHandle:
     https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Store.html#method.interrupt_handle
     """
 
-    def __init__(self, store):
+    def __init__(self, store: Store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
         ptr = dll.wasmtime_interrupt_handle_new(store.__ptr__)
@@ -51,7 +52,7 @@ class InterruptHandle:
             raise WasmtimeError("interrupts not enabled on Store")
         self.__ptr__ = ptr
 
-    def interrupt(self):
+    def interrupt(self) -> None:
         """
         Schedules an interrupt to be sent to interrupt this handle's store's
         next (or current) execution of wasm code.

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -1,10 +1,11 @@
 from ._ffi import *
 from wasmtime import ValType
+import typing
 
 
 class Val:
     @classmethod
-    def i32(cls, val):
+    def i32(cls, val: int) -> "Val":
         """
         Create a new 32-bit integer value
         """
@@ -15,7 +16,7 @@ class Val:
         return Val(ffi)
 
     @classmethod
-    def i64(cls, val):
+    def i64(cls, val: int) -> "Val":
         """
         Create a new 64-bit integer value
         """
@@ -26,7 +27,7 @@ class Val:
         return Val(ffi)
 
     @classmethod
-    def f32(cls, val):
+    def f32(cls, val: float) -> "Val":
         """
         Create a new 32-bit float value
         """
@@ -37,7 +38,7 @@ class Val:
         return Val(ffi)
 
     @classmethod
-    def f64(cls, val):
+    def f64(cls, val: float) -> "Val":
         """
         Create a new 64-bit float value
         """
@@ -47,13 +48,13 @@ class Val:
         ffi.of.f64 = val
         return Val(ffi)
 
-    def __init__(self, raw):
+    def __init__(self, raw: wasm_val_t):
         if not isinstance(raw, wasm_val_t):
             raise TypeError("expected a raw value")
         self.__raw__ = raw
 
     @classmethod
-    def __convert__(cls, ty, val):
+    def __convert__(cls, ty: ValType, val: typing.Union["Val", int, float]) -> "Val":
         if isinstance(val, Val):
             if ty != val.type:
                 raise TypeError("wrong type of `Val` provided")
@@ -69,7 +70,7 @@ class Val:
         raise WasmtimeError("don't know how to convert %r to %s" % (val, ty))
 
     @property
-    def value(self):
+    def value(self) -> typing.Optional[typing.Union[int, float]]:
         """
         Get the the underlying value as a python value
 
@@ -85,7 +86,7 @@ class Val:
             return self.__raw__.of.f64
         return None
 
-    def as_i32(self):
+    def as_i32(self) -> typing.Optional[int]:
         """
         Get the 32-bit integer value of this value, or `None` if it's not an i32
         """
@@ -94,7 +95,7 @@ class Val:
         else:
             return None
 
-    def as_i64(self):
+    def as_i64(self) -> typing.Optional[int]:
         """
         Get the 64-bit integer value of this value, or `None` if it's not an i64
         """
@@ -103,7 +104,7 @@ class Val:
         else:
             return None
 
-    def as_f32(self):
+    def as_f32(self) -> typing.Optional[float]:
         """
         Get the 32-bit float value of this value, or `None` if it's not an f32
         """
@@ -112,7 +113,7 @@ class Val:
         else:
             return None
 
-    def as_f64(self):
+    def as_f64(self) -> typing.Optional[float]:
         """
         Get the 64-bit float value of this value, or `None` if it's not an f64
         """
@@ -122,7 +123,7 @@ class Val:
             return None
 
     @property
-    def type(self):
+    def type(self) -> ValType:
         """
         Returns the `ValType` corresponding to this `Val`
         """

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -5,6 +5,9 @@ from ._extern import wrap_extern
 from ._config import setter_property
 import typing
 
+if typing.TYPE_CHECKING:
+    from _exportable import Exportable
+
 dll.wasi_config_new.restype = P_wasi_config_t
 dll.wasi_instance_new.restype = P_wasi_instance_t
 dll.wasi_instance_bind_import.restype = P_wasm_extern_t
@@ -110,7 +113,7 @@ class WasiInstance:
         self.__ptr__ = ptr
         self.store = store
 
-    def bind(self, import_: ImportType) -> typing.Optional["XInstance"]:
+    def bind(self, import_: ImportType) -> typing.Optional["Exportable"]:
         if not isinstance(import_, ImportType):
             raise TypeError("expected an `ImportType`")
         ptr = dll.wasi_instance_bind_import(self.__ptr__, import_.__ptr__)

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -3,6 +3,7 @@ from ctypes import *
 from wasmtime import Store, Trap, ImportType
 from ._extern import wrap_extern
 from ._config import setter_property
+import typing
 
 dll.wasi_config_new.restype = P_wasi_config_t
 dll.wasi_instance_new.restype = P_wasi_instance_t
@@ -14,18 +15,18 @@ class WasiConfig:
         self.__ptr__ = dll.wasi_config_new()
 
     @setter_property
-    def set_argv(self, argv):
+    def set_argv(self, argv: typing.List[str]):
         """
         Explicitly configure the `argv` for this WASI configuration
         """
         ptrs = to_char_array(argv)
         dll.wasi_config_set_argv(self.__ptr__, c_int(len(argv)), ptrs)
 
-    def inherit_argv(self):
+    def inherit_argv(self) -> None:
         dll.wasi_config_inherit_argv(self.__ptr__)
 
     @setter_property
-    def env(self, pairs):
+    def env(self, pairs: typing.Iterable[typing.Iterable]):
         """
         Configure environment variables to be returned for this WASI
         configuration.
@@ -43,34 +44,34 @@ class WasiConfig:
         dll.wasi_config_set_env(self.__ptr__, c_int(
             len(names)), name_ptrs, value_ptrs)
 
-    def inherit_env(self):
+    def inherit_env(self) -> None:
         dll.wasi_config_inherit_env(self.__ptr__)
 
     @setter_property
-    def stdin_file(self, path):
+    def stdin_file(self, path: str):
         dll.wasi_config_set_stdin_file(
             self.__ptr__, c_char_p(path.encode('utf-8')))
 
-    def inherit_stdin(self):
+    def inherit_stdin(self) -> None:
         dll.wasi_config_inherit_stdin(self.__ptr__)
 
     @setter_property
-    def stdout_file(self, path):
+    def stdout_file(self, path: str):
         dll.wasi_config_set_stdout_file(
             self.__ptr__, c_char_p(path.encode('utf-8')))
 
-    def inherit_stdout(self):
+    def inherit_stdout(self) -> None:
         dll.wasi_config_inherit_stdout(self.__ptr__)
 
     @setter_property
-    def stderr_file(self, path):
+    def stderr_file(self, path: str):
         dll.wasi_config_set_stderr_file(
             self.__ptr__, c_char_p(path.encode('utf-8')))
 
-    def inherit_stderr(self):
+    def inherit_stderr(self) -> None:
         dll.wasi_config_inherit_stderr(self.__ptr__)
 
-    def preopen_dir(self, path, guest_path):
+    def preopen_dir(self, path: str, guest_path: str) -> None:
         path_ptr = c_char_p(path.encode('utf-8'))
         guest_path_ptr = c_char_p(guest_path.encode('utf-8'))
         dll.wasi_config_preopen_dir(self.__ptr__, path_ptr, guest_path_ptr)
@@ -80,7 +81,7 @@ class WasiConfig:
             dll.wasi_config_delete(self.__ptr__)
 
 
-def to_char_array(strings):
+def to_char_array(strings: typing.List[str]) -> Array:
     ptrs = (c_char_p * len(strings))()
     for i, s in enumerate(strings):
         ptrs[i] = c_char_p(s.encode('utf-8'))
@@ -88,7 +89,7 @@ def to_char_array(strings):
 
 
 class WasiInstance:
-    def __init__(self, store, name, config):
+    def __init__(self, store: Store, name: str, config: WasiConfig):
         if not isinstance(store, Store):
             raise TypeError("expected a `Store`")
         if not isinstance(name, str):
@@ -109,7 +110,7 @@ class WasiInstance:
         self.__ptr__ = ptr
         self.store = store
 
-    def bind(self, import_):
+    def bind(self, import_: ImportType) -> typing.Optional["XInstance"]:
         if not isinstance(import_, ImportType):
             raise TypeError("expected an `ImportType`")
         ptr = dll.wasi_instance_bind_import(self.__ptr__, import_.__ptr__)

--- a/wasmtime/_wat2wasm.py
+++ b/wasmtime/_wat2wasm.py
@@ -1,11 +1,12 @@
 from ._ffi import *
 from ctypes import *
 from wasmtime import WasmtimeError
+import typing
 
 dll.wasmtime_wat2wasm.restype = P_wasmtime_error_t
 
 
-def wat2wasm(wat):
+def wat2wasm(wat: typing.Union[str, bytes]) -> bytearray:
     """
     Converts the [WebAssembly Text format][wat] to the binary format.
 

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -12,9 +12,13 @@ from wasmtime import Func, Table, Global, Memory
 import sys
 import os.path
 import importlib
+import typing
 
 from importlib.abc import Loader, MetaPathFinder
 from importlib.util import spec_from_file_location
+
+if typing.TYPE_CHECKING:
+    from importlib.machinery import ModuleSpec
 
 store = Store()
 linker = Linker(store)
@@ -28,7 +32,7 @@ linker.allow_shadowing = True
 
 
 class _WasmtimeMetaFinder(MetaPathFinder):
-    def find_spec(self, fullname, path, target=None):
+    def find_spec(self, fullname: str, path: str, target=None) -> typing.Optional["ModuleSpec"]:
         if path is None or path == "":
             path = [os.getcwd()]  # top level import --
             path.extend(sys.path)
@@ -57,7 +61,7 @@ class _WasmtimeLoader(Loader):
     def create_module(self, spec):
         return None  # use default module creation semantics
 
-    def exec_module(self, module):
+    def exec_module(self, module) -> None:
         wasm_module = Module.from_file(store, self.filename)
 
         for wasm_import in wasm_module.imports:


### PR DESCRIPTION
I've added a few missing pointer types to _ffi.py to help here.

I've also added the awkwardly-named "_typing.py", with type aliases:
 
```
XType = typing.Union[FuncType, TableType, MemoryType, GlobalType]
XInstance = typing.Union[Func, Table, Memory, Global]
```

**The module should be called something else.**

**I'm also not sure what the type aliases should be called. I'm new
to WebAssembly and even reading some of the spec, the respective
unions of these don't seem to have names.**

I've run the unit tests with [typeguard](https://typeguard.readthedocs.io/en/latest/) enabled, but typeguard doesn't
switch on `typing.TYPE_CHECKING`. I can sort that out later on.

