### PR TITLE
Auto-generate FFI bindings with `ctypes`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python download-wasmtime.py
-      - run: pip install pytest
+      - run: pip install -e ".[testing]"
       - run: pytest
 
   build:
@@ -76,16 +76,6 @@ jobs:
         name: wheels
         path: dist
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - run: pip install flake8
-      - run: flake8
-
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -109,7 +99,7 @@ jobs:
       with:
         python-version: '3.x'
     - run: python download-wasmtime.py
-    - run: pip install coverage pytest
+    - run: pip install -e ".[testing]"
     - run: coverage run -m pytest
     - run: coverage html
     - uses: actions/upload-artifact@v1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov
 wasmtime/linux-*
 wasmtime/darwin-*
 wasmtime/win32-*
+wasmtime/include

--- a/bindgen.py
+++ b/bindgen.py
@@ -158,14 +158,19 @@ def type_name(ty, ptr=False, typing=False):
 ast = parse_file(
     './wasmtime/include/wasmtime.h',
     use_cpp=True,
+    cpp_path='cc',
     cpp_args=[
+        '-E',
         '-I./wasmtime/include',
         '-D__attribute__(x)=',
         '-D__asm__(x)=',
+        '-D__asm(x)=',
         '-D_Static_assert(x, y)=',
         '-Dstatic_assert(x, y)=',
         '-D__restrict=',
         '-D__extension__=',
+        '-D__signed=',
+        '-D__builtin_va_list=int',
     ]
 )
 

--- a/bindgen.py
+++ b/bindgen.py
@@ -1,0 +1,182 @@
+# type: ignore
+
+# This is a small script to parse the header files from wasmtime and generate
+# appropriate function definitions in Python for each exported function. This
+# also reflects types into Python with `ctypes`. While there's at least one
+# other generate that does this already it seemed to not quite fit our purposes
+# with lots of extra an unnecessary boilerplate.
+
+from pycparser import c_ast, parse_file
+
+
+class Visitor(c_ast.NodeVisitor):
+    def __init__(self):
+        self.ret = ''
+        self.ret += '# flake8: noqa\n'
+        self.ret += '#\n'
+        self.ret += '# This is a procedurally generated file, DO NOT EDIT\n'
+        self.ret += '# instead edit `./bindgen.py` at the root of the repo\n'
+        self.ret += '\n'
+        self.ret += 'from ctypes import *\n'
+        self.ret += 'from ._ffi import dll, wasm_val_t\n'
+
+    # Skip all function definitions, we don't bind those
+    def visit_FuncDef(self, node):
+        pass
+
+    def visit_Struct(self, node):
+        if not node.name or not node.name.startswith('was'):
+            return
+        if node.name == 'wasm_val_t':
+            return
+        self.ret += "\n"
+        self.ret += "class {}(Structure):\n".format(node.name)
+        if node.decls:
+            self.ret += "    _fields_ = [\n"
+            for decl in node.decls:
+                self.ret += "        (\"{}\", {}),\n".format(decl.name, type_name(decl.type))
+            self.ret += "    ]\n"
+        else:
+            self.ret += "    pass\n"
+
+    def visit_Typedef(self, node):
+        if not node.name or not node.name.startswith('was'):
+            return
+        self.visit(node.type)
+        tyname = type_name(node.type)
+        if tyname != node.name:
+            self.ret += "\n"
+            self.ret += "{} = {}\n".format(node.name, type_name(node.type))
+
+    def visit_FuncDecl(self, node):
+        if isinstance(node.type, c_ast.TypeDecl):
+            ptr = False
+            ty = node.type
+        elif isinstance(node.type, c_ast.PtrDecl):
+            ptr = True
+            ty = node.type.type
+        name = ty.declname
+        # This is probably a type, skip it
+        if name.endswith('_t'):
+            return
+        # Skip anything not related to wasi or wasm
+        if not name.startswith('was'):
+            return
+
+        # TODO: these are bugs with upstream wasmtime
+        if name == 'wasm_frame_copy':
+            return
+        if name == 'wasm_frame_instance':
+            return
+        if name == 'wasm_module_serialize':
+            return
+        if name == 'wasm_module_deserialize':
+            return
+        if 'ref_as_' in name:
+            return
+        if 'extern_const' in name:
+            return
+        if 'foreign' in name:
+            return
+
+        ret = ty.type
+
+        argpairs = []
+        argtypes = []
+        argnames = []
+        if node.args:
+            for i, param in enumerate(node.args.params):
+                argname = param.name
+                if not argname or argname == "import" or argname == "global":
+                    argname = "arg{}".format(i)
+                argpairs.append("{}: {}".format(argname, type_name(param.type, typing=True)))
+                argnames.append(argname)
+                argtypes.append(type_name(param.type))
+        retty = type_name(node.type, ptr, typing=True)
+
+        self.ret += "\n"
+        self.ret += "_{0} = dll.{0}\n".format(name)
+        self.ret += "_{}.restype = {}\n".format(name, type_name(ret, ptr))
+        self.ret += "_{}.argtypes = [{}]\n".format(name, ', '.join(argtypes))
+        self.ret += "def {}({}) -> {}:\n".format(name, ', '.join(argpairs), retty)
+        self.ret += "    return _{}({})\n".format(name, ', '.join(argnames))
+
+
+def type_name(ty, ptr=False, typing=False):
+    while isinstance(ty, c_ast.TypeDecl):
+        ty = ty.type
+
+    if ptr:
+        if typing:
+            return "pointer"
+        if isinstance(ty, c_ast.IdentifierType) and ty.names[0] == "void":
+            return "c_void_p"
+        elif not isinstance(ty, c_ast.FuncDecl):
+            return "POINTER({})".format(type_name(ty, False, typing))
+
+    if isinstance(ty, c_ast.IdentifierType):
+        assert(len(ty.names) == 1)
+        if ty.names[0] == "void":
+            return "None"
+        elif ty.names[0] == "_Bool":
+            return "c_bool"
+        elif ty.names[0] == "byte_t":
+            return "c_ubyte"
+        elif ty.names[0] == "uint8_t":
+            return "c_uint8"
+        elif ty.names[0] == "uint32_t":
+            return "c_uint32"
+        elif ty.names[0] == "uint64_t":
+            return "c_uint64"
+        elif ty.names[0] == "size_t":
+            return "c_size_t"
+        elif ty.names[0] == "char":
+            return "c_char"
+        elif ty.names[0] == "int":
+            return "c_int"
+        return ty.names[0]
+    elif isinstance(ty, c_ast.Struct):
+        return ty.name
+    elif isinstance(ty, c_ast.FuncDecl):
+        tys = []
+        # TODO: apparently errors are thrown if we faithfully represent the
+        # pointer type here, seems odd?
+        if isinstance(ty.type, c_ast.PtrDecl):
+            tys.append("c_size_t")
+        else:
+            tys.append(type_name(ty.type))
+        if ty.args.params:
+            for param in ty.args.params:
+                tys.append(type_name(param.type))
+        return "CFUNCTYPE({})".format(', '.join(tys))
+    elif isinstance(ty, c_ast.PtrDecl) or isinstance(ty, c_ast.ArrayDecl):
+        return type_name(ty.type, True, typing)
+    else:
+        raise RuntimeError("unknown {}".format(ty))
+
+
+ast = parse_file(
+    './wasmtime/include/wasmtime.h',
+    use_cpp=True,
+    cpp_args=[
+        '-I./wasmtime/include',
+        '-D__attribute__(x)=',
+        '-D__asm__(x)=',
+        '-D_Static_assert(x, y)=',
+        '-Dstatic_assert(x, y)=',
+        '-D__restrict=',
+        '-D__extension__=',
+    ]
+)
+
+v = Visitor()
+v.visit(ast)
+
+if __name__ == "__main__":
+    with open("wasmtime/_bindings.py", "w") as f:
+        f.write(v.ret)
+else:
+    with open("wasmtime/_bindings.py", "r") as f:
+        contents = f.read()
+        if contents != v.ret:
+            raise RuntimeError("bindings need an update, run this script")

--- a/bindgen.py
+++ b/bindgen.py
@@ -158,17 +158,20 @@ def type_name(ty, ptr=False, typing=False):
 ast = parse_file(
     './wasmtime/include/wasmtime.h',
     use_cpp=True,
-    cpp_path='cc',
+    cpp_path='gcc',
     cpp_args=[
         '-E',
         '-I./wasmtime/include',
         '-D__attribute__(x)=',
         '-D__asm__(x)=',
         '-D__asm(x)=',
+        '-D__volatile__(x)=',
         '-D_Static_assert(x, y)=',
         '-Dstatic_assert(x, y)=',
         '-D__restrict=',
+        '-D__restrict__=',
         '-D__extension__=',
+        '-D__inline__=',
         '-D__signed=',
         '-D__builtin_va_list=int',
     ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --flake8

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import setuptools
 import os
 
@@ -36,6 +38,8 @@ setuptools.setup(
         'testing': [
             'coverage',
             'pytest',
+            'pycparser',
+            'pytest-flake8',
         ],
     },
     classifiers=[

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -1,0 +1,2047 @@
+# flake8: noqa
+#
+# This is a procedurally generated file, DO NOT EDIT
+# instead edit `./bindgen.py` at the root of the repo
+
+from ctypes import *
+from ._ffi import dll, wasm_val_t
+
+wasm_byte_t = c_ubyte
+
+class wasm_byte_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(wasm_byte_t)),
+    ]
+
+_wasm_byte_vec_new_empty = dll.wasm_byte_vec_new_empty
+_wasm_byte_vec_new_empty.restype = None
+_wasm_byte_vec_new_empty.argtypes = [POINTER(wasm_byte_vec_t)]
+def wasm_byte_vec_new_empty(out: pointer) -> None:
+    return _wasm_byte_vec_new_empty(out)
+
+_wasm_byte_vec_new_uninitialized = dll.wasm_byte_vec_new_uninitialized
+_wasm_byte_vec_new_uninitialized.restype = None
+_wasm_byte_vec_new_uninitialized.argtypes = [POINTER(wasm_byte_vec_t), c_size_t]
+def wasm_byte_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_byte_vec_new_uninitialized(out, arg1)
+
+_wasm_byte_vec_new = dll.wasm_byte_vec_new
+_wasm_byte_vec_new.restype = None
+_wasm_byte_vec_new.argtypes = [POINTER(wasm_byte_vec_t), c_size_t, POINTER(wasm_byte_t)]
+def wasm_byte_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_byte_vec_new(out, arg1, arg2)
+
+_wasm_byte_vec_copy = dll.wasm_byte_vec_copy
+_wasm_byte_vec_copy.restype = None
+_wasm_byte_vec_copy.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
+def wasm_byte_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_byte_vec_copy(out, arg1)
+
+_wasm_byte_vec_delete = dll.wasm_byte_vec_delete
+_wasm_byte_vec_delete.restype = None
+_wasm_byte_vec_delete.argtypes = [POINTER(wasm_byte_vec_t)]
+def wasm_byte_vec_delete(arg0: pointer) -> None:
+    return _wasm_byte_vec_delete(arg0)
+
+wasm_name_t = wasm_byte_vec_t
+
+class wasm_config_t(Structure):
+    pass
+
+_wasm_config_delete = dll.wasm_config_delete
+_wasm_config_delete.restype = None
+_wasm_config_delete.argtypes = [POINTER(wasm_config_t)]
+def wasm_config_delete(arg0: pointer) -> None:
+    return _wasm_config_delete(arg0)
+
+_wasm_config_new = dll.wasm_config_new
+_wasm_config_new.restype = POINTER(wasm_config_t)
+_wasm_config_new.argtypes = []
+def wasm_config_new() -> pointer:
+    return _wasm_config_new()
+
+class wasm_engine_t(Structure):
+    pass
+
+_wasm_engine_delete = dll.wasm_engine_delete
+_wasm_engine_delete.restype = None
+_wasm_engine_delete.argtypes = [POINTER(wasm_engine_t)]
+def wasm_engine_delete(arg0: pointer) -> None:
+    return _wasm_engine_delete(arg0)
+
+_wasm_engine_new = dll.wasm_engine_new
+_wasm_engine_new.restype = POINTER(wasm_engine_t)
+_wasm_engine_new.argtypes = []
+def wasm_engine_new() -> pointer:
+    return _wasm_engine_new()
+
+_wasm_engine_new_with_config = dll.wasm_engine_new_with_config
+_wasm_engine_new_with_config.restype = POINTER(wasm_engine_t)
+_wasm_engine_new_with_config.argtypes = [POINTER(wasm_config_t)]
+def wasm_engine_new_with_config(arg0: pointer) -> pointer:
+    return _wasm_engine_new_with_config(arg0)
+
+class wasm_store_t(Structure):
+    pass
+
+_wasm_store_delete = dll.wasm_store_delete
+_wasm_store_delete.restype = None
+_wasm_store_delete.argtypes = [POINTER(wasm_store_t)]
+def wasm_store_delete(arg0: pointer) -> None:
+    return _wasm_store_delete(arg0)
+
+_wasm_store_new = dll.wasm_store_new
+_wasm_store_new.restype = POINTER(wasm_store_t)
+_wasm_store_new.argtypes = [POINTER(wasm_engine_t)]
+def wasm_store_new(arg0: pointer) -> pointer:
+    return _wasm_store_new(arg0)
+
+wasm_mutability_t = c_uint8
+
+class wasm_limits_t(Structure):
+    _fields_ = [
+        ("min", c_uint32),
+        ("max", c_uint32),
+    ]
+
+class wasm_valtype_t(Structure):
+    pass
+
+_wasm_valtype_delete = dll.wasm_valtype_delete
+_wasm_valtype_delete.restype = None
+_wasm_valtype_delete.argtypes = [POINTER(wasm_valtype_t)]
+def wasm_valtype_delete(arg0: pointer) -> None:
+    return _wasm_valtype_delete(arg0)
+
+class wasm_valtype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_valtype_t))),
+    ]
+
+_wasm_valtype_vec_new_empty = dll.wasm_valtype_vec_new_empty
+_wasm_valtype_vec_new_empty.restype = None
+_wasm_valtype_vec_new_empty.argtypes = [POINTER(wasm_valtype_vec_t)]
+def wasm_valtype_vec_new_empty(out: pointer) -> None:
+    return _wasm_valtype_vec_new_empty(out)
+
+_wasm_valtype_vec_new_uninitialized = dll.wasm_valtype_vec_new_uninitialized
+_wasm_valtype_vec_new_uninitialized.restype = None
+_wasm_valtype_vec_new_uninitialized.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t]
+def wasm_valtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_valtype_vec_new_uninitialized(out, arg1)
+
+_wasm_valtype_vec_new = dll.wasm_valtype_vec_new
+_wasm_valtype_vec_new.restype = None
+_wasm_valtype_vec_new.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t, POINTER(POINTER(wasm_valtype_t))]
+def wasm_valtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_valtype_vec_new(out, arg1, arg2)
+
+_wasm_valtype_vec_copy = dll.wasm_valtype_vec_copy
+_wasm_valtype_vec_copy.restype = None
+_wasm_valtype_vec_copy.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
+def wasm_valtype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_valtype_vec_copy(out, arg1)
+
+_wasm_valtype_vec_delete = dll.wasm_valtype_vec_delete
+_wasm_valtype_vec_delete.restype = None
+_wasm_valtype_vec_delete.argtypes = [POINTER(wasm_valtype_vec_t)]
+def wasm_valtype_vec_delete(arg0: pointer) -> None:
+    return _wasm_valtype_vec_delete(arg0)
+
+_wasm_valtype_copy = dll.wasm_valtype_copy
+_wasm_valtype_copy.restype = POINTER(wasm_valtype_t)
+_wasm_valtype_copy.argtypes = [POINTER(wasm_valtype_t)]
+def wasm_valtype_copy(arg0: pointer) -> pointer:
+    return _wasm_valtype_copy(arg0)
+
+wasm_valkind_t = c_uint8
+
+_wasm_valtype_new = dll.wasm_valtype_new
+_wasm_valtype_new.restype = POINTER(wasm_valtype_t)
+_wasm_valtype_new.argtypes = [wasm_valkind_t]
+def wasm_valtype_new(arg0: wasm_valkind_t) -> pointer:
+    return _wasm_valtype_new(arg0)
+
+_wasm_valtype_kind = dll.wasm_valtype_kind
+_wasm_valtype_kind.restype = wasm_valkind_t
+_wasm_valtype_kind.argtypes = [POINTER(wasm_valtype_t)]
+def wasm_valtype_kind(arg0: pointer) -> wasm_valkind_t:
+    return _wasm_valtype_kind(arg0)
+
+class wasm_functype_t(Structure):
+    pass
+
+_wasm_functype_delete = dll.wasm_functype_delete
+_wasm_functype_delete.restype = None
+_wasm_functype_delete.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_delete(arg0: pointer) -> None:
+    return _wasm_functype_delete(arg0)
+
+class wasm_functype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_functype_t))),
+    ]
+
+_wasm_functype_vec_new_empty = dll.wasm_functype_vec_new_empty
+_wasm_functype_vec_new_empty.restype = None
+_wasm_functype_vec_new_empty.argtypes = [POINTER(wasm_functype_vec_t)]
+def wasm_functype_vec_new_empty(out: pointer) -> None:
+    return _wasm_functype_vec_new_empty(out)
+
+_wasm_functype_vec_new_uninitialized = dll.wasm_functype_vec_new_uninitialized
+_wasm_functype_vec_new_uninitialized.restype = None
+_wasm_functype_vec_new_uninitialized.argtypes = [POINTER(wasm_functype_vec_t), c_size_t]
+def wasm_functype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_functype_vec_new_uninitialized(out, arg1)
+
+_wasm_functype_vec_new = dll.wasm_functype_vec_new
+_wasm_functype_vec_new.restype = None
+_wasm_functype_vec_new.argtypes = [POINTER(wasm_functype_vec_t), c_size_t, POINTER(POINTER(wasm_functype_t))]
+def wasm_functype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_functype_vec_new(out, arg1, arg2)
+
+_wasm_functype_vec_copy = dll.wasm_functype_vec_copy
+_wasm_functype_vec_copy.restype = None
+_wasm_functype_vec_copy.argtypes = [POINTER(wasm_functype_vec_t), POINTER(wasm_functype_vec_t)]
+def wasm_functype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_functype_vec_copy(out, arg1)
+
+_wasm_functype_vec_delete = dll.wasm_functype_vec_delete
+_wasm_functype_vec_delete.restype = None
+_wasm_functype_vec_delete.argtypes = [POINTER(wasm_functype_vec_t)]
+def wasm_functype_vec_delete(arg0: pointer) -> None:
+    return _wasm_functype_vec_delete(arg0)
+
+_wasm_functype_copy = dll.wasm_functype_copy
+_wasm_functype_copy.restype = POINTER(wasm_functype_t)
+_wasm_functype_copy.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_copy(arg0: pointer) -> pointer:
+    return _wasm_functype_copy(arg0)
+
+_wasm_functype_new = dll.wasm_functype_new
+_wasm_functype_new.restype = POINTER(wasm_functype_t)
+_wasm_functype_new.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
+def wasm_functype_new(params: pointer, results: pointer) -> pointer:
+    return _wasm_functype_new(params, results)
+
+_wasm_functype_params = dll.wasm_functype_params
+_wasm_functype_params.restype = POINTER(wasm_valtype_vec_t)
+_wasm_functype_params.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_params(arg0: pointer) -> pointer:
+    return _wasm_functype_params(arg0)
+
+_wasm_functype_results = dll.wasm_functype_results
+_wasm_functype_results.restype = POINTER(wasm_valtype_vec_t)
+_wasm_functype_results.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_results(arg0: pointer) -> pointer:
+    return _wasm_functype_results(arg0)
+
+class wasm_globaltype_t(Structure):
+    pass
+
+_wasm_globaltype_delete = dll.wasm_globaltype_delete
+_wasm_globaltype_delete.restype = None
+_wasm_globaltype_delete.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_delete(arg0: pointer) -> None:
+    return _wasm_globaltype_delete(arg0)
+
+class wasm_globaltype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_globaltype_t))),
+    ]
+
+_wasm_globaltype_vec_new_empty = dll.wasm_globaltype_vec_new_empty
+_wasm_globaltype_vec_new_empty.restype = None
+_wasm_globaltype_vec_new_empty.argtypes = [POINTER(wasm_globaltype_vec_t)]
+def wasm_globaltype_vec_new_empty(out: pointer) -> None:
+    return _wasm_globaltype_vec_new_empty(out)
+
+_wasm_globaltype_vec_new_uninitialized = dll.wasm_globaltype_vec_new_uninitialized
+_wasm_globaltype_vec_new_uninitialized.restype = None
+_wasm_globaltype_vec_new_uninitialized.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t]
+def wasm_globaltype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_globaltype_vec_new_uninitialized(out, arg1)
+
+_wasm_globaltype_vec_new = dll.wasm_globaltype_vec_new
+_wasm_globaltype_vec_new.restype = None
+_wasm_globaltype_vec_new.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t, POINTER(POINTER(wasm_globaltype_t))]
+def wasm_globaltype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_globaltype_vec_new(out, arg1, arg2)
+
+_wasm_globaltype_vec_copy = dll.wasm_globaltype_vec_copy
+_wasm_globaltype_vec_copy.restype = None
+_wasm_globaltype_vec_copy.argtypes = [POINTER(wasm_globaltype_vec_t), POINTER(wasm_globaltype_vec_t)]
+def wasm_globaltype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_globaltype_vec_copy(out, arg1)
+
+_wasm_globaltype_vec_delete = dll.wasm_globaltype_vec_delete
+_wasm_globaltype_vec_delete.restype = None
+_wasm_globaltype_vec_delete.argtypes = [POINTER(wasm_globaltype_vec_t)]
+def wasm_globaltype_vec_delete(arg0: pointer) -> None:
+    return _wasm_globaltype_vec_delete(arg0)
+
+_wasm_globaltype_copy = dll.wasm_globaltype_copy
+_wasm_globaltype_copy.restype = POINTER(wasm_globaltype_t)
+_wasm_globaltype_copy.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_copy(arg0: pointer) -> pointer:
+    return _wasm_globaltype_copy(arg0)
+
+_wasm_globaltype_new = dll.wasm_globaltype_new
+_wasm_globaltype_new.restype = POINTER(wasm_globaltype_t)
+_wasm_globaltype_new.argtypes = [POINTER(wasm_valtype_t), wasm_mutability_t]
+def wasm_globaltype_new(arg0: pointer, arg1: wasm_mutability_t) -> pointer:
+    return _wasm_globaltype_new(arg0, arg1)
+
+_wasm_globaltype_content = dll.wasm_globaltype_content
+_wasm_globaltype_content.restype = POINTER(wasm_valtype_t)
+_wasm_globaltype_content.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_content(arg0: pointer) -> pointer:
+    return _wasm_globaltype_content(arg0)
+
+_wasm_globaltype_mutability = dll.wasm_globaltype_mutability
+_wasm_globaltype_mutability.restype = wasm_mutability_t
+_wasm_globaltype_mutability.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_mutability(arg0: pointer) -> wasm_mutability_t:
+    return _wasm_globaltype_mutability(arg0)
+
+class wasm_tabletype_t(Structure):
+    pass
+
+_wasm_tabletype_delete = dll.wasm_tabletype_delete
+_wasm_tabletype_delete.restype = None
+_wasm_tabletype_delete.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_delete(arg0: pointer) -> None:
+    return _wasm_tabletype_delete(arg0)
+
+class wasm_tabletype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_tabletype_t))),
+    ]
+
+_wasm_tabletype_vec_new_empty = dll.wasm_tabletype_vec_new_empty
+_wasm_tabletype_vec_new_empty.restype = None
+_wasm_tabletype_vec_new_empty.argtypes = [POINTER(wasm_tabletype_vec_t)]
+def wasm_tabletype_vec_new_empty(out: pointer) -> None:
+    return _wasm_tabletype_vec_new_empty(out)
+
+_wasm_tabletype_vec_new_uninitialized = dll.wasm_tabletype_vec_new_uninitialized
+_wasm_tabletype_vec_new_uninitialized.restype = None
+_wasm_tabletype_vec_new_uninitialized.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t]
+def wasm_tabletype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_tabletype_vec_new_uninitialized(out, arg1)
+
+_wasm_tabletype_vec_new = dll.wasm_tabletype_vec_new
+_wasm_tabletype_vec_new.restype = None
+_wasm_tabletype_vec_new.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t, POINTER(POINTER(wasm_tabletype_t))]
+def wasm_tabletype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_tabletype_vec_new(out, arg1, arg2)
+
+_wasm_tabletype_vec_copy = dll.wasm_tabletype_vec_copy
+_wasm_tabletype_vec_copy.restype = None
+_wasm_tabletype_vec_copy.argtypes = [POINTER(wasm_tabletype_vec_t), POINTER(wasm_tabletype_vec_t)]
+def wasm_tabletype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_tabletype_vec_copy(out, arg1)
+
+_wasm_tabletype_vec_delete = dll.wasm_tabletype_vec_delete
+_wasm_tabletype_vec_delete.restype = None
+_wasm_tabletype_vec_delete.argtypes = [POINTER(wasm_tabletype_vec_t)]
+def wasm_tabletype_vec_delete(arg0: pointer) -> None:
+    return _wasm_tabletype_vec_delete(arg0)
+
+_wasm_tabletype_copy = dll.wasm_tabletype_copy
+_wasm_tabletype_copy.restype = POINTER(wasm_tabletype_t)
+_wasm_tabletype_copy.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_copy(arg0: pointer) -> pointer:
+    return _wasm_tabletype_copy(arg0)
+
+_wasm_tabletype_new = dll.wasm_tabletype_new
+_wasm_tabletype_new.restype = POINTER(wasm_tabletype_t)
+_wasm_tabletype_new.argtypes = [POINTER(wasm_valtype_t), POINTER(wasm_limits_t)]
+def wasm_tabletype_new(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_tabletype_new(arg0, arg1)
+
+_wasm_tabletype_element = dll.wasm_tabletype_element
+_wasm_tabletype_element.restype = POINTER(wasm_valtype_t)
+_wasm_tabletype_element.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_element(arg0: pointer) -> pointer:
+    return _wasm_tabletype_element(arg0)
+
+_wasm_tabletype_limits = dll.wasm_tabletype_limits
+_wasm_tabletype_limits.restype = POINTER(wasm_limits_t)
+_wasm_tabletype_limits.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_limits(arg0: pointer) -> pointer:
+    return _wasm_tabletype_limits(arg0)
+
+class wasm_memorytype_t(Structure):
+    pass
+
+_wasm_memorytype_delete = dll.wasm_memorytype_delete
+_wasm_memorytype_delete.restype = None
+_wasm_memorytype_delete.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_delete(arg0: pointer) -> None:
+    return _wasm_memorytype_delete(arg0)
+
+class wasm_memorytype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_memorytype_t))),
+    ]
+
+_wasm_memorytype_vec_new_empty = dll.wasm_memorytype_vec_new_empty
+_wasm_memorytype_vec_new_empty.restype = None
+_wasm_memorytype_vec_new_empty.argtypes = [POINTER(wasm_memorytype_vec_t)]
+def wasm_memorytype_vec_new_empty(out: pointer) -> None:
+    return _wasm_memorytype_vec_new_empty(out)
+
+_wasm_memorytype_vec_new_uninitialized = dll.wasm_memorytype_vec_new_uninitialized
+_wasm_memorytype_vec_new_uninitialized.restype = None
+_wasm_memorytype_vec_new_uninitialized.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t]
+def wasm_memorytype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_memorytype_vec_new_uninitialized(out, arg1)
+
+_wasm_memorytype_vec_new = dll.wasm_memorytype_vec_new
+_wasm_memorytype_vec_new.restype = None
+_wasm_memorytype_vec_new.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t, POINTER(POINTER(wasm_memorytype_t))]
+def wasm_memorytype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_memorytype_vec_new(out, arg1, arg2)
+
+_wasm_memorytype_vec_copy = dll.wasm_memorytype_vec_copy
+_wasm_memorytype_vec_copy.restype = None
+_wasm_memorytype_vec_copy.argtypes = [POINTER(wasm_memorytype_vec_t), POINTER(wasm_memorytype_vec_t)]
+def wasm_memorytype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_memorytype_vec_copy(out, arg1)
+
+_wasm_memorytype_vec_delete = dll.wasm_memorytype_vec_delete
+_wasm_memorytype_vec_delete.restype = None
+_wasm_memorytype_vec_delete.argtypes = [POINTER(wasm_memorytype_vec_t)]
+def wasm_memorytype_vec_delete(arg0: pointer) -> None:
+    return _wasm_memorytype_vec_delete(arg0)
+
+_wasm_memorytype_copy = dll.wasm_memorytype_copy
+_wasm_memorytype_copy.restype = POINTER(wasm_memorytype_t)
+_wasm_memorytype_copy.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_copy(arg0: pointer) -> pointer:
+    return _wasm_memorytype_copy(arg0)
+
+_wasm_memorytype_new = dll.wasm_memorytype_new
+_wasm_memorytype_new.restype = POINTER(wasm_memorytype_t)
+_wasm_memorytype_new.argtypes = [POINTER(wasm_limits_t)]
+def wasm_memorytype_new(arg0: pointer) -> pointer:
+    return _wasm_memorytype_new(arg0)
+
+_wasm_memorytype_limits = dll.wasm_memorytype_limits
+_wasm_memorytype_limits.restype = POINTER(wasm_limits_t)
+_wasm_memorytype_limits.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_limits(arg0: pointer) -> pointer:
+    return _wasm_memorytype_limits(arg0)
+
+class wasm_externtype_t(Structure):
+    pass
+
+_wasm_externtype_delete = dll.wasm_externtype_delete
+_wasm_externtype_delete.restype = None
+_wasm_externtype_delete.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_delete(arg0: pointer) -> None:
+    return _wasm_externtype_delete(arg0)
+
+class wasm_externtype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_externtype_t))),
+    ]
+
+_wasm_externtype_vec_new_empty = dll.wasm_externtype_vec_new_empty
+_wasm_externtype_vec_new_empty.restype = None
+_wasm_externtype_vec_new_empty.argtypes = [POINTER(wasm_externtype_vec_t)]
+def wasm_externtype_vec_new_empty(out: pointer) -> None:
+    return _wasm_externtype_vec_new_empty(out)
+
+_wasm_externtype_vec_new_uninitialized = dll.wasm_externtype_vec_new_uninitialized
+_wasm_externtype_vec_new_uninitialized.restype = None
+_wasm_externtype_vec_new_uninitialized.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t]
+def wasm_externtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_externtype_vec_new_uninitialized(out, arg1)
+
+_wasm_externtype_vec_new = dll.wasm_externtype_vec_new
+_wasm_externtype_vec_new.restype = None
+_wasm_externtype_vec_new.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t, POINTER(POINTER(wasm_externtype_t))]
+def wasm_externtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_externtype_vec_new(out, arg1, arg2)
+
+_wasm_externtype_vec_copy = dll.wasm_externtype_vec_copy
+_wasm_externtype_vec_copy.restype = None
+_wasm_externtype_vec_copy.argtypes = [POINTER(wasm_externtype_vec_t), POINTER(wasm_externtype_vec_t)]
+def wasm_externtype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_externtype_vec_copy(out, arg1)
+
+_wasm_externtype_vec_delete = dll.wasm_externtype_vec_delete
+_wasm_externtype_vec_delete.restype = None
+_wasm_externtype_vec_delete.argtypes = [POINTER(wasm_externtype_vec_t)]
+def wasm_externtype_vec_delete(arg0: pointer) -> None:
+    return _wasm_externtype_vec_delete(arg0)
+
+_wasm_externtype_copy = dll.wasm_externtype_copy
+_wasm_externtype_copy.restype = POINTER(wasm_externtype_t)
+_wasm_externtype_copy.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_copy(arg0: pointer) -> pointer:
+    return _wasm_externtype_copy(arg0)
+
+wasm_externkind_t = c_uint8
+
+_wasm_externtype_kind = dll.wasm_externtype_kind
+_wasm_externtype_kind.restype = wasm_externkind_t
+_wasm_externtype_kind.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_kind(arg0: pointer) -> wasm_externkind_t:
+    return _wasm_externtype_kind(arg0)
+
+_wasm_functype_as_externtype = dll.wasm_functype_as_externtype
+_wasm_functype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_functype_as_externtype.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_functype_as_externtype(arg0)
+
+_wasm_globaltype_as_externtype = dll.wasm_globaltype_as_externtype
+_wasm_globaltype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_globaltype_as_externtype.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_globaltype_as_externtype(arg0)
+
+_wasm_tabletype_as_externtype = dll.wasm_tabletype_as_externtype
+_wasm_tabletype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_tabletype_as_externtype.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_tabletype_as_externtype(arg0)
+
+_wasm_memorytype_as_externtype = dll.wasm_memorytype_as_externtype
+_wasm_memorytype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_memorytype_as_externtype.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_memorytype_as_externtype(arg0)
+
+_wasm_externtype_as_functype = dll.wasm_externtype_as_functype
+_wasm_externtype_as_functype.restype = POINTER(wasm_functype_t)
+_wasm_externtype_as_functype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_functype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_functype(arg0)
+
+_wasm_externtype_as_globaltype = dll.wasm_externtype_as_globaltype
+_wasm_externtype_as_globaltype.restype = POINTER(wasm_globaltype_t)
+_wasm_externtype_as_globaltype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_globaltype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_globaltype(arg0)
+
+_wasm_externtype_as_tabletype = dll.wasm_externtype_as_tabletype
+_wasm_externtype_as_tabletype.restype = POINTER(wasm_tabletype_t)
+_wasm_externtype_as_tabletype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_tabletype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_tabletype(arg0)
+
+_wasm_externtype_as_memorytype = dll.wasm_externtype_as_memorytype
+_wasm_externtype_as_memorytype.restype = POINTER(wasm_memorytype_t)
+_wasm_externtype_as_memorytype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_memorytype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_memorytype(arg0)
+
+_wasm_functype_as_externtype_const = dll.wasm_functype_as_externtype_const
+_wasm_functype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_functype_as_externtype_const.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_functype_as_externtype_const(arg0)
+
+_wasm_globaltype_as_externtype_const = dll.wasm_globaltype_as_externtype_const
+_wasm_globaltype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_globaltype_as_externtype_const.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_globaltype_as_externtype_const(arg0)
+
+_wasm_tabletype_as_externtype_const = dll.wasm_tabletype_as_externtype_const
+_wasm_tabletype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_tabletype_as_externtype_const.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_tabletype_as_externtype_const(arg0)
+
+_wasm_memorytype_as_externtype_const = dll.wasm_memorytype_as_externtype_const
+_wasm_memorytype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_memorytype_as_externtype_const.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_memorytype_as_externtype_const(arg0)
+
+_wasm_externtype_as_functype_const = dll.wasm_externtype_as_functype_const
+_wasm_externtype_as_functype_const.restype = POINTER(wasm_functype_t)
+_wasm_externtype_as_functype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_functype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_functype_const(arg0)
+
+_wasm_externtype_as_globaltype_const = dll.wasm_externtype_as_globaltype_const
+_wasm_externtype_as_globaltype_const.restype = POINTER(wasm_globaltype_t)
+_wasm_externtype_as_globaltype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_globaltype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_globaltype_const(arg0)
+
+_wasm_externtype_as_tabletype_const = dll.wasm_externtype_as_tabletype_const
+_wasm_externtype_as_tabletype_const.restype = POINTER(wasm_tabletype_t)
+_wasm_externtype_as_tabletype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_tabletype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_tabletype_const(arg0)
+
+_wasm_externtype_as_memorytype_const = dll.wasm_externtype_as_memorytype_const
+_wasm_externtype_as_memorytype_const.restype = POINTER(wasm_memorytype_t)
+_wasm_externtype_as_memorytype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_memorytype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_memorytype_const(arg0)
+
+class wasm_importtype_t(Structure):
+    pass
+
+_wasm_importtype_delete = dll.wasm_importtype_delete
+_wasm_importtype_delete.restype = None
+_wasm_importtype_delete.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_delete(arg0: pointer) -> None:
+    return _wasm_importtype_delete(arg0)
+
+class wasm_importtype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_importtype_t))),
+    ]
+
+_wasm_importtype_vec_new_empty = dll.wasm_importtype_vec_new_empty
+_wasm_importtype_vec_new_empty.restype = None
+_wasm_importtype_vec_new_empty.argtypes = [POINTER(wasm_importtype_vec_t)]
+def wasm_importtype_vec_new_empty(out: pointer) -> None:
+    return _wasm_importtype_vec_new_empty(out)
+
+_wasm_importtype_vec_new_uninitialized = dll.wasm_importtype_vec_new_uninitialized
+_wasm_importtype_vec_new_uninitialized.restype = None
+_wasm_importtype_vec_new_uninitialized.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t]
+def wasm_importtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_importtype_vec_new_uninitialized(out, arg1)
+
+_wasm_importtype_vec_new = dll.wasm_importtype_vec_new
+_wasm_importtype_vec_new.restype = None
+_wasm_importtype_vec_new.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t, POINTER(POINTER(wasm_importtype_t))]
+def wasm_importtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_importtype_vec_new(out, arg1, arg2)
+
+_wasm_importtype_vec_copy = dll.wasm_importtype_vec_copy
+_wasm_importtype_vec_copy.restype = None
+_wasm_importtype_vec_copy.argtypes = [POINTER(wasm_importtype_vec_t), POINTER(wasm_importtype_vec_t)]
+def wasm_importtype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_importtype_vec_copy(out, arg1)
+
+_wasm_importtype_vec_delete = dll.wasm_importtype_vec_delete
+_wasm_importtype_vec_delete.restype = None
+_wasm_importtype_vec_delete.argtypes = [POINTER(wasm_importtype_vec_t)]
+def wasm_importtype_vec_delete(arg0: pointer) -> None:
+    return _wasm_importtype_vec_delete(arg0)
+
+_wasm_importtype_copy = dll.wasm_importtype_copy
+_wasm_importtype_copy.restype = POINTER(wasm_importtype_t)
+_wasm_importtype_copy.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_copy(arg0: pointer) -> pointer:
+    return _wasm_importtype_copy(arg0)
+
+_wasm_importtype_new = dll.wasm_importtype_new
+_wasm_importtype_new.restype = POINTER(wasm_importtype_t)
+_wasm_importtype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
+def wasm_importtype_new(module: pointer, name: pointer, arg2: pointer) -> pointer:
+    return _wasm_importtype_new(module, name, arg2)
+
+_wasm_importtype_module = dll.wasm_importtype_module
+_wasm_importtype_module.restype = POINTER(wasm_name_t)
+_wasm_importtype_module.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_module(arg0: pointer) -> pointer:
+    return _wasm_importtype_module(arg0)
+
+_wasm_importtype_name = dll.wasm_importtype_name
+_wasm_importtype_name.restype = POINTER(wasm_name_t)
+_wasm_importtype_name.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_name(arg0: pointer) -> pointer:
+    return _wasm_importtype_name(arg0)
+
+_wasm_importtype_type = dll.wasm_importtype_type
+_wasm_importtype_type.restype = POINTER(wasm_externtype_t)
+_wasm_importtype_type.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_type(arg0: pointer) -> pointer:
+    return _wasm_importtype_type(arg0)
+
+class wasm_exporttype_t(Structure):
+    pass
+
+_wasm_exporttype_delete = dll.wasm_exporttype_delete
+_wasm_exporttype_delete.restype = None
+_wasm_exporttype_delete.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_delete(arg0: pointer) -> None:
+    return _wasm_exporttype_delete(arg0)
+
+class wasm_exporttype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_exporttype_t))),
+    ]
+
+_wasm_exporttype_vec_new_empty = dll.wasm_exporttype_vec_new_empty
+_wasm_exporttype_vec_new_empty.restype = None
+_wasm_exporttype_vec_new_empty.argtypes = [POINTER(wasm_exporttype_vec_t)]
+def wasm_exporttype_vec_new_empty(out: pointer) -> None:
+    return _wasm_exporttype_vec_new_empty(out)
+
+_wasm_exporttype_vec_new_uninitialized = dll.wasm_exporttype_vec_new_uninitialized
+_wasm_exporttype_vec_new_uninitialized.restype = None
+_wasm_exporttype_vec_new_uninitialized.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t]
+def wasm_exporttype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_exporttype_vec_new_uninitialized(out, arg1)
+
+_wasm_exporttype_vec_new = dll.wasm_exporttype_vec_new
+_wasm_exporttype_vec_new.restype = None
+_wasm_exporttype_vec_new.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t, POINTER(POINTER(wasm_exporttype_t))]
+def wasm_exporttype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_exporttype_vec_new(out, arg1, arg2)
+
+_wasm_exporttype_vec_copy = dll.wasm_exporttype_vec_copy
+_wasm_exporttype_vec_copy.restype = None
+_wasm_exporttype_vec_copy.argtypes = [POINTER(wasm_exporttype_vec_t), POINTER(wasm_exporttype_vec_t)]
+def wasm_exporttype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_exporttype_vec_copy(out, arg1)
+
+_wasm_exporttype_vec_delete = dll.wasm_exporttype_vec_delete
+_wasm_exporttype_vec_delete.restype = None
+_wasm_exporttype_vec_delete.argtypes = [POINTER(wasm_exporttype_vec_t)]
+def wasm_exporttype_vec_delete(arg0: pointer) -> None:
+    return _wasm_exporttype_vec_delete(arg0)
+
+_wasm_exporttype_copy = dll.wasm_exporttype_copy
+_wasm_exporttype_copy.restype = POINTER(wasm_exporttype_t)
+_wasm_exporttype_copy.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_copy(arg0: pointer) -> pointer:
+    return _wasm_exporttype_copy(arg0)
+
+_wasm_exporttype_new = dll.wasm_exporttype_new
+_wasm_exporttype_new.restype = POINTER(wasm_exporttype_t)
+_wasm_exporttype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
+def wasm_exporttype_new(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_exporttype_new(arg0, arg1)
+
+_wasm_exporttype_name = dll.wasm_exporttype_name
+_wasm_exporttype_name.restype = POINTER(wasm_name_t)
+_wasm_exporttype_name.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_name(arg0: pointer) -> pointer:
+    return _wasm_exporttype_name(arg0)
+
+_wasm_exporttype_type = dll.wasm_exporttype_type
+_wasm_exporttype_type.restype = POINTER(wasm_externtype_t)
+_wasm_exporttype_type.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_type(arg0: pointer) -> pointer:
+    return _wasm_exporttype_type(arg0)
+
+class wasm_ref_t(Structure):
+    pass
+
+_wasm_val_delete = dll.wasm_val_delete
+_wasm_val_delete.restype = None
+_wasm_val_delete.argtypes = [POINTER(wasm_val_t)]
+def wasm_val_delete(v: pointer) -> None:
+    return _wasm_val_delete(v)
+
+_wasm_val_copy = dll.wasm_val_copy
+_wasm_val_copy.restype = None
+_wasm_val_copy.argtypes = [POINTER(wasm_val_t), POINTER(wasm_val_t)]
+def wasm_val_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_val_copy(out, arg1)
+
+class wasm_val_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(wasm_val_t)),
+    ]
+
+_wasm_val_vec_new_empty = dll.wasm_val_vec_new_empty
+_wasm_val_vec_new_empty.restype = None
+_wasm_val_vec_new_empty.argtypes = [POINTER(wasm_val_vec_t)]
+def wasm_val_vec_new_empty(out: pointer) -> None:
+    return _wasm_val_vec_new_empty(out)
+
+_wasm_val_vec_new_uninitialized = dll.wasm_val_vec_new_uninitialized
+_wasm_val_vec_new_uninitialized.restype = None
+_wasm_val_vec_new_uninitialized.argtypes = [POINTER(wasm_val_vec_t), c_size_t]
+def wasm_val_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_val_vec_new_uninitialized(out, arg1)
+
+_wasm_val_vec_new = dll.wasm_val_vec_new
+_wasm_val_vec_new.restype = None
+_wasm_val_vec_new.argtypes = [POINTER(wasm_val_vec_t), c_size_t, POINTER(wasm_val_t)]
+def wasm_val_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_val_vec_new(out, arg1, arg2)
+
+_wasm_val_vec_copy = dll.wasm_val_vec_copy
+_wasm_val_vec_copy.restype = None
+_wasm_val_vec_copy.argtypes = [POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t)]
+def wasm_val_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_val_vec_copy(out, arg1)
+
+_wasm_val_vec_delete = dll.wasm_val_vec_delete
+_wasm_val_vec_delete.restype = None
+_wasm_val_vec_delete.argtypes = [POINTER(wasm_val_vec_t)]
+def wasm_val_vec_delete(arg0: pointer) -> None:
+    return _wasm_val_vec_delete(arg0)
+
+class wasm_ref_t(Structure):
+    pass
+
+_wasm_ref_delete = dll.wasm_ref_delete
+_wasm_ref_delete.restype = None
+_wasm_ref_delete.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_delete(arg0: pointer) -> None:
+    return _wasm_ref_delete(arg0)
+
+_wasm_ref_copy = dll.wasm_ref_copy
+_wasm_ref_copy.restype = POINTER(wasm_ref_t)
+_wasm_ref_copy.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_copy(arg0: pointer) -> pointer:
+    return _wasm_ref_copy(arg0)
+
+_wasm_ref_same = dll.wasm_ref_same
+_wasm_ref_same.restype = c_bool
+_wasm_ref_same.argtypes = [POINTER(wasm_ref_t), POINTER(wasm_ref_t)]
+def wasm_ref_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_ref_same(arg0, arg1)
+
+_wasm_ref_get_host_info = dll.wasm_ref_get_host_info
+_wasm_ref_get_host_info.restype = c_void_p
+_wasm_ref_get_host_info.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_ref_get_host_info(arg0)
+
+_wasm_ref_set_host_info = dll.wasm_ref_set_host_info
+_wasm_ref_set_host_info.restype = None
+_wasm_ref_set_host_info.argtypes = [POINTER(wasm_ref_t), c_void_p]
+def wasm_ref_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_ref_set_host_info(arg0, arg1)
+
+_wasm_ref_set_host_info_with_finalizer = dll.wasm_ref_set_host_info_with_finalizer
+_wasm_ref_set_host_info_with_finalizer.restype = None
+_wasm_ref_set_host_info_with_finalizer.argtypes = [POINTER(wasm_ref_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_ref_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_ref_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+class wasm_frame_t(Structure):
+    pass
+
+_wasm_frame_delete = dll.wasm_frame_delete
+_wasm_frame_delete.restype = None
+_wasm_frame_delete.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_delete(arg0: pointer) -> None:
+    return _wasm_frame_delete(arg0)
+
+class wasm_frame_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_frame_t))),
+    ]
+
+_wasm_frame_vec_new_empty = dll.wasm_frame_vec_new_empty
+_wasm_frame_vec_new_empty.restype = None
+_wasm_frame_vec_new_empty.argtypes = [POINTER(wasm_frame_vec_t)]
+def wasm_frame_vec_new_empty(out: pointer) -> None:
+    return _wasm_frame_vec_new_empty(out)
+
+_wasm_frame_vec_new_uninitialized = dll.wasm_frame_vec_new_uninitialized
+_wasm_frame_vec_new_uninitialized.restype = None
+_wasm_frame_vec_new_uninitialized.argtypes = [POINTER(wasm_frame_vec_t), c_size_t]
+def wasm_frame_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_frame_vec_new_uninitialized(out, arg1)
+
+_wasm_frame_vec_new = dll.wasm_frame_vec_new
+_wasm_frame_vec_new.restype = None
+_wasm_frame_vec_new.argtypes = [POINTER(wasm_frame_vec_t), c_size_t, POINTER(POINTER(wasm_frame_t))]
+def wasm_frame_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_frame_vec_new(out, arg1, arg2)
+
+_wasm_frame_vec_copy = dll.wasm_frame_vec_copy
+_wasm_frame_vec_copy.restype = None
+_wasm_frame_vec_copy.argtypes = [POINTER(wasm_frame_vec_t), POINTER(wasm_frame_vec_t)]
+def wasm_frame_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_frame_vec_copy(out, arg1)
+
+_wasm_frame_vec_delete = dll.wasm_frame_vec_delete
+_wasm_frame_vec_delete.restype = None
+_wasm_frame_vec_delete.argtypes = [POINTER(wasm_frame_vec_t)]
+def wasm_frame_vec_delete(arg0: pointer) -> None:
+    return _wasm_frame_vec_delete(arg0)
+
+_wasm_frame_func_index = dll.wasm_frame_func_index
+_wasm_frame_func_index.restype = c_uint32
+_wasm_frame_func_index.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_func_index(arg0: pointer) -> c_uint32:
+    return _wasm_frame_func_index(arg0)
+
+_wasm_frame_func_offset = dll.wasm_frame_func_offset
+_wasm_frame_func_offset.restype = c_size_t
+_wasm_frame_func_offset.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_func_offset(arg0: pointer) -> c_size_t:
+    return _wasm_frame_func_offset(arg0)
+
+_wasm_frame_module_offset = dll.wasm_frame_module_offset
+_wasm_frame_module_offset.restype = c_size_t
+_wasm_frame_module_offset.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_module_offset(arg0: pointer) -> c_size_t:
+    return _wasm_frame_module_offset(arg0)
+
+wasm_message_t = wasm_name_t
+
+class wasm_trap_t(Structure):
+    pass
+
+_wasm_trap_delete = dll.wasm_trap_delete
+_wasm_trap_delete.restype = None
+_wasm_trap_delete.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_delete(arg0: pointer) -> None:
+    return _wasm_trap_delete(arg0)
+
+_wasm_trap_copy = dll.wasm_trap_copy
+_wasm_trap_copy.restype = POINTER(wasm_trap_t)
+_wasm_trap_copy.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_copy(arg0: pointer) -> pointer:
+    return _wasm_trap_copy(arg0)
+
+_wasm_trap_same = dll.wasm_trap_same
+_wasm_trap_same.restype = c_bool
+_wasm_trap_same.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_trap_t)]
+def wasm_trap_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_trap_same(arg0, arg1)
+
+_wasm_trap_get_host_info = dll.wasm_trap_get_host_info
+_wasm_trap_get_host_info.restype = c_void_p
+_wasm_trap_get_host_info.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_trap_get_host_info(arg0)
+
+_wasm_trap_set_host_info = dll.wasm_trap_set_host_info
+_wasm_trap_set_host_info.restype = None
+_wasm_trap_set_host_info.argtypes = [POINTER(wasm_trap_t), c_void_p]
+def wasm_trap_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_trap_set_host_info(arg0, arg1)
+
+_wasm_trap_set_host_info_with_finalizer = dll.wasm_trap_set_host_info_with_finalizer
+_wasm_trap_set_host_info_with_finalizer.restype = None
+_wasm_trap_set_host_info_with_finalizer.argtypes = [POINTER(wasm_trap_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_trap_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_trap_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_trap_as_ref = dll.wasm_trap_as_ref
+_wasm_trap_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_trap_as_ref.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_as_ref(arg0: pointer) -> pointer:
+    return _wasm_trap_as_ref(arg0)
+
+_wasm_trap_as_ref_const = dll.wasm_trap_as_ref_const
+_wasm_trap_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_trap_as_ref_const.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_trap_as_ref_const(arg0)
+
+_wasm_trap_new = dll.wasm_trap_new
+_wasm_trap_new.restype = POINTER(wasm_trap_t)
+_wasm_trap_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_message_t)]
+def wasm_trap_new(store: pointer, arg1: pointer) -> pointer:
+    return _wasm_trap_new(store, arg1)
+
+_wasm_trap_message = dll.wasm_trap_message
+_wasm_trap_message.restype = None
+_wasm_trap_message.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_message_t)]
+def wasm_trap_message(arg0: pointer, out: pointer) -> None:
+    return _wasm_trap_message(arg0, out)
+
+_wasm_trap_origin = dll.wasm_trap_origin
+_wasm_trap_origin.restype = POINTER(wasm_frame_t)
+_wasm_trap_origin.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_origin(arg0: pointer) -> pointer:
+    return _wasm_trap_origin(arg0)
+
+_wasm_trap_trace = dll.wasm_trap_trace
+_wasm_trap_trace.restype = None
+_wasm_trap_trace.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_frame_vec_t)]
+def wasm_trap_trace(arg0: pointer, out: pointer) -> None:
+    return _wasm_trap_trace(arg0, out)
+
+class wasm_foreign_t(Structure):
+    pass
+
+class wasm_module_t(Structure):
+    pass
+
+_wasm_module_delete = dll.wasm_module_delete
+_wasm_module_delete.restype = None
+_wasm_module_delete.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_delete(arg0: pointer) -> None:
+    return _wasm_module_delete(arg0)
+
+_wasm_module_copy = dll.wasm_module_copy
+_wasm_module_copy.restype = POINTER(wasm_module_t)
+_wasm_module_copy.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_copy(arg0: pointer) -> pointer:
+    return _wasm_module_copy(arg0)
+
+_wasm_module_same = dll.wasm_module_same
+_wasm_module_same.restype = c_bool
+_wasm_module_same.argtypes = [POINTER(wasm_module_t), POINTER(wasm_module_t)]
+def wasm_module_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_module_same(arg0, arg1)
+
+_wasm_module_get_host_info = dll.wasm_module_get_host_info
+_wasm_module_get_host_info.restype = c_void_p
+_wasm_module_get_host_info.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_module_get_host_info(arg0)
+
+_wasm_module_set_host_info = dll.wasm_module_set_host_info
+_wasm_module_set_host_info.restype = None
+_wasm_module_set_host_info.argtypes = [POINTER(wasm_module_t), c_void_p]
+def wasm_module_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_module_set_host_info(arg0, arg1)
+
+_wasm_module_set_host_info_with_finalizer = dll.wasm_module_set_host_info_with_finalizer
+_wasm_module_set_host_info_with_finalizer.restype = None
+_wasm_module_set_host_info_with_finalizer.argtypes = [POINTER(wasm_module_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_module_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_module_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_module_as_ref = dll.wasm_module_as_ref
+_wasm_module_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_module_as_ref.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_as_ref(arg0: pointer) -> pointer:
+    return _wasm_module_as_ref(arg0)
+
+_wasm_module_as_ref_const = dll.wasm_module_as_ref_const
+_wasm_module_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_module_as_ref_const.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_module_as_ref_const(arg0)
+
+class wasm_shared_module_t(Structure):
+    pass
+
+_wasm_shared_module_delete = dll.wasm_shared_module_delete
+_wasm_shared_module_delete.restype = None
+_wasm_shared_module_delete.argtypes = [POINTER(wasm_shared_module_t)]
+def wasm_shared_module_delete(arg0: pointer) -> None:
+    return _wasm_shared_module_delete(arg0)
+
+_wasm_module_share = dll.wasm_module_share
+_wasm_module_share.restype = POINTER(wasm_shared_module_t)
+_wasm_module_share.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_share(arg0: pointer) -> pointer:
+    return _wasm_module_share(arg0)
+
+_wasm_module_obtain = dll.wasm_module_obtain
+_wasm_module_obtain.restype = POINTER(wasm_module_t)
+_wasm_module_obtain.argtypes = [POINTER(wasm_store_t), POINTER(wasm_shared_module_t)]
+def wasm_module_obtain(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_module_obtain(arg0, arg1)
+
+_wasm_module_new = dll.wasm_module_new
+_wasm_module_new.restype = POINTER(wasm_module_t)
+_wasm_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasm_module_new(arg0: pointer, binary: pointer) -> pointer:
+    return _wasm_module_new(arg0, binary)
+
+_wasm_module_validate = dll.wasm_module_validate
+_wasm_module_validate.restype = c_bool
+_wasm_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasm_module_validate(arg0: pointer, binary: pointer) -> c_bool:
+    return _wasm_module_validate(arg0, binary)
+
+_wasm_module_imports = dll.wasm_module_imports
+_wasm_module_imports.restype = None
+_wasm_module_imports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_importtype_vec_t)]
+def wasm_module_imports(arg0: pointer, out: pointer) -> None:
+    return _wasm_module_imports(arg0, out)
+
+_wasm_module_exports = dll.wasm_module_exports
+_wasm_module_exports.restype = None
+_wasm_module_exports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_exporttype_vec_t)]
+def wasm_module_exports(arg0: pointer, out: pointer) -> None:
+    return _wasm_module_exports(arg0, out)
+
+class wasm_func_t(Structure):
+    pass
+
+_wasm_func_delete = dll.wasm_func_delete
+_wasm_func_delete.restype = None
+_wasm_func_delete.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_delete(arg0: pointer) -> None:
+    return _wasm_func_delete(arg0)
+
+_wasm_func_copy = dll.wasm_func_copy
+_wasm_func_copy.restype = POINTER(wasm_func_t)
+_wasm_func_copy.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_copy(arg0: pointer) -> pointer:
+    return _wasm_func_copy(arg0)
+
+_wasm_func_same = dll.wasm_func_same
+_wasm_func_same.restype = c_bool
+_wasm_func_same.argtypes = [POINTER(wasm_func_t), POINTER(wasm_func_t)]
+def wasm_func_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_func_same(arg0, arg1)
+
+_wasm_func_get_host_info = dll.wasm_func_get_host_info
+_wasm_func_get_host_info.restype = c_void_p
+_wasm_func_get_host_info.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_func_get_host_info(arg0)
+
+_wasm_func_set_host_info = dll.wasm_func_set_host_info
+_wasm_func_set_host_info.restype = None
+_wasm_func_set_host_info.argtypes = [POINTER(wasm_func_t), c_void_p]
+def wasm_func_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_func_set_host_info(arg0, arg1)
+
+_wasm_func_set_host_info_with_finalizer = dll.wasm_func_set_host_info_with_finalizer
+_wasm_func_set_host_info_with_finalizer.restype = None
+_wasm_func_set_host_info_with_finalizer.argtypes = [POINTER(wasm_func_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_func_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_func_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_func_as_ref = dll.wasm_func_as_ref
+_wasm_func_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_func_as_ref.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_ref(arg0: pointer) -> pointer:
+    return _wasm_func_as_ref(arg0)
+
+_wasm_func_as_ref_const = dll.wasm_func_as_ref_const
+_wasm_func_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_func_as_ref_const.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_func_as_ref_const(arg0)
+
+wasm_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+wasm_func_callback_with_env_t = CFUNCTYPE(c_size_t, c_void_p, POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+_wasm_func_new = dll.wasm_func_new
+_wasm_func_new.restype = POINTER(wasm_func_t)
+_wasm_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_t]
+def wasm_func_new(arg0: pointer, arg1: pointer, arg2: wasm_func_callback_t) -> pointer:
+    return _wasm_func_new(arg0, arg1, arg2)
+
+_wasm_func_new_with_env = dll.wasm_func_new_with_env
+_wasm_func_new_with_env.restype = POINTER(wasm_func_t)
+_wasm_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_func_new_with_env(arg0: pointer, type: pointer, arg2: wasm_func_callback_with_env_t, env: pointer, finalizer: pointer) -> pointer:
+    return _wasm_func_new_with_env(arg0, type, arg2, env, finalizer)
+
+_wasm_func_type = dll.wasm_func_type
+_wasm_func_type.restype = POINTER(wasm_functype_t)
+_wasm_func_type.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_type(arg0: pointer) -> pointer:
+    return _wasm_func_type(arg0)
+
+_wasm_func_param_arity = dll.wasm_func_param_arity
+_wasm_func_param_arity.restype = c_size_t
+_wasm_func_param_arity.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_param_arity(arg0: pointer) -> c_size_t:
+    return _wasm_func_param_arity(arg0)
+
+_wasm_func_result_arity = dll.wasm_func_result_arity
+_wasm_func_result_arity.restype = c_size_t
+_wasm_func_result_arity.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_result_arity(arg0: pointer) -> c_size_t:
+    return _wasm_func_result_arity(arg0)
+
+_wasm_func_call = dll.wasm_func_call
+_wasm_func_call.restype = POINTER(wasm_trap_t)
+_wasm_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), POINTER(wasm_val_t)]
+def wasm_func_call(arg0: pointer, args: pointer, results: pointer) -> pointer:
+    return _wasm_func_call(arg0, args, results)
+
+class wasm_global_t(Structure):
+    pass
+
+_wasm_global_delete = dll.wasm_global_delete
+_wasm_global_delete.restype = None
+_wasm_global_delete.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_delete(arg0: pointer) -> None:
+    return _wasm_global_delete(arg0)
+
+_wasm_global_copy = dll.wasm_global_copy
+_wasm_global_copy.restype = POINTER(wasm_global_t)
+_wasm_global_copy.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_copy(arg0: pointer) -> pointer:
+    return _wasm_global_copy(arg0)
+
+_wasm_global_same = dll.wasm_global_same
+_wasm_global_same.restype = c_bool
+_wasm_global_same.argtypes = [POINTER(wasm_global_t), POINTER(wasm_global_t)]
+def wasm_global_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_global_same(arg0, arg1)
+
+_wasm_global_get_host_info = dll.wasm_global_get_host_info
+_wasm_global_get_host_info.restype = c_void_p
+_wasm_global_get_host_info.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_global_get_host_info(arg0)
+
+_wasm_global_set_host_info = dll.wasm_global_set_host_info
+_wasm_global_set_host_info.restype = None
+_wasm_global_set_host_info.argtypes = [POINTER(wasm_global_t), c_void_p]
+def wasm_global_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_global_set_host_info(arg0, arg1)
+
+_wasm_global_set_host_info_with_finalizer = dll.wasm_global_set_host_info_with_finalizer
+_wasm_global_set_host_info_with_finalizer.restype = None
+_wasm_global_set_host_info_with_finalizer.argtypes = [POINTER(wasm_global_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_global_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_global_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_global_as_ref = dll.wasm_global_as_ref
+_wasm_global_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_global_as_ref.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_ref(arg0: pointer) -> pointer:
+    return _wasm_global_as_ref(arg0)
+
+_wasm_global_as_ref_const = dll.wasm_global_as_ref_const
+_wasm_global_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_global_as_ref_const.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_global_as_ref_const(arg0)
+
+_wasm_global_new = dll.wasm_global_new
+_wasm_global_new.restype = POINTER(wasm_global_t)
+_wasm_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t)]
+def wasm_global_new(arg0: pointer, arg1: pointer, arg2: pointer) -> pointer:
+    return _wasm_global_new(arg0, arg1, arg2)
+
+_wasm_global_type = dll.wasm_global_type
+_wasm_global_type.restype = POINTER(wasm_globaltype_t)
+_wasm_global_type.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_type(arg0: pointer) -> pointer:
+    return _wasm_global_type(arg0)
+
+_wasm_global_get = dll.wasm_global_get
+_wasm_global_get.restype = None
+_wasm_global_get.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
+def wasm_global_get(arg0: pointer, out: pointer) -> None:
+    return _wasm_global_get(arg0, out)
+
+_wasm_global_set = dll.wasm_global_set
+_wasm_global_set.restype = None
+_wasm_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
+def wasm_global_set(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_global_set(arg0, arg1)
+
+class wasm_table_t(Structure):
+    pass
+
+_wasm_table_delete = dll.wasm_table_delete
+_wasm_table_delete.restype = None
+_wasm_table_delete.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_delete(arg0: pointer) -> None:
+    return _wasm_table_delete(arg0)
+
+_wasm_table_copy = dll.wasm_table_copy
+_wasm_table_copy.restype = POINTER(wasm_table_t)
+_wasm_table_copy.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_copy(arg0: pointer) -> pointer:
+    return _wasm_table_copy(arg0)
+
+_wasm_table_same = dll.wasm_table_same
+_wasm_table_same.restype = c_bool
+_wasm_table_same.argtypes = [POINTER(wasm_table_t), POINTER(wasm_table_t)]
+def wasm_table_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_table_same(arg0, arg1)
+
+_wasm_table_get_host_info = dll.wasm_table_get_host_info
+_wasm_table_get_host_info.restype = c_void_p
+_wasm_table_get_host_info.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_table_get_host_info(arg0)
+
+_wasm_table_set_host_info = dll.wasm_table_set_host_info
+_wasm_table_set_host_info.restype = None
+_wasm_table_set_host_info.argtypes = [POINTER(wasm_table_t), c_void_p]
+def wasm_table_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_table_set_host_info(arg0, arg1)
+
+_wasm_table_set_host_info_with_finalizer = dll.wasm_table_set_host_info_with_finalizer
+_wasm_table_set_host_info_with_finalizer.restype = None
+_wasm_table_set_host_info_with_finalizer.argtypes = [POINTER(wasm_table_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_table_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_table_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_table_as_ref = dll.wasm_table_as_ref
+_wasm_table_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_table_as_ref.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_ref(arg0: pointer) -> pointer:
+    return _wasm_table_as_ref(arg0)
+
+_wasm_table_as_ref_const = dll.wasm_table_as_ref_const
+_wasm_table_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_table_as_ref_const.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_table_as_ref_const(arg0)
+
+wasm_table_size_t = c_uint32
+
+_wasm_table_new = dll.wasm_table_new
+_wasm_table_new.restype = POINTER(wasm_table_t)
+_wasm_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_ref_t)]
+def wasm_table_new(arg0: pointer, arg1: pointer, init: pointer) -> pointer:
+    return _wasm_table_new(arg0, arg1, init)
+
+_wasm_table_type = dll.wasm_table_type
+_wasm_table_type.restype = POINTER(wasm_tabletype_t)
+_wasm_table_type.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_type(arg0: pointer) -> pointer:
+    return _wasm_table_type(arg0)
+
+_wasm_table_get = dll.wasm_table_get
+_wasm_table_get.restype = POINTER(wasm_ref_t)
+_wasm_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t]
+def wasm_table_get(arg0: pointer, index: wasm_table_size_t) -> pointer:
+    return _wasm_table_get(arg0, index)
+
+_wasm_table_set = dll.wasm_table_set
+_wasm_table_set.restype = c_bool
+_wasm_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
+def wasm_table_set(arg0: pointer, index: wasm_table_size_t, arg2: pointer) -> c_bool:
+    return _wasm_table_set(arg0, index, arg2)
+
+_wasm_table_size = dll.wasm_table_size
+_wasm_table_size.restype = wasm_table_size_t
+_wasm_table_size.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_size(arg0: pointer) -> wasm_table_size_t:
+    return _wasm_table_size(arg0)
+
+_wasm_table_grow = dll.wasm_table_grow
+_wasm_table_grow.restype = c_bool
+_wasm_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
+def wasm_table_grow(arg0: pointer, delta: wasm_table_size_t, init: pointer) -> c_bool:
+    return _wasm_table_grow(arg0, delta, init)
+
+class wasm_memory_t(Structure):
+    pass
+
+_wasm_memory_delete = dll.wasm_memory_delete
+_wasm_memory_delete.restype = None
+_wasm_memory_delete.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_delete(arg0: pointer) -> None:
+    return _wasm_memory_delete(arg0)
+
+_wasm_memory_copy = dll.wasm_memory_copy
+_wasm_memory_copy.restype = POINTER(wasm_memory_t)
+_wasm_memory_copy.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_copy(arg0: pointer) -> pointer:
+    return _wasm_memory_copy(arg0)
+
+_wasm_memory_same = dll.wasm_memory_same
+_wasm_memory_same.restype = c_bool
+_wasm_memory_same.argtypes = [POINTER(wasm_memory_t), POINTER(wasm_memory_t)]
+def wasm_memory_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_memory_same(arg0, arg1)
+
+_wasm_memory_get_host_info = dll.wasm_memory_get_host_info
+_wasm_memory_get_host_info.restype = c_void_p
+_wasm_memory_get_host_info.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_memory_get_host_info(arg0)
+
+_wasm_memory_set_host_info = dll.wasm_memory_set_host_info
+_wasm_memory_set_host_info.restype = None
+_wasm_memory_set_host_info.argtypes = [POINTER(wasm_memory_t), c_void_p]
+def wasm_memory_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_memory_set_host_info(arg0, arg1)
+
+_wasm_memory_set_host_info_with_finalizer = dll.wasm_memory_set_host_info_with_finalizer
+_wasm_memory_set_host_info_with_finalizer.restype = None
+_wasm_memory_set_host_info_with_finalizer.argtypes = [POINTER(wasm_memory_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_memory_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_memory_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_memory_as_ref = dll.wasm_memory_as_ref
+_wasm_memory_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_memory_as_ref.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_ref(arg0: pointer) -> pointer:
+    return _wasm_memory_as_ref(arg0)
+
+_wasm_memory_as_ref_const = dll.wasm_memory_as_ref_const
+_wasm_memory_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_memory_as_ref_const.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_memory_as_ref_const(arg0)
+
+wasm_memory_pages_t = c_uint32
+
+_wasm_memory_new = dll.wasm_memory_new
+_wasm_memory_new.restype = POINTER(wasm_memory_t)
+_wasm_memory_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_memorytype_t)]
+def wasm_memory_new(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_memory_new(arg0, arg1)
+
+_wasm_memory_type = dll.wasm_memory_type
+_wasm_memory_type.restype = POINTER(wasm_memorytype_t)
+_wasm_memory_type.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_type(arg0: pointer) -> pointer:
+    return _wasm_memory_type(arg0)
+
+_wasm_memory_data = dll.wasm_memory_data
+_wasm_memory_data.restype = POINTER(c_ubyte)
+_wasm_memory_data.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_data(arg0: pointer) -> pointer:
+    return _wasm_memory_data(arg0)
+
+_wasm_memory_data_size = dll.wasm_memory_data_size
+_wasm_memory_data_size.restype = c_size_t
+_wasm_memory_data_size.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_data_size(arg0: pointer) -> c_size_t:
+    return _wasm_memory_data_size(arg0)
+
+_wasm_memory_size = dll.wasm_memory_size
+_wasm_memory_size.restype = wasm_memory_pages_t
+_wasm_memory_size.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_size(arg0: pointer) -> wasm_memory_pages_t:
+    return _wasm_memory_size(arg0)
+
+_wasm_memory_grow = dll.wasm_memory_grow
+_wasm_memory_grow.restype = c_bool
+_wasm_memory_grow.argtypes = [POINTER(wasm_memory_t), wasm_memory_pages_t]
+def wasm_memory_grow(arg0: pointer, delta: wasm_memory_pages_t) -> c_bool:
+    return _wasm_memory_grow(arg0, delta)
+
+class wasm_extern_t(Structure):
+    pass
+
+_wasm_extern_delete = dll.wasm_extern_delete
+_wasm_extern_delete.restype = None
+_wasm_extern_delete.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_delete(arg0: pointer) -> None:
+    return _wasm_extern_delete(arg0)
+
+_wasm_extern_copy = dll.wasm_extern_copy
+_wasm_extern_copy.restype = POINTER(wasm_extern_t)
+_wasm_extern_copy.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_copy(arg0: pointer) -> pointer:
+    return _wasm_extern_copy(arg0)
+
+_wasm_extern_same = dll.wasm_extern_same
+_wasm_extern_same.restype = c_bool
+_wasm_extern_same.argtypes = [POINTER(wasm_extern_t), POINTER(wasm_extern_t)]
+def wasm_extern_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_extern_same(arg0, arg1)
+
+_wasm_extern_get_host_info = dll.wasm_extern_get_host_info
+_wasm_extern_get_host_info.restype = c_void_p
+_wasm_extern_get_host_info.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_extern_get_host_info(arg0)
+
+_wasm_extern_set_host_info = dll.wasm_extern_set_host_info
+_wasm_extern_set_host_info.restype = None
+_wasm_extern_set_host_info.argtypes = [POINTER(wasm_extern_t), c_void_p]
+def wasm_extern_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_extern_set_host_info(arg0, arg1)
+
+_wasm_extern_set_host_info_with_finalizer = dll.wasm_extern_set_host_info_with_finalizer
+_wasm_extern_set_host_info_with_finalizer.restype = None
+_wasm_extern_set_host_info_with_finalizer.argtypes = [POINTER(wasm_extern_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_extern_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_extern_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_extern_as_ref = dll.wasm_extern_as_ref
+_wasm_extern_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_extern_as_ref.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_ref(arg0: pointer) -> pointer:
+    return _wasm_extern_as_ref(arg0)
+
+_wasm_extern_as_ref_const = dll.wasm_extern_as_ref_const
+_wasm_extern_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_extern_as_ref_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_ref_const(arg0)
+
+class wasm_extern_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_extern_t))),
+    ]
+
+_wasm_extern_vec_new_empty = dll.wasm_extern_vec_new_empty
+_wasm_extern_vec_new_empty.restype = None
+_wasm_extern_vec_new_empty.argtypes = [POINTER(wasm_extern_vec_t)]
+def wasm_extern_vec_new_empty(out: pointer) -> None:
+    return _wasm_extern_vec_new_empty(out)
+
+_wasm_extern_vec_new_uninitialized = dll.wasm_extern_vec_new_uninitialized
+_wasm_extern_vec_new_uninitialized.restype = None
+_wasm_extern_vec_new_uninitialized.argtypes = [POINTER(wasm_extern_vec_t), c_size_t]
+def wasm_extern_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_extern_vec_new_uninitialized(out, arg1)
+
+_wasm_extern_vec_new = dll.wasm_extern_vec_new
+_wasm_extern_vec_new.restype = None
+_wasm_extern_vec_new.argtypes = [POINTER(wasm_extern_vec_t), c_size_t, POINTER(POINTER(wasm_extern_t))]
+def wasm_extern_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_extern_vec_new(out, arg1, arg2)
+
+_wasm_extern_vec_copy = dll.wasm_extern_vec_copy
+_wasm_extern_vec_copy.restype = None
+_wasm_extern_vec_copy.argtypes = [POINTER(wasm_extern_vec_t), POINTER(wasm_extern_vec_t)]
+def wasm_extern_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_extern_vec_copy(out, arg1)
+
+_wasm_extern_vec_delete = dll.wasm_extern_vec_delete
+_wasm_extern_vec_delete.restype = None
+_wasm_extern_vec_delete.argtypes = [POINTER(wasm_extern_vec_t)]
+def wasm_extern_vec_delete(arg0: pointer) -> None:
+    return _wasm_extern_vec_delete(arg0)
+
+_wasm_extern_kind = dll.wasm_extern_kind
+_wasm_extern_kind.restype = wasm_externkind_t
+_wasm_extern_kind.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_kind(arg0: pointer) -> wasm_externkind_t:
+    return _wasm_extern_kind(arg0)
+
+_wasm_extern_type = dll.wasm_extern_type
+_wasm_extern_type.restype = POINTER(wasm_externtype_t)
+_wasm_extern_type.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_type(arg0: pointer) -> pointer:
+    return _wasm_extern_type(arg0)
+
+_wasm_func_as_extern = dll.wasm_func_as_extern
+_wasm_func_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_func_as_extern.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_extern(arg0: pointer) -> pointer:
+    return _wasm_func_as_extern(arg0)
+
+_wasm_global_as_extern = dll.wasm_global_as_extern
+_wasm_global_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_global_as_extern.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_extern(arg0: pointer) -> pointer:
+    return _wasm_global_as_extern(arg0)
+
+_wasm_table_as_extern = dll.wasm_table_as_extern
+_wasm_table_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_table_as_extern.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_extern(arg0: pointer) -> pointer:
+    return _wasm_table_as_extern(arg0)
+
+_wasm_memory_as_extern = dll.wasm_memory_as_extern
+_wasm_memory_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_memory_as_extern.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_extern(arg0: pointer) -> pointer:
+    return _wasm_memory_as_extern(arg0)
+
+_wasm_extern_as_func = dll.wasm_extern_as_func
+_wasm_extern_as_func.restype = POINTER(wasm_func_t)
+_wasm_extern_as_func.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_func(arg0: pointer) -> pointer:
+    return _wasm_extern_as_func(arg0)
+
+_wasm_extern_as_global = dll.wasm_extern_as_global
+_wasm_extern_as_global.restype = POINTER(wasm_global_t)
+_wasm_extern_as_global.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_global(arg0: pointer) -> pointer:
+    return _wasm_extern_as_global(arg0)
+
+_wasm_extern_as_table = dll.wasm_extern_as_table
+_wasm_extern_as_table.restype = POINTER(wasm_table_t)
+_wasm_extern_as_table.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_table(arg0: pointer) -> pointer:
+    return _wasm_extern_as_table(arg0)
+
+_wasm_extern_as_memory = dll.wasm_extern_as_memory
+_wasm_extern_as_memory.restype = POINTER(wasm_memory_t)
+_wasm_extern_as_memory.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_memory(arg0: pointer) -> pointer:
+    return _wasm_extern_as_memory(arg0)
+
+_wasm_extern_as_func_const = dll.wasm_extern_as_func_const
+_wasm_extern_as_func_const.restype = POINTER(wasm_func_t)
+_wasm_extern_as_func_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_func_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_func_const(arg0)
+
+_wasm_extern_as_global_const = dll.wasm_extern_as_global_const
+_wasm_extern_as_global_const.restype = POINTER(wasm_global_t)
+_wasm_extern_as_global_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_global_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_global_const(arg0)
+
+_wasm_extern_as_table_const = dll.wasm_extern_as_table_const
+_wasm_extern_as_table_const.restype = POINTER(wasm_table_t)
+_wasm_extern_as_table_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_table_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_table_const(arg0)
+
+_wasm_extern_as_memory_const = dll.wasm_extern_as_memory_const
+_wasm_extern_as_memory_const.restype = POINTER(wasm_memory_t)
+_wasm_extern_as_memory_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_memory_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_memory_const(arg0)
+
+class wasm_instance_t(Structure):
+    pass
+
+_wasm_instance_delete = dll.wasm_instance_delete
+_wasm_instance_delete.restype = None
+_wasm_instance_delete.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_delete(arg0: pointer) -> None:
+    return _wasm_instance_delete(arg0)
+
+_wasm_instance_copy = dll.wasm_instance_copy
+_wasm_instance_copy.restype = POINTER(wasm_instance_t)
+_wasm_instance_copy.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_copy(arg0: pointer) -> pointer:
+    return _wasm_instance_copy(arg0)
+
+_wasm_instance_same = dll.wasm_instance_same
+_wasm_instance_same.restype = c_bool
+_wasm_instance_same.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_instance_t)]
+def wasm_instance_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_instance_same(arg0, arg1)
+
+_wasm_instance_get_host_info = dll.wasm_instance_get_host_info
+_wasm_instance_get_host_info.restype = c_void_p
+_wasm_instance_get_host_info.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_instance_get_host_info(arg0)
+
+_wasm_instance_set_host_info = dll.wasm_instance_set_host_info
+_wasm_instance_set_host_info.restype = None
+_wasm_instance_set_host_info.argtypes = [POINTER(wasm_instance_t), c_void_p]
+def wasm_instance_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_instance_set_host_info(arg0, arg1)
+
+_wasm_instance_set_host_info_with_finalizer = dll.wasm_instance_set_host_info_with_finalizer
+_wasm_instance_set_host_info_with_finalizer.restype = None
+_wasm_instance_set_host_info_with_finalizer.argtypes = [POINTER(wasm_instance_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_instance_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_instance_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_instance_as_ref = dll.wasm_instance_as_ref
+_wasm_instance_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_instance_as_ref.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_as_ref(arg0: pointer) -> pointer:
+    return _wasm_instance_as_ref(arg0)
+
+_wasm_instance_as_ref_const = dll.wasm_instance_as_ref_const
+_wasm_instance_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_instance_as_ref_const.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_instance_as_ref_const(arg0)
+
+_wasm_instance_new = dll.wasm_instance_new
+_wasm_instance_new.restype = POINTER(wasm_instance_t)
+_wasm_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), POINTER(POINTER(wasm_trap_t))]
+def wasm_instance_new(arg0: pointer, arg1: pointer, imports: pointer, arg3: pointer) -> pointer:
+    return _wasm_instance_new(arg0, arg1, imports, arg3)
+
+_wasm_instance_exports = dll.wasm_instance_exports
+_wasm_instance_exports.restype = None
+_wasm_instance_exports.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_extern_vec_t)]
+def wasm_instance_exports(arg0: pointer, out: pointer) -> None:
+    return _wasm_instance_exports(arg0, out)
+
+class wasi_config_t(Structure):
+    pass
+
+_wasi_config_delete = dll.wasi_config_delete
+_wasi_config_delete.restype = None
+_wasi_config_delete.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_delete(arg0: pointer) -> None:
+    return _wasi_config_delete(arg0)
+
+_wasi_config_new = dll.wasi_config_new
+_wasi_config_new.restype = POINTER(wasi_config_t)
+_wasi_config_new.argtypes = []
+def wasi_config_new() -> pointer:
+    return _wasi_config_new()
+
+_wasi_config_set_argv = dll.wasi_config_set_argv
+_wasi_config_set_argv.restype = None
+_wasi_config_set_argv.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char))]
+def wasi_config_set_argv(config: pointer, argc: c_int, argv: pointer) -> None:
+    return _wasi_config_set_argv(config, argc, argv)
+
+_wasi_config_inherit_argv = dll.wasi_config_inherit_argv
+_wasi_config_inherit_argv.restype = None
+_wasi_config_inherit_argv.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_argv(config: pointer) -> None:
+    return _wasi_config_inherit_argv(config)
+
+_wasi_config_set_env = dll.wasi_config_set_env
+_wasi_config_set_env.restype = None
+_wasi_config_set_env.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char)), POINTER(POINTER(c_char))]
+def wasi_config_set_env(config: pointer, envc: c_int, names: pointer, values: pointer) -> None:
+    return _wasi_config_set_env(config, envc, names, values)
+
+_wasi_config_inherit_env = dll.wasi_config_inherit_env
+_wasi_config_inherit_env.restype = None
+_wasi_config_inherit_env.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_env(config: pointer) -> None:
+    return _wasi_config_inherit_env(config)
+
+_wasi_config_set_stdin_file = dll.wasi_config_set_stdin_file
+_wasi_config_set_stdin_file.restype = c_bool
+_wasi_config_set_stdin_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
+def wasi_config_set_stdin_file(config: pointer, path: pointer) -> c_bool:
+    return _wasi_config_set_stdin_file(config, path)
+
+_wasi_config_inherit_stdin = dll.wasi_config_inherit_stdin
+_wasi_config_inherit_stdin.restype = None
+_wasi_config_inherit_stdin.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_stdin(config: pointer) -> None:
+    return _wasi_config_inherit_stdin(config)
+
+_wasi_config_set_stdout_file = dll.wasi_config_set_stdout_file
+_wasi_config_set_stdout_file.restype = c_bool
+_wasi_config_set_stdout_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
+def wasi_config_set_stdout_file(config: pointer, path: pointer) -> c_bool:
+    return _wasi_config_set_stdout_file(config, path)
+
+_wasi_config_inherit_stdout = dll.wasi_config_inherit_stdout
+_wasi_config_inherit_stdout.restype = None
+_wasi_config_inherit_stdout.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_stdout(config: pointer) -> None:
+    return _wasi_config_inherit_stdout(config)
+
+_wasi_config_set_stderr_file = dll.wasi_config_set_stderr_file
+_wasi_config_set_stderr_file.restype = c_bool
+_wasi_config_set_stderr_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
+def wasi_config_set_stderr_file(config: pointer, path: pointer) -> c_bool:
+    return _wasi_config_set_stderr_file(config, path)
+
+_wasi_config_inherit_stderr = dll.wasi_config_inherit_stderr
+_wasi_config_inherit_stderr.restype = None
+_wasi_config_inherit_stderr.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_stderr(config: pointer) -> None:
+    return _wasi_config_inherit_stderr(config)
+
+_wasi_config_preopen_dir = dll.wasi_config_preopen_dir
+_wasi_config_preopen_dir.restype = c_bool
+_wasi_config_preopen_dir.argtypes = [POINTER(wasi_config_t), POINTER(c_char), POINTER(c_char)]
+def wasi_config_preopen_dir(config: pointer, path: pointer, guest_path: pointer) -> c_bool:
+    return _wasi_config_preopen_dir(config, path, guest_path)
+
+class wasi_instance_t(Structure):
+    pass
+
+_wasi_instance_delete = dll.wasi_instance_delete
+_wasi_instance_delete.restype = None
+_wasi_instance_delete.argtypes = [POINTER(wasi_instance_t)]
+def wasi_instance_delete(arg0: pointer) -> None:
+    return _wasi_instance_delete(arg0)
+
+_wasi_instance_new = dll.wasi_instance_new
+_wasi_instance_new.restype = POINTER(wasi_instance_t)
+_wasi_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(c_char), POINTER(wasi_config_t), POINTER(POINTER(wasm_trap_t))]
+def wasi_instance_new(store: pointer, name: pointer, config: pointer, trap: pointer) -> pointer:
+    return _wasi_instance_new(store, name, config, trap)
+
+_wasi_instance_bind_import = dll.wasi_instance_bind_import
+_wasi_instance_bind_import.restype = POINTER(wasm_extern_t)
+_wasi_instance_bind_import.argtypes = [POINTER(wasi_instance_t), POINTER(wasm_importtype_t)]
+def wasi_instance_bind_import(instance: pointer, arg1: pointer) -> pointer:
+    return _wasi_instance_bind_import(instance, arg1)
+
+class wasmtime_error_t(Structure):
+    pass
+
+_wasmtime_error_delete = dll.wasmtime_error_delete
+_wasmtime_error_delete.restype = None
+_wasmtime_error_delete.argtypes = [POINTER(wasmtime_error_t)]
+def wasmtime_error_delete(arg0: pointer) -> None:
+    return _wasmtime_error_delete(arg0)
+
+_wasmtime_error_message = dll.wasmtime_error_message
+_wasmtime_error_message.restype = None
+_wasmtime_error_message.argtypes = [POINTER(wasmtime_error_t), POINTER(wasm_name_t)]
+def wasmtime_error_message(error: pointer, message: pointer) -> None:
+    return _wasmtime_error_message(error, message)
+
+wasmtime_strategy_t = c_uint8
+
+wasmtime_opt_level_t = c_uint8
+
+wasmtime_profiling_strategy_t = c_uint8
+
+_wasmtime_config_debug_info_set = dll.wasmtime_config_debug_info_set
+_wasmtime_config_debug_info_set.restype = None
+_wasmtime_config_debug_info_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_debug_info_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_debug_info_set(arg0, arg1)
+
+_wasmtime_config_interruptable_set = dll.wasmtime_config_interruptable_set
+_wasmtime_config_interruptable_set.restype = None
+_wasmtime_config_interruptable_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_interruptable_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_interruptable_set(arg0, arg1)
+
+_wasmtime_config_max_wasm_stack_set = dll.wasmtime_config_max_wasm_stack_set
+_wasmtime_config_max_wasm_stack_set.restype = None
+_wasmtime_config_max_wasm_stack_set.argtypes = [POINTER(wasm_config_t), c_size_t]
+def wasmtime_config_max_wasm_stack_set(arg0: pointer, arg1: c_size_t) -> None:
+    return _wasmtime_config_max_wasm_stack_set(arg0, arg1)
+
+_wasmtime_config_wasm_threads_set = dll.wasmtime_config_wasm_threads_set
+_wasmtime_config_wasm_threads_set.restype = None
+_wasmtime_config_wasm_threads_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_threads_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_threads_set(arg0, arg1)
+
+_wasmtime_config_wasm_reference_types_set = dll.wasmtime_config_wasm_reference_types_set
+_wasmtime_config_wasm_reference_types_set.restype = None
+_wasmtime_config_wasm_reference_types_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_reference_types_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_reference_types_set(arg0, arg1)
+
+_wasmtime_config_wasm_simd_set = dll.wasmtime_config_wasm_simd_set
+_wasmtime_config_wasm_simd_set.restype = None
+_wasmtime_config_wasm_simd_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_simd_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_simd_set(arg0, arg1)
+
+_wasmtime_config_wasm_bulk_memory_set = dll.wasmtime_config_wasm_bulk_memory_set
+_wasmtime_config_wasm_bulk_memory_set.restype = None
+_wasmtime_config_wasm_bulk_memory_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_bulk_memory_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_bulk_memory_set(arg0, arg1)
+
+_wasmtime_config_wasm_multi_value_set = dll.wasmtime_config_wasm_multi_value_set
+_wasmtime_config_wasm_multi_value_set.restype = None
+_wasmtime_config_wasm_multi_value_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_multi_value_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_multi_value_set(arg0, arg1)
+
+_wasmtime_config_strategy_set = dll.wasmtime_config_strategy_set
+_wasmtime_config_strategy_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_config_strategy_set.argtypes = [POINTER(wasm_config_t), wasmtime_strategy_t]
+def wasmtime_config_strategy_set(arg0: pointer, arg1: wasmtime_strategy_t) -> pointer:
+    return _wasmtime_config_strategy_set(arg0, arg1)
+
+_wasmtime_config_cranelift_debug_verifier_set = dll.wasmtime_config_cranelift_debug_verifier_set
+_wasmtime_config_cranelift_debug_verifier_set.restype = None
+_wasmtime_config_cranelift_debug_verifier_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_cranelift_debug_verifier_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_cranelift_debug_verifier_set(arg0, arg1)
+
+_wasmtime_config_cranelift_opt_level_set = dll.wasmtime_config_cranelift_opt_level_set
+_wasmtime_config_cranelift_opt_level_set.restype = None
+_wasmtime_config_cranelift_opt_level_set.argtypes = [POINTER(wasm_config_t), wasmtime_opt_level_t]
+def wasmtime_config_cranelift_opt_level_set(arg0: pointer, arg1: wasmtime_opt_level_t) -> None:
+    return _wasmtime_config_cranelift_opt_level_set(arg0, arg1)
+
+_wasmtime_config_profiler_set = dll.wasmtime_config_profiler_set
+_wasmtime_config_profiler_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_config_profiler_set.argtypes = [POINTER(wasm_config_t), wasmtime_profiling_strategy_t]
+def wasmtime_config_profiler_set(arg0: pointer, arg1: wasmtime_profiling_strategy_t) -> pointer:
+    return _wasmtime_config_profiler_set(arg0, arg1)
+
+_wasmtime_config_static_memory_maximum_size_set = dll.wasmtime_config_static_memory_maximum_size_set
+_wasmtime_config_static_memory_maximum_size_set.restype = None
+_wasmtime_config_static_memory_maximum_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
+def wasmtime_config_static_memory_maximum_size_set(arg0: pointer, arg1: c_uint64) -> None:
+    return _wasmtime_config_static_memory_maximum_size_set(arg0, arg1)
+
+_wasmtime_config_static_memory_guard_size_set = dll.wasmtime_config_static_memory_guard_size_set
+_wasmtime_config_static_memory_guard_size_set.restype = None
+_wasmtime_config_static_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
+def wasmtime_config_static_memory_guard_size_set(arg0: pointer, arg1: c_uint64) -> None:
+    return _wasmtime_config_static_memory_guard_size_set(arg0, arg1)
+
+_wasmtime_config_dynamic_memory_guard_size_set = dll.wasmtime_config_dynamic_memory_guard_size_set
+_wasmtime_config_dynamic_memory_guard_size_set.restype = None
+_wasmtime_config_dynamic_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
+def wasmtime_config_dynamic_memory_guard_size_set(arg0: pointer, arg1: c_uint64) -> None:
+    return _wasmtime_config_dynamic_memory_guard_size_set(arg0, arg1)
+
+_wasmtime_config_cache_config_load = dll.wasmtime_config_cache_config_load
+_wasmtime_config_cache_config_load.restype = POINTER(wasmtime_error_t)
+_wasmtime_config_cache_config_load.argtypes = [POINTER(wasm_config_t), POINTER(c_char)]
+def wasmtime_config_cache_config_load(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasmtime_config_cache_config_load(arg0, arg1)
+
+_wasmtime_wat2wasm = dll.wasmtime_wat2wasm
+_wasmtime_wat2wasm.restype = POINTER(wasmtime_error_t)
+_wasmtime_wat2wasm.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
+def wasmtime_wat2wasm(wat: pointer, ret: pointer) -> pointer:
+    return _wasmtime_wat2wasm(wat, ret)
+
+class wasmtime_linker_t(Structure):
+    pass
+
+_wasmtime_linker_delete = dll.wasmtime_linker_delete
+_wasmtime_linker_delete.restype = None
+_wasmtime_linker_delete.argtypes = [POINTER(wasmtime_linker_t)]
+def wasmtime_linker_delete(arg0: pointer) -> None:
+    return _wasmtime_linker_delete(arg0)
+
+_wasmtime_linker_new = dll.wasmtime_linker_new
+_wasmtime_linker_new.restype = POINTER(wasmtime_linker_t)
+_wasmtime_linker_new.argtypes = [POINTER(wasm_store_t)]
+def wasmtime_linker_new(store: pointer) -> pointer:
+    return _wasmtime_linker_new(store)
+
+_wasmtime_linker_allow_shadowing = dll.wasmtime_linker_allow_shadowing
+_wasmtime_linker_allow_shadowing.restype = None
+_wasmtime_linker_allow_shadowing.argtypes = [POINTER(wasmtime_linker_t), c_bool]
+def wasmtime_linker_allow_shadowing(linker: pointer, allow_shadowing: c_bool) -> None:
+    return _wasmtime_linker_allow_shadowing(linker, allow_shadowing)
+
+_wasmtime_linker_define = dll.wasmtime_linker_define
+_wasmtime_linker_define.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_define.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_extern_t)]
+def wasmtime_linker_define(linker: pointer, module: pointer, name: pointer, item: pointer) -> pointer:
+    return _wasmtime_linker_define(linker, module, name, item)
+
+_wasmtime_linker_define_wasi = dll.wasmtime_linker_define_wasi
+_wasmtime_linker_define_wasi.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_define_wasi.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasi_instance_t)]
+def wasmtime_linker_define_wasi(linker: pointer, instance: pointer) -> pointer:
+    return _wasmtime_linker_define_wasi(linker, instance)
+
+_wasmtime_linker_define_instance = dll.wasmtime_linker_define_instance
+_wasmtime_linker_define_instance.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_define_instance.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_instance_t)]
+def wasmtime_linker_define_instance(linker: pointer, name: pointer, instance: pointer) -> pointer:
+    return _wasmtime_linker_define_instance(linker, name, instance)
+
+_wasmtime_linker_instantiate = dll.wasmtime_linker_instantiate
+_wasmtime_linker_instantiate.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_instantiate.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
+def wasmtime_linker_instantiate(linker: pointer, module: pointer, instance: pointer, trap: pointer) -> pointer:
+    return _wasmtime_linker_instantiate(linker, module, instance, trap)
+
+_wasmtime_linker_module = dll.wasmtime_linker_module
+_wasmtime_linker_module.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_module.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_module_t)]
+def wasmtime_linker_module(linker: pointer, name: pointer, module: pointer) -> pointer:
+    return _wasmtime_linker_module(linker, name, module)
+
+_wasmtime_linker_get_default = dll.wasmtime_linker_get_default
+_wasmtime_linker_get_default.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_get_default.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(POINTER(wasm_func_t))]
+def wasmtime_linker_get_default(linker: pointer, name: pointer, func: pointer) -> pointer:
+    return _wasmtime_linker_get_default(linker, name, func)
+
+class wasmtime_caller_t(Structure):
+    pass
+
+wasmtime_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_t), POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+wasmtime_func_callback_with_env_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_t), c_void_p, POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+_wasmtime_func_new = dll.wasmtime_func_new
+_wasmtime_func_new.restype = POINTER(wasm_func_t)
+_wasmtime_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_t]
+def wasmtime_func_new(arg0: pointer, arg1: pointer, callback: wasmtime_func_callback_t) -> pointer:
+    return _wasmtime_func_new(arg0, arg1, callback)
+
+_wasmtime_func_new_with_env = dll.wasmtime_func_new_with_env
+_wasmtime_func_new_with_env.restype = POINTER(wasm_func_t)
+_wasmtime_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasmtime_func_new_with_env(store: pointer, type: pointer, callback: wasmtime_func_callback_with_env_t, env: pointer, finalizer: pointer) -> pointer:
+    return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)
+
+_wasmtime_caller_export_get = dll.wasmtime_caller_export_get
+_wasmtime_caller_export_get.restype = POINTER(wasm_extern_t)
+_wasmtime_caller_export_get.argtypes = [POINTER(wasmtime_caller_t), POINTER(wasm_name_t)]
+def wasmtime_caller_export_get(caller: pointer, name: pointer) -> pointer:
+    return _wasmtime_caller_export_get(caller, name)
+
+class wasmtime_interrupt_handle_t(Structure):
+    pass
+
+_wasmtime_interrupt_handle_delete = dll.wasmtime_interrupt_handle_delete
+_wasmtime_interrupt_handle_delete.restype = None
+_wasmtime_interrupt_handle_delete.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
+def wasmtime_interrupt_handle_delete(arg0: pointer) -> None:
+    return _wasmtime_interrupt_handle_delete(arg0)
+
+_wasmtime_interrupt_handle_new = dll.wasmtime_interrupt_handle_new
+_wasmtime_interrupt_handle_new.restype = POINTER(wasmtime_interrupt_handle_t)
+_wasmtime_interrupt_handle_new.argtypes = [POINTER(wasm_store_t)]
+def wasmtime_interrupt_handle_new(store: pointer) -> pointer:
+    return _wasmtime_interrupt_handle_new(store)
+
+_wasmtime_interrupt_handle_interrupt = dll.wasmtime_interrupt_handle_interrupt
+_wasmtime_interrupt_handle_interrupt.restype = None
+_wasmtime_interrupt_handle_interrupt.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
+def wasmtime_interrupt_handle_interrupt(handle: pointer) -> None:
+    return _wasmtime_interrupt_handle_interrupt(handle)
+
+_wasmtime_frame_func_name = dll.wasmtime_frame_func_name
+_wasmtime_frame_func_name.restype = POINTER(wasm_name_t)
+_wasmtime_frame_func_name.argtypes = [POINTER(wasm_frame_t)]
+def wasmtime_frame_func_name(arg0: pointer) -> pointer:
+    return _wasmtime_frame_func_name(arg0)
+
+_wasmtime_frame_module_name = dll.wasmtime_frame_module_name
+_wasmtime_frame_module_name.restype = POINTER(wasm_name_t)
+_wasmtime_frame_module_name.argtypes = [POINTER(wasm_frame_t)]
+def wasmtime_frame_module_name(arg0: pointer) -> pointer:
+    return _wasmtime_frame_module_name(arg0)
+
+_wasmtime_func_call = dll.wasmtime_func_call
+_wasmtime_func_call.restype = POINTER(wasmtime_error_t)
+_wasmtime_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), c_size_t, POINTER(wasm_val_t), c_size_t, POINTER(POINTER(wasm_trap_t))]
+def wasmtime_func_call(func: pointer, args: pointer, num_args: c_size_t, results: pointer, num_results: c_size_t, trap: pointer) -> pointer:
+    return _wasmtime_func_call(func, args, num_args, results, num_results, trap)
+
+_wasmtime_global_new = dll.wasmtime_global_new
+_wasmtime_global_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t), POINTER(POINTER(wasm_global_t))]
+def wasmtime_global_new(store: pointer, type: pointer, val: pointer, ret: pointer) -> pointer:
+    return _wasmtime_global_new(store, type, val, ret)
+
+_wasmtime_global_set = dll.wasmtime_global_set
+_wasmtime_global_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
+def wasmtime_global_set(arg0: pointer, val: pointer) -> pointer:
+    return _wasmtime_global_set(arg0, val)
+
+_wasmtime_instance_new = dll.wasmtime_instance_new
+_wasmtime_instance_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), c_size_t, POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
+def wasmtime_instance_new(store: pointer, module: pointer, imports: pointer, num_imports: c_size_t, instance: pointer, trap: pointer) -> pointer:
+    return _wasmtime_instance_new(store, module, imports, num_imports, instance, trap)
+
+_wasmtime_module_new = dll.wasmtime_module_new
+_wasmtime_module_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t), POINTER(POINTER(wasm_module_t))]
+def wasmtime_module_new(store: pointer, binary: pointer, ret: pointer) -> pointer:
+    return _wasmtime_module_new(store, binary, ret)
+
+_wasmtime_module_validate = dll.wasmtime_module_validate
+_wasmtime_module_validate.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasmtime_module_validate(store: pointer, binary: pointer) -> pointer:
+    return _wasmtime_module_validate(store, binary)
+
+_wasmtime_funcref_table_new = dll.wasmtime_funcref_table_new
+_wasmtime_funcref_table_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_funcref_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_func_t), POINTER(POINTER(wasm_table_t))]
+def wasmtime_funcref_table_new(store: pointer, element_ty: pointer, init: pointer, table: pointer) -> pointer:
+    return _wasmtime_funcref_table_new(store, element_ty, init, table)
+
+_wasmtime_funcref_table_get = dll.wasmtime_funcref_table_get
+_wasmtime_funcref_table_get.restype = c_bool
+_wasmtime_funcref_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(POINTER(wasm_func_t))]
+def wasmtime_funcref_table_get(table: pointer, index: wasm_table_size_t, func: pointer) -> c_bool:
+    return _wasmtime_funcref_table_get(table, index, func)
+
+_wasmtime_funcref_table_set = dll.wasmtime_funcref_table_set
+_wasmtime_funcref_table_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_funcref_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t)]
+def wasmtime_funcref_table_set(table: pointer, index: wasm_table_size_t, value: pointer) -> pointer:
+    return _wasmtime_funcref_table_set(table, index, value)
+
+_wasmtime_funcref_table_grow = dll.wasmtime_funcref_table_grow
+_wasmtime_funcref_table_grow.restype = POINTER(wasmtime_error_t)
+_wasmtime_funcref_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t), POINTER(wasm_table_size_t)]
+def wasmtime_funcref_table_grow(table: pointer, delta: wasm_table_size_t, init: pointer, prev_size: pointer) -> pointer:
+    return _wasmtime_funcref_table_grow(table, delta, init, prev_size)

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -1,11 +1,6 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
 from wasmtime import WasmtimeError
-
-dll.wasm_config_new.restype = P_wasm_config_t
-dll.wasmtime_config_strategy_set.restype = P_wasmtime_error_t
-dll.wasmtime_config_profiler_set.restype = P_wasmtime_error_t
-dll.wasmtime_config_cache_config_load.restype = P_wasmtime_error_t
 
 
 def setter_property(fset):
@@ -25,7 +20,7 @@ class Config:
     """
 
     def __init__(self):
-        self.__ptr__ = dll.wasm_config_new()
+        self.__ptr__ = ffi.wasm_config_new()
 
     @setter_property
     def debug_info(self, enable):
@@ -36,7 +31,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_debug_info_set(self.__ptr__, enable)
+        ffi.wasmtime_config_debug_info_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_threads(self, enable):
@@ -48,7 +43,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_reference_types(self, enable):
@@ -60,7 +55,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_simd(self, enable):
@@ -72,7 +67,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_bulk_memory(self, enable):
@@ -84,7 +79,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_multi_value(self, enable):
@@ -96,7 +91,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
 
     @setter_property
     def strategy(self, strategy):
@@ -111,11 +106,11 @@ class Config:
         """
 
         if strategy == "auto":
-            error = dll.wasmtime_config_strategy_set(self.__ptr__, 0)
+            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 0)
         elif strategy == "cranelift":
-            error = dll.wasmtime_config_strategy_set(self.__ptr__, 1)
+            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 1)
         elif strategy == "lightbeam":
-            error = dll.wasmtime_config_strategy_set(self.__ptr__, 2)
+            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 2)
         else:
             raise WasmtimeError("unknown strategy: " + str(strategy))
         if error:
@@ -125,25 +120,25 @@ class Config:
     def cranelift_debug_verifier(self, enable):
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
+        ffi.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
 
     @setter_property
     def cranelift_opt_level(self, opt_level):
         if opt_level == "none":
-            dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
         elif opt_level == "speed":
-            dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 1)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 1)
         elif opt_level == "speed_and_size":
-            dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 2)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 2)
         else:
             raise WasmtimeError("unknown opt level: " + str(opt_level))
 
     @setter_property
     def profiler(self, profiler):
         if profiler == "none":
-            error = dll.wasmtime_config_profiler_set(self.__ptr__, 0)
+            error = ffi.wasmtime_config_profiler_set(self.__ptr__, 0)
         elif profiler == "jitdump":
-            error = dll.wasmtime_config_profiler_set(self.__ptr__, 1)
+            error = ffi.wasmtime_config_profiler_set(self.__ptr__, 1)
         else:
             raise WasmtimeError("unknown profiler: " + str(profiler))
         if error:
@@ -165,9 +160,9 @@ class Config:
         if isinstance(enabled, bool):
             if not enabled:
                 raise WasmtimeError("caching cannot be explicitly disabled")
-            error = dll.wasmtime_config_cache_config_load(self.__ptr__, 0)
+            error = ffi.wasmtime_config_cache_config_load(self.__ptr__, None)
         elif isinstance(enabled, str):
-            error = dll.wasmtime_config_cache_config_load(self.__ptr__,
+            error = ffi.wasmtime_config_cache_config_load(self.__ptr__,
                                                           c_char_p(enabled.encode('utf-8')))
         else:
             raise TypeError("expected string or bool")
@@ -185,8 +180,8 @@ class Config:
             val = 1
         else:
             val = 0
-        dll.wasmtime_config_interruptable_set(self.__ptr__, val)
+        ffi.wasmtime_config_interruptable_set(self.__ptr__, val)
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasm_config_delete(self.__ptr__)
+            ffi.wasm_config_delete(self.__ptr__)

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -1,15 +1,11 @@
-from ._ffi import *
-from ctypes import *
+from . import _ffi as ffi
 from wasmtime import Config, WasmtimeError
-
-dll.wasm_engine_new.restype = P_wasm_engine_t
-dll.wasm_engine_new_with_config.restype = P_wasm_engine_t
 
 
 class Engine:
     def __init__(self, config=None):
         if config is None:
-            self.__ptr__ = dll.wasm_engine_new()
+            self.__ptr__ = ffi.wasm_engine_new()
         elif not isinstance(config, Config):
             raise TypeError("expected Config")
         elif not hasattr(config, '__ptr__'):
@@ -17,8 +13,8 @@ class Engine:
         else:
             ptr = config.__ptr__
             delattr(config, '__ptr__')
-            self.__ptr__ = dll.wasm_engine_new_with_config(ptr)
+            self.__ptr__ = ffi.wasm_engine_new_with_config(ptr)
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasm_engine_delete(self.__ptr__)
+            ffi.wasm_engine_delete(self.__ptr__)

--- a/wasmtime/_error.py
+++ b/wasmtime/_error.py
@@ -1,4 +1,4 @@
-from ctypes import byref
+from ctypes import byref, POINTER
 
 
 class WasmtimeError(Exception):
@@ -7,14 +7,14 @@ class WasmtimeError(Exception):
 
     @classmethod
     def __from_ptr__(cls, ptr):
-        from ._ffi import P_wasmtime_error_t, wasm_byte_vec_t, dll  # Avoid circular import
-        if not isinstance(ptr, P_wasmtime_error_t):
+        from . import _ffi as ffi
+        if not isinstance(ptr, POINTER(ffi.wasmtime_error_t)):
             raise TypeError("wrong pointer type")
-        message_vec = wasm_byte_vec_t()
-        dll.wasmtime_error_message(ptr, byref(message_vec))
-        message = message_vec.to_str()
-        dll.wasm_byte_vec_delete(byref(message_vec))
-        dll.wasmtime_error_delete(ptr)
+        message_vec = ffi.wasm_byte_vec_t()
+        ffi.wasmtime_error_message(ptr, byref(message_vec))
+        message = ffi.to_str(message_vec)
+        ffi.wasm_byte_vec_delete(byref(message_vec))
+        ffi.wasmtime_error_delete(ptr)
         return WasmtimeError(message)
 
     def __str__(self):

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -1,17 +1,11 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
-
-dll.wasm_extern_as_func.restype = P_wasm_func_t
-dll.wasm_extern_as_table.restype = P_wasm_table_t
-dll.wasm_extern_as_global.restype = P_wasm_global_t
-dll.wasm_extern_as_memory.restype = P_wasm_memory_t
-dll.wasm_extern_type.restype = P_wasm_externtype_t
 
 
 def wrap_extern(ptr, owner):
     from wasmtime import Func, Table, Global, Memory
 
-    if not isinstance(ptr, P_wasm_extern_t):
+    if not isinstance(ptr, POINTER(ffi.wasm_extern_t)):
         raise TypeError("wrong pointer type")
 
     # We must free this as an extern, so if there's no ambient owner then
@@ -19,16 +13,16 @@ def wrap_extern(ptr, owner):
     if owner is None:
         owner = Extern(ptr)
 
-    val = dll.wasm_extern_as_func(ptr)
+    val = ffi.wasm_extern_as_func(ptr)
     if val:
         return Func.__from_ptr__(val, owner)
-    val = dll.wasm_extern_as_table(ptr)
+    val = ffi.wasm_extern_as_table(ptr)
     if val:
         return Table.__from_ptr__(val, owner)
-    val = dll.wasm_extern_as_global(ptr)
+    val = ffi.wasm_extern_as_global(ptr)
     if val:
         return Global.__from_ptr__(val, owner)
-    val = dll.wasm_extern_as_memory(ptr)
+    val = ffi.wasm_extern_as_memory(ptr)
     assert(val)
     return Memory.__from_ptr__(val, owner)
 
@@ -53,4 +47,4 @@ class Extern:
         self.ptr = ptr
 
     def __del__(self):
-        dll.wasm_extern_delete(self.ptr)
+        ffi.wasm_extern_delete(self.ptr)

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -39,226 +39,6 @@ WASM_CONST = c_uint8(0)
 WASM_VAR = c_uint8(1)
 
 
-class wasm_valtype_t(Structure):
-    pass
-
-
-P_wasm_valtype_t = POINTER(wasm_valtype_t)
-
-
-class wasm_globaltype_t(Structure):
-    pass
-
-
-P_wasm_globaltype_t = POINTER(wasm_globaltype_t)
-
-
-class wasm_functype_t(Structure):
-    pass
-
-
-P_wasm_functype_t = POINTER(wasm_functype_t)
-
-
-class wasm_tabletype_t(Structure):
-    pass
-
-
-P_wasm_tabletype_t = POINTER(wasm_tabletype_t)
-
-
-class wasm_memorytype_t(Structure):
-    pass
-
-
-P_wasm_memorytype_t = POINTER(wasm_memorytype_t)
-
-
-class wasm_externtype_t(Structure):
-    pass
-
-
-P_wasm_externtype_t = POINTER(wasm_externtype_t)
-
-
-class wasm_engine_t(Structure):
-    pass
-
-
-P_wasm_engine_t = POINTER(wasm_engine_t)
-
-
-class wasm_store_t(Structure):
-    pass
-
-
-P_wasm_store_t = POINTER(wasm_store_t)
-
-
-class wasm_config_t(Structure):
-    pass
-
-
-P_wasm_config_t = POINTER(wasm_config_t)
-
-
-class wasm_importtype_t(Structure):
-    pass
-
-
-P_wasm_importtype_t = POINTER(wasm_importtype_t)
-
-
-class wasm_exporttype_t(Structure):
-    pass
-
-
-P_wasm_exporttype_t = POINTER(wasm_exporttype_t)
-
-
-class wasm_module_t(Structure):
-    pass
-
-
-P_wasm_module_t = POINTER(wasm_module_t)
-
-
-class wasm_global_t(Structure):
-    pass
-
-
-P_wasm_global_t = POINTER(wasm_global_t)
-
-
-class wasm_table_t(Structure):
-    pass
-
-
-P_wasm_table_t = POINTER(wasm_table_t)
-
-
-class wasm_memory_t(Structure):
-    pass
-
-
-P_wasm_memory_t = POINTER(wasm_memory_t)
-
-
-class wasm_func_t(Structure):
-    pass
-
-
-P_wasm_func_t = POINTER(wasm_func_t)
-
-
-class wasm_trap_t(Structure):
-    pass
-
-
-P_wasm_trap_t = POINTER(wasm_trap_t)
-
-
-class wasm_extern_t(Structure):
-    pass
-
-
-P_wasm_extern_t = POINTER(wasm_extern_t)
-
-
-class wasm_instance_t(Structure):
-    pass
-
-
-P_wasm_instance_t = POINTER(wasm_instance_t)
-
-
-class wasmtime_linker_t(Structure):
-    pass
-
-
-P_wasmtime_linker_t = POINTER(wasmtime_linker_t)
-
-
-class wasmtime_caller_t(Structure):
-    pass
-
-
-P_wasmtime_caller_t = POINTER(wasmtime_caller_t)
-
-
-class wasi_config_t(Structure):
-    pass
-
-
-P_wasi_config_t = POINTER(wasi_config_t)
-
-
-class wasi_instance_t(Structure):
-    pass
-
-
-P_wasi_instance_t = POINTER(wasi_instance_t)
-
-
-class wasm_frame_t(Structure):
-    pass
-
-
-P_wasm_frame_t = POINTER(wasm_frame_t)
-
-
-class wasmtime_error_t(Structure):
-    pass
-
-
-P_wasmtime_error_t = POINTER(wasmtime_error_t)
-
-
-class wasmtime_interrupt_handle_t(Structure):
-    pass
-
-
-P_wasmtime_interrupt_handle_t = POINTER(wasmtime_interrupt_handle_t)
-
-
-class wasm_valtype_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_valtype_t))]
-
-
-class wasm_limits_t(Structure):
-    _fields_ = [("min", c_uint32), ("max", c_uint32)]
-
-
-class wasm_byte_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(c_uint8))]
-
-    def to_bytes(self):
-        ty = c_uint8 * self.size
-        return bytearray(ty.from_address(addressof(self.data.contents)))
-
-    def to_str(self):
-        return self.to_bytes().decode("utf-8")
-
-
-wasm_name_t = wasm_byte_vec_t
-
-
-class wasm_exporttype_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_exporttype_t))]
-
-
-class wasm_importtype_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_importtype_t))]
-
-
-class wasm_extern_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_extern_t))]
-
-
-class wasm_frame_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_frame_t))]
-
-
 class wasm_val_union(Union):
     _fields_ = [
         ("i32", c_int32),
@@ -270,6 +50,18 @@ class wasm_val_union(Union):
 
 class wasm_val_t(Structure):
     _fields_ = [("kind", c_uint8), ("of", wasm_val_union)]
+
+
+from ._bindings import * # noqa
+
+
+def to_bytes(vec):
+    ty = c_uint8 * vec.size
+    return bytearray(ty.from_address(addressof(vec.data.contents)))
+
+
+def to_str(vec):
+    return to_bytes(vec).decode("utf-8")
 
 
 def str_to_name(s, trailing_nul=False):

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -1,11 +1,6 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
 from wasmtime import Store, GlobalType, Val, WasmtimeError
-
-dll.wasmtime_global_new.restype = P_wasmtime_error_t
-dll.wasm_global_type.restype = P_wasm_globaltype_t
-dll.wasm_global_as_extern.restype = P_wasm_extern_t
-dll.wasmtime_global_set.restype = P_wasmtime_error_t
 
 
 class Global:
@@ -15,8 +10,8 @@ class Global:
         if not isinstance(ty, GlobalType):
             raise TypeError("expected a GlobalType")
         val = Val.__convert__(ty.content, val)
-        ptr = P_wasm_global_t()
-        error = dll.wasmtime_global_new(
+        ptr = POINTER(ffi.wasm_global_t)()
+        error = ffi.wasmtime_global_new(
             store.__ptr__,
             ty.__ptr__,
             byref(val.__raw__),
@@ -29,7 +24,7 @@ class Global:
     @classmethod
     def __from_ptr__(cls, ptr, owner):
         ty = cls.__new__(cls)
-        if not isinstance(ptr, P_wasm_global_t):
+        if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
         ty.__owner__ = owner
@@ -41,7 +36,7 @@ class Global:
         Gets the type of this global as a `GlobalType`
         """
 
-        ptr = dll.wasm_global_type(self.__ptr__)
+        ptr = ffi.wasm_global_type(self.__ptr__)
         return GlobalType.__from_ptr__(ptr, None)
 
     @property
@@ -51,8 +46,8 @@ class Global:
 
         Returns a native python type
         """
-        raw = wasm_val_t()
-        dll.wasm_global_get(self.__ptr__, byref(raw))
+        raw = ffi.wasm_val_t()
+        ffi.wasm_global_get(self.__ptr__, byref(raw))
         return Val(raw).value
 
     @value.setter
@@ -61,13 +56,13 @@ class Global:
         Sets the value of this global to a new value
         """
         val = Val.__convert__(self.type.content, val)
-        error = dll.wasmtime_global_set(self.__ptr__, byref(val.__raw__))
+        error = ffi.wasmtime_global_set(self.__ptr__, byref(val.__raw__))
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def _as_extern(self):
-        return dll.wasm_global_as_extern(self.__ptr__)
+        return ffi.wasm_global_as_extern(self.__ptr__)
 
     def __del__(self):
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            dll.wasm_global_delete(self.__ptr__)
+            ffi.wasm_global_delete(self.__ptr__)

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -1,22 +1,16 @@
-from ._ffi import *
 from ctypes import *
 from wasmtime import Store, Instance
 from wasmtime import Module, Trap, WasiInstance, WasmtimeError
+from . import _ffi as ffi
 from ._extern import get_extern_ptr
 from ._config import setter_property
-
-dll.wasmtime_linker_new.restype = P_wasmtime_linker_t
-dll.wasmtime_linker_define.restype = P_wasmtime_error_t
-dll.wasmtime_linker_define_instance.restype = P_wasmtime_error_t
-dll.wasmtime_linker_define_wasi.restype = P_wasmtime_error_t
-dll.wasmtime_linker_instantiate.restype = P_wasmtime_error_t
 
 
 class Linker:
     def __init__(self, store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        self.__ptr__ = dll.wasmtime_linker_new(store.__ptr__)
+        self.__ptr__ = ffi.wasmtime_linker_new(store.__ptr__)
         self.store = store
 
     @setter_property
@@ -27,13 +21,13 @@ class Linker:
         """
         if not isinstance(allow, bool):
             raise TypeError("expected a boolean")
-        dll.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
+        ffi.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
 
     def define(self, module, name, item):
         raw_item = get_extern_ptr(item)
-        module_raw = str_to_name(module)
-        name_raw = str_to_name(name)
-        error = dll.wasmtime_linker_define(
+        module_raw = ffi.str_to_name(module)
+        name_raw = ffi.str_to_name(name)
+        error = ffi.wasmtime_linker_define(
             self.__ptr__,
             byref(module_raw),
             byref(name_raw),
@@ -44,8 +38,8 @@ class Linker:
     def define_instance(self, name, instance):
         if not isinstance(instance, Instance):
             raise TypeError("expected an `Instance`")
-        name_raw = str_to_name(name)
-        error = dll.wasmtime_linker_define_instance(self.__ptr__, byref(name_raw),
+        name_raw = ffi.str_to_name(name)
+        error = ffi.wasmtime_linker_define_instance(self.__ptr__, byref(name_raw),
                                                     instance.__ptr__)
         if error:
             raise WasmtimeError.__from_ptr__(error)
@@ -53,16 +47,16 @@ class Linker:
     def define_wasi(self, instance):
         if not isinstance(instance, WasiInstance):
             raise TypeError("expected an `WasiInstance`")
-        error = dll.wasmtime_linker_define_wasi(self.__ptr__, instance.__ptr__)
+        error = ffi.wasmtime_linker_define_wasi(self.__ptr__, instance.__ptr__)
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def instantiate(self, module):
         if not isinstance(module, Module):
             raise TypeError("expected a `Module`")
-        trap = P_wasm_trap_t()
-        instance = P_wasm_instance_t()
-        error = dll.wasmtime_linker_instantiate(
+        trap = POINTER(ffi.wasm_trap_t)()
+        instance = POINTER(ffi.wasm_instance_t)()
+        error = ffi.wasmtime_linker_instantiate(
             self.__ptr__, module.__ptr__, byref(instance), byref(trap))
         if error:
             raise WasmtimeError.__from_ptr__(error)
@@ -72,4 +66,4 @@ class Linker:
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasmtime_linker_delete(self.__ptr__)
+            ffi.wasmtime_linker_delete(self.__ptr__)

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -1,9 +1,5 @@
-from ._ffi import *
-from ctypes import *
+from . import _ffi as ffi
 from wasmtime import Engine, WasmtimeError
-
-dll.wasm_store_new.restype = P_wasm_store_t
-dll.wasmtime_interrupt_handle_new.restype = P_wasmtime_interrupt_handle_t
 
 
 class Store:
@@ -12,7 +8,7 @@ class Store:
             engine = Engine()
         elif not isinstance(engine, Engine):
             raise TypeError("expected an Engine")
-        self.__ptr__ = dll.wasm_store_new(engine.__ptr__)
+        self.__ptr__ = ffi.wasm_store_new(engine.__ptr__)
         self.engine = engine
 
     def interrupt_handle(self):
@@ -31,7 +27,7 @@ class Store:
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasm_store_delete(self.__ptr__)
+            ffi.wasm_store_delete(self.__ptr__)
 
 
 class InterruptHandle:
@@ -46,7 +42,7 @@ class InterruptHandle:
     def __init__(self, store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        ptr = dll.wasmtime_interrupt_handle_new(store.__ptr__)
+        ptr = ffi.wasmtime_interrupt_handle_new(store.__ptr__)
         if not ptr:
             raise WasmtimeError("interrupts not enabled on Store")
         self.__ptr__ = ptr
@@ -56,8 +52,8 @@ class InterruptHandle:
         Schedules an interrupt to be sent to interrupt this handle's store's
         next (or current) execution of wasm code.
         """
-        dll.wasmtime_interrupt_handle_interrupt(self.__ptr__)
+        ffi.wasmtime_interrupt_handle_interrupt(self.__ptr__)
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasmtime_interrupt_handle_delete(self.__ptr__)
+            ffi.wasmtime_interrupt_handle_delete(self.__ptr__)

--- a/wasmtime/_wat2wasm.py
+++ b/wasmtime/_wat2wasm.py
@@ -1,8 +1,6 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
 from wasmtime import WasmtimeError
-
-dll.wasmtime_wat2wasm.restype = P_wasmtime_error_t
 
 
 def wat2wasm(wat):
@@ -26,12 +24,12 @@ def wat2wasm(wat):
     if isinstance(wat, str):
         wat = wat.encode('utf8')
     wat_buffer = cast(create_string_buffer(wat), POINTER(c_uint8))
-    wat = wasm_byte_vec_t(len(wat), wat_buffer)
-    wasm = wasm_byte_vec_t()
-    error = dll.wasmtime_wat2wasm(byref(wat), byref(wasm))
+    wat = ffi.wasm_byte_vec_t(len(wat), wat_buffer)
+    wasm = ffi.wasm_byte_vec_t()
+    error = ffi.wasmtime_wat2wasm(byref(wat), byref(wasm))
     if error:
         raise WasmtimeError.__from_ptr__(error)
     else:
-        ret = wasm.to_bytes()
-        dll.wasm_byte_vec_delete(byref(wasm))
+        ret = ffi.to_bytes(wasm)
+        ffi.wasm_byte_vec_delete(byref(wasm))
         return ret


### PR DESCRIPTION
This commit migrates this binding of Wasmtime to auto-generate `ctypes`
definitions for all exported functions and types from wasmtime. The goal
of this is to automate binding generation and avoid having to hand-write
all imported types/functions. Currently all our functions stylistically
specify their return types (some for correctness), and this makes it so
they're procedurally generated and additionally specify argument types.

This should enable us to get better type checking with `ctypes` itself
as well as enable type annotations in this library since all imported
functions are procedurally generated and typed accordingly.