### PR TITLE
Add type annotations throughout the codebase, check on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, pypy3]
+        python-version: [3.6, 3.7, 3.8]
         exclude:
         # Looks like pypy on Windows is 32-bit, so don't test it since we
         # only work with 64-bit builds

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags-ignore: [dev]
   pull_request:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 0 * * *' # run at 00:00 UTC
 
@@ -132,7 +132,7 @@ jobs:
     - run: mv coverage generated-docs
     - name: Push to gh-pages
       run: curl -LsSf https://git.io/fhJ8n | rustc - && (cd generated-docs && ../rust_out)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:
         GITHUB_DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         BUILD_REPOSITORY_ID: ${{ github.repository }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python download-wasmtime.py
-      - run: pip install pytest
+      - run: pip install -e ".[testing]"
       - run: pytest
 
   build:
@@ -76,16 +76,6 @@ jobs:
         name: wheels
         path: dist
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      - run: pip install flake8
-      - run: flake8
-
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -109,7 +99,7 @@ jobs:
       with:
         python-version: '3.x'
     - run: python download-wasmtime.py
-    - run: pip install coverage pytest
+    - run: pip install -e ".[testing]"
     - run: coverage run -m pytest
     - run: coverage html
     - uses: actions/upload-artifact@v1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov
 wasmtime/linux-*
 wasmtime/darwin-*
 wasmtime/win32-*
+wasmtime/include

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ def say_hello():
     print("Hello from Python!")
 hello = Func(store, FuncType([], []), say_hello)
 
-instance = Instance(module, [hello])
+instance = Instance(store, module, [hello])
 run = instance.exports["run"]
 run()
 ```

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
       <img src="https://img.shields.io/pypi/pyversions/wasmtime.svg" alt="Latest Version"/>
     </a>
     <a href="https://bytecodealliance.github.io/wasmtime-py/">
-      <img src="https://img.shields.io/badge/docs-master-green" alt="Documentation"/>
+      <img src="https://img.shields.io/badge/docs-main-green" alt="Documentation"/>
     </a>
     <a href="https://bytecodealliance.github.io/wasmtime-py/coverage/">
-      <img src="https://img.shields.io/badge/coverage-master-green" alt="Code Coverage"/>
+      <img src="https://img.shields.io/badge/coverage-main-green" alt="Code Coverage"/>
     </a>
   </p>
 
@@ -66,7 +66,7 @@ run()
 Be sure to check out the [`examples` directory], which has other usage patterns
 as well as the [full API documentation][apidoc] of the `wasmtime-py` package.
 
-[`examples` directory]: https://github.com/bytecodealliance/wasmtime-py/tree/master/examples
+[`examples` directory]: https://github.com/bytecodealliance/wasmtime-py/tree/main/examples
 [apidoc]: https://bytecodealliance.github.io/wasmtime-py/
 
 If your WebAssembly module works this way, then you can also import the WebAssembly module
@@ -125,11 +125,11 @@ After that you should be good to go!
 
 The CI for this project does a few different things:
 
-* API docs are generated for pushes to the master branch and are [published
+* API docs are generated for pushes to the `main` branch and are [published
     online][apidoc].
-* Test coverage information is generated for pushes to the master branch and are
+* Test coverage information is generated for pushes to the `main` branch and are
   [available online](https://bytecodealliance.github.io/wasmtime-py/coverage/).
-* Each push to `master` will publish a release to
+* Each push to `main` will publish a release to
   [test.pypi.org](https://test.pypi.org/project/wasmtime/) for local inspection.
 * Tagged commits will automatically be published to
   [pypi.org](https://pypi.org/project/wasmtime/).

--- a/bindgen.py
+++ b/bindgen.py
@@ -111,7 +111,7 @@ class Visitor(c_ast.NodeVisitor):
         self.ret += "_{}.restype = {}\n".format(name, type_name(ret, ptr))
         self.ret += "_{}.argtypes = [{}]\n".format(name, ', '.join(argtypes))
         self.ret += "def {}({}) -> {}:\n".format(name, ', '.join(argpairs), retty)
-        self.ret += "    return _{}({})\n".format(name, ', '.join(argnames))
+        self.ret += "    return _{}({})  # type: ignore\n".format(name, ', '.join(argnames))
 
 
 def type_name(ty, ptr=False, typing=False):

--- a/bindgen.py
+++ b/bindgen.py
@@ -1,0 +1,182 @@
+# type: ignore
+
+# This is a small script to parse the header files from wasmtime and generate
+# appropriate function definitions in Python for each exported function. This
+# also reflects types into Python with `ctypes`. While there's at least one
+# other generate that does this already it seemed to not quite fit our purposes
+# with lots of extra an unnecessary boilerplate.
+
+from pycparser import c_ast, parse_file
+
+
+class Visitor(c_ast.NodeVisitor):
+    def __init__(self):
+        self.ret = ''
+        self.ret += '# flake8: noqa\n'
+        self.ret += '#\n'
+        self.ret += '# This is a procedurally generated file, DO NOT EDIT\n'
+        self.ret += '# instead edit `./bindgen.py` at the root of the repo\n'
+        self.ret += '\n'
+        self.ret += 'from ctypes import *\n'
+        self.ret += 'from ._ffi import dll, wasm_val_t\n'
+
+    # Skip all function definitions, we don't bind those
+    def visit_FuncDef(self, node):
+        pass
+
+    def visit_Struct(self, node):
+        if not node.name or not node.name.startswith('was'):
+            return
+        if node.name == 'wasm_val_t':
+            return
+        self.ret += "\n"
+        self.ret += "class {}(Structure):\n".format(node.name)
+        if node.decls:
+            self.ret += "    _fields_ = [\n"
+            for decl in node.decls:
+                self.ret += "        (\"{}\", {}),\n".format(decl.name, type_name(decl.type))
+            self.ret += "    ]\n"
+        else:
+            self.ret += "    pass\n"
+
+    def visit_Typedef(self, node):
+        if not node.name or not node.name.startswith('was'):
+            return
+        self.visit(node.type)
+        tyname = type_name(node.type)
+        if tyname != node.name:
+            self.ret += "\n"
+            self.ret += "{} = {}\n".format(node.name, type_name(node.type))
+
+    def visit_FuncDecl(self, node):
+        if isinstance(node.type, c_ast.TypeDecl):
+            ptr = False
+            ty = node.type
+        elif isinstance(node.type, c_ast.PtrDecl):
+            ptr = True
+            ty = node.type.type
+        name = ty.declname
+        # This is probably a type, skip it
+        if name.endswith('_t'):
+            return
+        # Skip anything not related to wasi or wasm
+        if not name.startswith('was'):
+            return
+
+        # TODO: these are bugs with upstream wasmtime
+        if name == 'wasm_frame_copy':
+            return
+        if name == 'wasm_frame_instance':
+            return
+        if name == 'wasm_module_serialize':
+            return
+        if name == 'wasm_module_deserialize':
+            return
+        if 'ref_as_' in name:
+            return
+        if 'extern_const' in name:
+            return
+        if 'foreign' in name:
+            return
+
+        ret = ty.type
+
+        argpairs = []
+        argtypes = []
+        argnames = []
+        if node.args:
+            for i, param in enumerate(node.args.params):
+                argname = param.name
+                if not argname or argname == "import" or argname == "global":
+                    argname = "arg{}".format(i)
+                argpairs.append("{}: {}".format(argname, type_name(param.type, typing=True)))
+                argnames.append(argname)
+                argtypes.append(type_name(param.type))
+        retty = type_name(node.type, ptr, typing=True)
+
+        self.ret += "\n"
+        self.ret += "_{0} = dll.{0}\n".format(name)
+        self.ret += "_{}.restype = {}\n".format(name, type_name(ret, ptr))
+        self.ret += "_{}.argtypes = [{}]\n".format(name, ', '.join(argtypes))
+        self.ret += "def {}({}) -> {}:\n".format(name, ', '.join(argpairs), retty)
+        self.ret += "    return _{}({})\n".format(name, ', '.join(argnames))
+
+
+def type_name(ty, ptr=False, typing=False):
+    while isinstance(ty, c_ast.TypeDecl):
+        ty = ty.type
+
+    if ptr:
+        if typing:
+            return "pointer"
+        if isinstance(ty, c_ast.IdentifierType) and ty.names[0] == "void":
+            return "c_void_p"
+        elif not isinstance(ty, c_ast.FuncDecl):
+            return "POINTER({})".format(type_name(ty, False, typing))
+
+    if isinstance(ty, c_ast.IdentifierType):
+        assert(len(ty.names) == 1)
+        if ty.names[0] == "void":
+            return "None"
+        elif ty.names[0] == "_Bool":
+            return "c_bool"
+        elif ty.names[0] == "byte_t":
+            return "c_ubyte"
+        elif ty.names[0] == "uint8_t":
+            return "c_uint8"
+        elif ty.names[0] == "uint32_t":
+            return "c_uint32"
+        elif ty.names[0] == "uint64_t":
+            return "c_uint64"
+        elif ty.names[0] == "size_t":
+            return "c_size_t"
+        elif ty.names[0] == "char":
+            return "c_char"
+        elif ty.names[0] == "int":
+            return "c_int"
+        return ty.names[0]
+    elif isinstance(ty, c_ast.Struct):
+        return ty.name
+    elif isinstance(ty, c_ast.FuncDecl):
+        tys = []
+        # TODO: apparently errors are thrown if we faithfully represent the
+        # pointer type here, seems odd?
+        if isinstance(ty.type, c_ast.PtrDecl):
+            tys.append("c_size_t")
+        else:
+            tys.append(type_name(ty.type))
+        if ty.args.params:
+            for param in ty.args.params:
+                tys.append(type_name(param.type))
+        return "CFUNCTYPE({})".format(', '.join(tys))
+    elif isinstance(ty, c_ast.PtrDecl) or isinstance(ty, c_ast.ArrayDecl):
+        return type_name(ty.type, True, typing)
+    else:
+        raise RuntimeError("unknown {}".format(ty))
+
+
+ast = parse_file(
+    './wasmtime/include/wasmtime.h',
+    use_cpp=True,
+    cpp_args=[
+        '-I./wasmtime/include',
+        '-D__attribute__(x)=',
+        '-D__asm__(x)=',
+        '-D_Static_assert(x, y)=',
+        '-Dstatic_assert(x, y)=',
+        '-D__restrict=',
+        '-D__extension__=',
+    ]
+)
+
+v = Visitor()
+v.visit(ast)
+
+if __name__ == "__main__":
+    with open("wasmtime/_bindings.py", "w") as f:
+        f.write(v.ret)
+else:
+    with open("wasmtime/_bindings.py", "r") as f:
+        contents = f.read()
+        if contents != v.ret:
+            raise RuntimeError("bindings need an update, run this script")

--- a/examples/loader.py
+++ b/examples/loader.py
@@ -3,11 +3,11 @@
 
 import wasmtime.loader  # noqa: F401
 
-import loader_load_python
-import loader_load_wasm
+import loader_load_python  # type: ignore
+import loader_load_wasm  # type: ignore
 
 # This imports our `loader_add.wat` file next to this module
-import loader_add
+import loader_add  # type: ignore
 assert(loader_add.add(1, 2) == 3)
 
 # This imports our `loader_load_wasm.wat`, which in turn imports

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,9 @@ disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
+[mypy-tests.*]
+check_untyped_defs = True
+
 # Ignore errors in examples
 [mypy-gcd]
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-#warn_return_any = True
+warn_return_any = True
 warn_unused_configs = True
 
 [mypy-wasmtime.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,8 @@ warn_no_return = True
 [mypy-wasmtime.*]
 disallow_incomplete_defs = True
 warn_return_any = True
+disallow_any_unimported = True
+disallow_untyped_calls = True
 
 # Ignore errors in examples
 [mypy-gcd]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+#warn_return_any = True
+warn_unused_configs = True
+
+[mypy-wasmtime.*]
+#disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 warn_unused_configs = True
 warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unreachable = True
+warn_no_return = True
 
 [mypy-wasmtime.*]
 disallow_incomplete_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,10 +6,11 @@ warn_unreachable = True
 warn_no_return = True
 
 [mypy-wasmtime.*]
-disallow_incomplete_defs = True
 warn_return_any = True
 disallow_any_unimported = True
 disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
 
 # Ignore errors in examples
 [mypy-gcd]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,19 @@
 [mypy]
-warn_return_any = True
 warn_unused_configs = True
+warn_unused_ignores = True
 
 [mypy-wasmtime.*]
-#disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
+# Ignore errors in examples
+[mypy-gcd]
+ignore_errors = True
+[mypy-multi]
+ignore_errors = True
+[mypy-memory]
+ignore_errors = True
+[mypy-hello]
+ignore_errors = True
+[mypy-linking]
+ignore_errors = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --flake8

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules --flake8
+addopts = --doctest-modules --flake8 --mypy

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import setuptools
 import os
 
@@ -36,6 +38,8 @@ setuptools.setup(
         'testing': [
             'coverage',
             'pytest',
+            'pycparser',
+            'pytest-flake8',
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
             'pytest',
             'pycparser',
             'pytest-flake8',
+            'pytest-mypy',
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = "0.16.0"
+version = "0.17.0"
 
 # Give unique version numbers to all commits so our publication-on-each commit
 # works on master

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 version = "0.17.0"
 
 # Give unique version numbers to all commits so our publication-on-each commit
-# works on master
+# works on main
 if 'PROD' not in os.environ:
     stream = os.popen('git rev-list HEAD --count')
     output = stream.read()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,7 +10,7 @@ class TestEngine(unittest.TestCase):
 
     def test_errors(self):
         with self.assertRaises(TypeError):
-            Engine(3)
+            Engine(3)  # type: ignore
         config = Config()
         Engine(config)
         with self.assertRaises(WasmtimeError):

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -47,9 +47,9 @@ class TestFunc(unittest.TestCase):
         store = Store()
         ty = FuncType([], [])
         with self.assertRaises(TypeError):
-            Func(1, ty, lambda: None)
+            Func(1, ty, lambda: None)  # type: ignore
         with self.assertRaises(TypeError):
-            Func(store, 1, lambda: None)
+            Func(store, 1, lambda: None)  # type: ignore
         func = Func(store, ty, lambda: None)
         with self.assertRaises(WasmtimeError):
             func(2)
@@ -130,7 +130,7 @@ class TestFunc(unittest.TestCase):
         func = Func(store, FuncType([], []), runtest2, access_caller=True)
         Instance(store, module, [func])
         self.assertTrue(hit['yes'])
-        self.assertTrue(hit['caller'].get('foo') is None)
+        self.assertTrue(hit['caller'].get('foo') is None)  # type: ignore
 
         # Test that `Caller` is invalidated even on exceptions
         hit2 = {}

--- a/tests/test_global.py
+++ b/tests/test_global.py
@@ -21,15 +21,15 @@ class TestGlobal(unittest.TestCase):
         store = Store()
         ty = GlobalType(ValType.i32(), True)
         with self.assertRaises(TypeError):
-            Global(store, ty, store)
+            Global(store, ty, store)  # type: ignore
         with self.assertRaises(TypeError):
-            Global(store, 1, Val.i32(1))
+            Global(store, 1, Val.i32(1))  # type: ignore
         with self.assertRaises(TypeError):
-            Global(1, ty, Val.i32(1))
+            Global(1, ty, Val.i32(1))  # type: ignore
 
         g = Global(store, ty, Val.i32(1))
         with self.assertRaises(TypeError):
-            g.value = g
+            g.value = g  # type: ignore
 
         ty = GlobalType(ValType.i32(), False)
         g = Global(store, ty, Val.i32(1))

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -15,18 +15,18 @@ class TestInstance(unittest.TestCase):
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports), 1)
         extern = instance.exports[0]
-        self.assertTrue(isinstance(extern, Func))
-        self.assertTrue(isinstance(extern.type, FuncType))
+        assert(isinstance(extern, Func))
+        assert(isinstance(extern.type, FuncType))
 
         extern()
 
-        self.assertTrue(instance.exports[''] is not None)
+        assert(instance.exports[''] is not None)
         with self.assertRaises(KeyError):
             instance.exports['x']
         with self.assertRaises(IndexError):
             instance.exports[100]
-        self.assertTrue(instance.exports.get('x') is None)
-        self.assertTrue(instance.exports.get(2) is None)
+        assert(instance.exports.get('x') is None)
+        assert(instance.exports.get(2) is None)
 
     def test_export_global(self):
         store = Store()
@@ -35,9 +35,9 @@ class TestInstance(unittest.TestCase):
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports), 1)
         extern = instance.exports[0]
-        self.assertTrue(isinstance(extern, Global))
+        assert(isinstance(extern, Global))
         self.assertEqual(extern.value, 3)
-        self.assertTrue(isinstance(extern.type, GlobalType))
+        assert(isinstance(extern.type, GlobalType))
 
     def test_export_memory(self):
         store = Store()
@@ -45,7 +45,7 @@ class TestInstance(unittest.TestCase):
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports), 1)
         extern = instance.exports[0]
-        self.assertTrue(isinstance(extern, Memory))
+        assert(isinstance(extern, Memory))
         self.assertEqual(extern.size, 1)
 
     def test_export_table(self):
@@ -54,7 +54,7 @@ class TestInstance(unittest.TestCase):
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports), 1)
         extern = instance.exports[0]
-        self.assertTrue(isinstance(extern, Table))
+        assert(isinstance(extern, Table))
 
     def test_multiple_exports(self):
         store = Store()
@@ -67,9 +67,9 @@ class TestInstance(unittest.TestCase):
         """)
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports), 3)
-        self.assertTrue(isinstance(instance.exports[0], Func))
-        self.assertTrue(isinstance(instance.exports[1], Func))
-        self.assertTrue(isinstance(instance.exports[2], Global))
+        assert(isinstance(instance.exports[0], Func))
+        assert(isinstance(instance.exports[1], Func))
+        assert(isinstance(instance.exports[2], Global))
 
     def test_import_func(self):
         store = Store()
@@ -82,9 +82,9 @@ class TestInstance(unittest.TestCase):
         hit = []
         func = Func(module.store, FuncType([], []), lambda: hit.append(True))
         Instance(store, module, [func])
-        self.assertTrue(len(hit) == 1)
+        assert(len(hit) == 1)
         Instance(store, module, [func])
-        self.assertTrue(len(hit) == 2)
+        assert(len(hit) == 2)
 
     def test_import_global(self):
         store = Store()
@@ -100,17 +100,24 @@ class TestInstance(unittest.TestCase):
         """)
         g = Global(module.store, GlobalType(ValType.i32(), True), 2)
         instance = Instance(store, module, [g])
-        self.assertEqual(instance.exports[0](), 2)
+        f = instance.exports[0]
+        assert(isinstance(f, Func))
+
+        self.assertEqual(f(), 2)
         g.value = 4
-        self.assertEqual(instance.exports[0](), 4)
+        self.assertEqual(f(), 4)
 
         instance2 = Instance(store, module, [g])
-        self.assertEqual(instance.exports[0](), 4)
-        self.assertEqual(instance2.exports[0](), 4)
+        f2 = instance2.exports[0]
+        assert(isinstance(f2, Func))
+        self.assertEqual(f(), 4)
+        self.assertEqual(f2(), 4)
 
-        instance.exports[1]()
-        self.assertEqual(instance.exports[0](), 5)
-        self.assertEqual(instance2.exports[0](), 5)
+        update = instance.exports[1]
+        assert(isinstance(update, Func))
+        update()
+        self.assertEqual(f(), 5)
+        self.assertEqual(f2(), 5)
 
     def test_import_memory(self):
         store = Store()
@@ -141,9 +148,9 @@ class TestInstance(unittest.TestCase):
     def test_invalid(self):
         store = Store()
         with self.assertRaises(TypeError):
-            Instance(store, 1, [])
+            Instance(store, 1, [])  # type: ignore
         with self.assertRaises(TypeError):
-            Instance(store, Module(store, '(module (import "" "" (func)))'), [1])
+            Instance(store, Module(store, '(module (import "" "" (func)))'), [1])  # type: ignore
 
         val = Func(store, FuncType([], []), lambda: None)
         module = Module(store, '(module (import "" "" (func)))')

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -30,17 +30,17 @@ class TestLinker(unittest.TestCase):
         linker.define("", "a", func)
 
         with self.assertRaises(TypeError):
-            linker.define("", "", 2)
+            linker.define("", "", 2)  # type: ignore
         with self.assertRaises(TypeError):
-            linker.define(2, "", func)
+            linker.define(2, "", func)  # type: ignore
         with self.assertRaises(TypeError):
-            linker.define("", 2, func)
+            linker.define("", 2, func)  # type: ignore
 
     def test_define_instance(self):
         store = Store()
         linker = Linker(store)
         with self.assertRaises(TypeError):
-            linker.define_instance("x", 2)
+            linker.define_instance("x", 2)  # type: ignore
 
         module = Module(store, "(module)")
         linker.define_instance("a", Instance(store, module, []))
@@ -104,6 +104,6 @@ class TestLinker(unittest.TestCase):
         with self.assertRaises(TypeError):
             linker.allow_shadowing = 2
         with self.assertRaises(TypeError):
-            Linker(2)
+            Linker(2)  # type: ignore
         with self.assertRaises(TypeError):
-            linker.instantiate(3)
+            linker.instantiate(3)  # type: ignore

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -15,7 +15,7 @@ class TestMemory(unittest.TestCase):
         self.assertTrue(memory.grow(0))
         self.assertEqual(memory.size, 2)
         with self.assertRaises(TypeError):
-            memory.grow('')
+            memory.grow('')  # type: ignore
         with self.assertRaises(WasmtimeError):
             memory.grow(-1)
         self.assertEqual(memory.data_ptr[0], 0)
@@ -34,6 +34,6 @@ class TestMemory(unittest.TestCase):
         store = Store()
         ty = MemoryType(Limits(1, 2))
         with self.assertRaises(TypeError):
-            Memory(1, ty)
+            Memory(1, ty)  # type: ignore
         with self.assertRaises(TypeError):
-            Memory(store, 1)
+            Memory(store, 1)  # type: ignore

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -11,13 +11,13 @@ class TestModule(unittest.TestCase):
 
     def test_invalid(self):
         with self.assertRaises(TypeError):
-            Module.validate(1, b'')
+            Module.validate(1, b'')  # type: ignore
         with self.assertRaises(TypeError):
-            Module.validate(Store(), 2)
+            Module.validate(Store(), 2)  # type: ignore
         with self.assertRaises(TypeError):
-            Module(1, b'')
+            Module(1, b'')  # type: ignore
         with self.assertRaises(TypeError):
-            Module(Store(), 2)
+            Module(Store(), 2)  # type: ignore
         with self.assertRaises(WasmtimeError):
             Module(Store(), b'')
         with self.assertRaises(WasmtimeError):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,7 +10,7 @@ class TestStore(unittest.TestCase):
 
     def test_errors(self):
         with self.assertRaises(TypeError):
-            Store(3)
+            Store(3)  # type: ignore
 
     def test_interrupt_handle_requires_interruptable(self):
         with self.assertRaises(WasmtimeError):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -11,6 +11,7 @@ class TestTable(unittest.TestCase):
         """)
         table = Instance(store, module, []).exports[0]
         self.assertTrue(isinstance(table, Table))
+        assert(isinstance(table.type, TableType))
         self.assertEqual(table.type.limits, Limits(1, None))
         self.assertEqual(table.size, 1)
 
@@ -32,9 +33,9 @@ class TestTable(unittest.TestCase):
 
         # type errors
         with self.assertRaises(TypeError):
-            table.grow('x', None)
+            table.grow('x', None)  # type: ignore
         with self.assertRaises(TypeError):
-            table.grow(2, 'x')
+            table.grow(2, 'x')  # type: ignore
 
         # growth works
         table.grow(1, None)
@@ -60,6 +61,7 @@ class TestTable(unittest.TestCase):
         func = Func(store, FuncType([], []), set_called)
         table.grow(1, func)
         assert(not called['hit'])
+        assert(isinstance(table[1], Func))
         table[1]()
         assert(called['hit'])
 
@@ -75,7 +77,7 @@ class TestTable(unittest.TestCase):
     def test_errors(self):
         ty = TableType(ValType.i32(), Limits(1, 2))
         with self.assertRaises(TypeError):
-            Table(1, ty, 2)
+            Table(1, ty, 2)  # type: ignore
         store = Store()
         with self.assertRaises(TypeError):
-            Table(store, 2, 2)
+            Table(store, 2, 2)  # type: ignore

--- a/tests/test_trap.py
+++ b/tests/test_trap.py
@@ -12,9 +12,9 @@ class TestTrap(unittest.TestCase):
     def test_errors(self):
         store = Store()
         with self.assertRaises(TypeError):
-            Trap(1, '')
+            Trap(1, '')  # type: ignore
         with self.assertRaises(TypeError):
-            Trap(store, 1)
+            Trap(store, 1)  # type: ignore
 
     def test_frames(self):
         store = Store()
@@ -30,7 +30,9 @@ class TestTrap(unittest.TestCase):
         """)
         i = Instance(store, module, [])
         try:
-            i.exports[0]()
+            e = i.exports[0]
+            assert(isinstance(e, Func))
+            e()
         except Trap as e:
             trap = e
 
@@ -65,7 +67,9 @@ wasm backtrace:
         """)
         i = Instance(store, module, [])
         try:
-            i.exports[0]()
+            e = i.exports[0]
+            assert(isinstance(e, Func))
+            e()
         except Trap as e:
             trap = e
 

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -6,9 +6,9 @@ from wasmtime import *
 class TestValue(unittest.TestCase):
     def test_i32(self):
         with self.assertRaises(TypeError):
-            Val.i32('')
+            Val.i32('')  # type: ignore
         with self.assertRaises(TypeError):
-            Val.i32(1.2)
+            Val.i32(1.2)  # type: ignore
 
         i = Val.i32(1)
         self.assertEqual(i.as_i32(), 1)
@@ -24,9 +24,9 @@ class TestValue(unittest.TestCase):
 
     def test_i64(self):
         with self.assertRaises(TypeError):
-            Val.i64('')
+            Val.i64('')  # type: ignore
         with self.assertRaises(TypeError):
-            Val.i64(1.2)
+            Val.i64(1.2)  # type: ignore
 
         i = Val.i64(1)
         self.assertEqual(i.as_i64(), 1)
@@ -46,7 +46,7 @@ class TestValue(unittest.TestCase):
 
     def test_f32(self):
         with self.assertRaises(TypeError):
-            Val.f32('')
+            Val.f32('')  # type: ignore
         with self.assertRaises(TypeError):
             Val.f32(1)
 
@@ -59,7 +59,7 @@ class TestValue(unittest.TestCase):
 
     def test_f64(self):
         with self.assertRaises(TypeError):
-            Val.f64('')
+            Val.f64('')  # type: ignore
         with self.assertRaises(TypeError):
             Val.f64(1)
 

--- a/tests/test_wasi.py
+++ b/tests/test_wasi.py
@@ -34,13 +34,13 @@ class TestWasi(unittest.TestCase):
 
         # Type errors
         with self.assertRaises(TypeError):
-            WasiInstance(1, "nonexistent_wasi", config)
+            WasiInstance(1, "nonexistent_wasi", config)  # type: ignore
         with self.assertRaises(TypeError):
-            WasiInstance(Store(), 1, config)
+            WasiInstance(Store(), 1, config)  # type: ignore
         with self.assertRaises(TypeError):
-            WasiInstance(Store(), "nonexistent_wasi", 1)
+            WasiInstance(Store(), "nonexistent_wasi", 1)  # type: ignore
         with self.assertRaises(TypeError):
-            instance.bind(3)
+            instance.bind(3)  # type: ignore
 
         module = Module(instance.store, """
             (module
@@ -51,6 +51,7 @@ class TestWasi(unittest.TestCase):
         imp = module.imports[0]
         binding = instance.bind(imp)
         self.assertTrue(isinstance(binding, Func))
+        assert(isinstance(binding, Func))
         binding(1, 2)  # should return EFAULT basically
 
     def test_preview1(self):
@@ -66,4 +67,5 @@ class TestWasi(unittest.TestCase):
         imp = module.imports[0]
         binding = instance.bind(imp)
         self.assertTrue(isinstance(binding, Func))
+        assert(isinstance(binding, Func))
         binding(1, 2)  # should return EFAULT basically

--- a/wasmtime/__init__.py
+++ b/wasmtime/__init__.py
@@ -21,7 +21,7 @@ from ._types import FuncType, GlobalType, MemoryType, TableType
 from ._types import ValType, Limits, ImportType, ExportType
 from ._wat2wasm import wat2wasm
 from ._module import Module
-from ._value import Val
+from ._value import Val, IntoVal
 from ._trap import Trap, Frame
 from ._func import Func, Caller
 from ._globals import Global
@@ -44,6 +44,7 @@ __all__ = [
     'Limits',
     'ImportType',
     'ExportType',
+    'IntoVal',
     'Val',
     'Func',
     'Caller',

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -790,9 +790,6 @@ _wasm_val_vec_delete.argtypes = [POINTER(wasm_val_vec_t)]
 def wasm_val_vec_delete(arg0: pointer) -> None:
     return _wasm_val_vec_delete(arg0)
 
-class wasm_ref_t(Structure):
-    pass
-
 _wasm_ref_delete = dll.wasm_ref_delete
 _wasm_ref_delete.restype = None
 _wasm_ref_delete.argtypes = [POINTER(wasm_ref_t)]
@@ -1126,13 +1123,13 @@ wasm_func_callback_with_env_t = CFUNCTYPE(c_size_t, c_void_p, POINTER(wasm_val_t
 _wasm_func_new = dll.wasm_func_new
 _wasm_func_new.restype = POINTER(wasm_func_t)
 _wasm_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_t]
-def wasm_func_new(arg0: pointer, arg1: pointer, arg2: wasm_func_callback_t) -> pointer:
+def wasm_func_new(arg0: pointer, arg1: pointer, arg2: pointer) -> pointer:
     return _wasm_func_new(arg0, arg1, arg2)
 
 _wasm_func_new_with_env = dll.wasm_func_new_with_env
 _wasm_func_new_with_env.restype = POINTER(wasm_func_t)
 _wasm_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_func_new_with_env(arg0: pointer, type: pointer, arg2: wasm_func_callback_with_env_t, env: pointer, finalizer: pointer) -> pointer:
+def wasm_func_new_with_env(arg0: pointer, type: pointer, arg2: pointer, env: pointer, finalizer: pointer) -> pointer:
     return _wasm_func_new_with_env(arg0, type, arg2, env, finalizer)
 
 _wasm_func_type = dll.wasm_func_type
@@ -1938,13 +1935,13 @@ wasmtime_func_callback_with_env_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_
 _wasmtime_func_new = dll.wasmtime_func_new
 _wasmtime_func_new.restype = POINTER(wasm_func_t)
 _wasmtime_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_t]
-def wasmtime_func_new(arg0: pointer, arg1: pointer, callback: wasmtime_func_callback_t) -> pointer:
+def wasmtime_func_new(arg0: pointer, arg1: pointer, callback: pointer) -> pointer:
     return _wasmtime_func_new(arg0, arg1, callback)
 
 _wasmtime_func_new_with_env = dll.wasmtime_func_new_with_env
 _wasmtime_func_new_with_env.restype = POINTER(wasm_func_t)
 _wasmtime_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasmtime_func_new_with_env(store: pointer, type: pointer, callback: wasmtime_func_callback_with_env_t, env: pointer, finalizer: pointer) -> pointer:
+def wasmtime_func_new_with_env(store: pointer, type: pointer, callback: pointer, env: pointer, finalizer: pointer) -> pointer:
     return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)
 
 _wasmtime_caller_export_get = dll.wasmtime_caller_export_get

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -1,0 +1,2047 @@
+# flake8: noqa
+#
+# This is a procedurally generated file, DO NOT EDIT
+# instead edit `./bindgen.py` at the root of the repo
+
+from ctypes import *
+from ._ffi import dll, wasm_val_t
+
+wasm_byte_t = c_ubyte
+
+class wasm_byte_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(wasm_byte_t)),
+    ]
+
+_wasm_byte_vec_new_empty = dll.wasm_byte_vec_new_empty
+_wasm_byte_vec_new_empty.restype = None
+_wasm_byte_vec_new_empty.argtypes = [POINTER(wasm_byte_vec_t)]
+def wasm_byte_vec_new_empty(out: pointer) -> None:
+    return _wasm_byte_vec_new_empty(out)
+
+_wasm_byte_vec_new_uninitialized = dll.wasm_byte_vec_new_uninitialized
+_wasm_byte_vec_new_uninitialized.restype = None
+_wasm_byte_vec_new_uninitialized.argtypes = [POINTER(wasm_byte_vec_t), c_size_t]
+def wasm_byte_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_byte_vec_new_uninitialized(out, arg1)
+
+_wasm_byte_vec_new = dll.wasm_byte_vec_new
+_wasm_byte_vec_new.restype = None
+_wasm_byte_vec_new.argtypes = [POINTER(wasm_byte_vec_t), c_size_t, POINTER(wasm_byte_t)]
+def wasm_byte_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_byte_vec_new(out, arg1, arg2)
+
+_wasm_byte_vec_copy = dll.wasm_byte_vec_copy
+_wasm_byte_vec_copy.restype = None
+_wasm_byte_vec_copy.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
+def wasm_byte_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_byte_vec_copy(out, arg1)
+
+_wasm_byte_vec_delete = dll.wasm_byte_vec_delete
+_wasm_byte_vec_delete.restype = None
+_wasm_byte_vec_delete.argtypes = [POINTER(wasm_byte_vec_t)]
+def wasm_byte_vec_delete(arg0: pointer) -> None:
+    return _wasm_byte_vec_delete(arg0)
+
+wasm_name_t = wasm_byte_vec_t
+
+class wasm_config_t(Structure):
+    pass
+
+_wasm_config_delete = dll.wasm_config_delete
+_wasm_config_delete.restype = None
+_wasm_config_delete.argtypes = [POINTER(wasm_config_t)]
+def wasm_config_delete(arg0: pointer) -> None:
+    return _wasm_config_delete(arg0)
+
+_wasm_config_new = dll.wasm_config_new
+_wasm_config_new.restype = POINTER(wasm_config_t)
+_wasm_config_new.argtypes = []
+def wasm_config_new() -> pointer:
+    return _wasm_config_new()
+
+class wasm_engine_t(Structure):
+    pass
+
+_wasm_engine_delete = dll.wasm_engine_delete
+_wasm_engine_delete.restype = None
+_wasm_engine_delete.argtypes = [POINTER(wasm_engine_t)]
+def wasm_engine_delete(arg0: pointer) -> None:
+    return _wasm_engine_delete(arg0)
+
+_wasm_engine_new = dll.wasm_engine_new
+_wasm_engine_new.restype = POINTER(wasm_engine_t)
+_wasm_engine_new.argtypes = []
+def wasm_engine_new() -> pointer:
+    return _wasm_engine_new()
+
+_wasm_engine_new_with_config = dll.wasm_engine_new_with_config
+_wasm_engine_new_with_config.restype = POINTER(wasm_engine_t)
+_wasm_engine_new_with_config.argtypes = [POINTER(wasm_config_t)]
+def wasm_engine_new_with_config(arg0: pointer) -> pointer:
+    return _wasm_engine_new_with_config(arg0)
+
+class wasm_store_t(Structure):
+    pass
+
+_wasm_store_delete = dll.wasm_store_delete
+_wasm_store_delete.restype = None
+_wasm_store_delete.argtypes = [POINTER(wasm_store_t)]
+def wasm_store_delete(arg0: pointer) -> None:
+    return _wasm_store_delete(arg0)
+
+_wasm_store_new = dll.wasm_store_new
+_wasm_store_new.restype = POINTER(wasm_store_t)
+_wasm_store_new.argtypes = [POINTER(wasm_engine_t)]
+def wasm_store_new(arg0: pointer) -> pointer:
+    return _wasm_store_new(arg0)
+
+wasm_mutability_t = c_uint8
+
+class wasm_limits_t(Structure):
+    _fields_ = [
+        ("min", c_uint32),
+        ("max", c_uint32),
+    ]
+
+class wasm_valtype_t(Structure):
+    pass
+
+_wasm_valtype_delete = dll.wasm_valtype_delete
+_wasm_valtype_delete.restype = None
+_wasm_valtype_delete.argtypes = [POINTER(wasm_valtype_t)]
+def wasm_valtype_delete(arg0: pointer) -> None:
+    return _wasm_valtype_delete(arg0)
+
+class wasm_valtype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_valtype_t))),
+    ]
+
+_wasm_valtype_vec_new_empty = dll.wasm_valtype_vec_new_empty
+_wasm_valtype_vec_new_empty.restype = None
+_wasm_valtype_vec_new_empty.argtypes = [POINTER(wasm_valtype_vec_t)]
+def wasm_valtype_vec_new_empty(out: pointer) -> None:
+    return _wasm_valtype_vec_new_empty(out)
+
+_wasm_valtype_vec_new_uninitialized = dll.wasm_valtype_vec_new_uninitialized
+_wasm_valtype_vec_new_uninitialized.restype = None
+_wasm_valtype_vec_new_uninitialized.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t]
+def wasm_valtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_valtype_vec_new_uninitialized(out, arg1)
+
+_wasm_valtype_vec_new = dll.wasm_valtype_vec_new
+_wasm_valtype_vec_new.restype = None
+_wasm_valtype_vec_new.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t, POINTER(POINTER(wasm_valtype_t))]
+def wasm_valtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_valtype_vec_new(out, arg1, arg2)
+
+_wasm_valtype_vec_copy = dll.wasm_valtype_vec_copy
+_wasm_valtype_vec_copy.restype = None
+_wasm_valtype_vec_copy.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
+def wasm_valtype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_valtype_vec_copy(out, arg1)
+
+_wasm_valtype_vec_delete = dll.wasm_valtype_vec_delete
+_wasm_valtype_vec_delete.restype = None
+_wasm_valtype_vec_delete.argtypes = [POINTER(wasm_valtype_vec_t)]
+def wasm_valtype_vec_delete(arg0: pointer) -> None:
+    return _wasm_valtype_vec_delete(arg0)
+
+_wasm_valtype_copy = dll.wasm_valtype_copy
+_wasm_valtype_copy.restype = POINTER(wasm_valtype_t)
+_wasm_valtype_copy.argtypes = [POINTER(wasm_valtype_t)]
+def wasm_valtype_copy(arg0: pointer) -> pointer:
+    return _wasm_valtype_copy(arg0)
+
+wasm_valkind_t = c_uint8
+
+_wasm_valtype_new = dll.wasm_valtype_new
+_wasm_valtype_new.restype = POINTER(wasm_valtype_t)
+_wasm_valtype_new.argtypes = [wasm_valkind_t]
+def wasm_valtype_new(arg0: wasm_valkind_t) -> pointer:
+    return _wasm_valtype_new(arg0)
+
+_wasm_valtype_kind = dll.wasm_valtype_kind
+_wasm_valtype_kind.restype = wasm_valkind_t
+_wasm_valtype_kind.argtypes = [POINTER(wasm_valtype_t)]
+def wasm_valtype_kind(arg0: pointer) -> wasm_valkind_t:
+    return _wasm_valtype_kind(arg0)
+
+class wasm_functype_t(Structure):
+    pass
+
+_wasm_functype_delete = dll.wasm_functype_delete
+_wasm_functype_delete.restype = None
+_wasm_functype_delete.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_delete(arg0: pointer) -> None:
+    return _wasm_functype_delete(arg0)
+
+class wasm_functype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_functype_t))),
+    ]
+
+_wasm_functype_vec_new_empty = dll.wasm_functype_vec_new_empty
+_wasm_functype_vec_new_empty.restype = None
+_wasm_functype_vec_new_empty.argtypes = [POINTER(wasm_functype_vec_t)]
+def wasm_functype_vec_new_empty(out: pointer) -> None:
+    return _wasm_functype_vec_new_empty(out)
+
+_wasm_functype_vec_new_uninitialized = dll.wasm_functype_vec_new_uninitialized
+_wasm_functype_vec_new_uninitialized.restype = None
+_wasm_functype_vec_new_uninitialized.argtypes = [POINTER(wasm_functype_vec_t), c_size_t]
+def wasm_functype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_functype_vec_new_uninitialized(out, arg1)
+
+_wasm_functype_vec_new = dll.wasm_functype_vec_new
+_wasm_functype_vec_new.restype = None
+_wasm_functype_vec_new.argtypes = [POINTER(wasm_functype_vec_t), c_size_t, POINTER(POINTER(wasm_functype_t))]
+def wasm_functype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_functype_vec_new(out, arg1, arg2)
+
+_wasm_functype_vec_copy = dll.wasm_functype_vec_copy
+_wasm_functype_vec_copy.restype = None
+_wasm_functype_vec_copy.argtypes = [POINTER(wasm_functype_vec_t), POINTER(wasm_functype_vec_t)]
+def wasm_functype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_functype_vec_copy(out, arg1)
+
+_wasm_functype_vec_delete = dll.wasm_functype_vec_delete
+_wasm_functype_vec_delete.restype = None
+_wasm_functype_vec_delete.argtypes = [POINTER(wasm_functype_vec_t)]
+def wasm_functype_vec_delete(arg0: pointer) -> None:
+    return _wasm_functype_vec_delete(arg0)
+
+_wasm_functype_copy = dll.wasm_functype_copy
+_wasm_functype_copy.restype = POINTER(wasm_functype_t)
+_wasm_functype_copy.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_copy(arg0: pointer) -> pointer:
+    return _wasm_functype_copy(arg0)
+
+_wasm_functype_new = dll.wasm_functype_new
+_wasm_functype_new.restype = POINTER(wasm_functype_t)
+_wasm_functype_new.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
+def wasm_functype_new(params: pointer, results: pointer) -> pointer:
+    return _wasm_functype_new(params, results)
+
+_wasm_functype_params = dll.wasm_functype_params
+_wasm_functype_params.restype = POINTER(wasm_valtype_vec_t)
+_wasm_functype_params.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_params(arg0: pointer) -> pointer:
+    return _wasm_functype_params(arg0)
+
+_wasm_functype_results = dll.wasm_functype_results
+_wasm_functype_results.restype = POINTER(wasm_valtype_vec_t)
+_wasm_functype_results.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_results(arg0: pointer) -> pointer:
+    return _wasm_functype_results(arg0)
+
+class wasm_globaltype_t(Structure):
+    pass
+
+_wasm_globaltype_delete = dll.wasm_globaltype_delete
+_wasm_globaltype_delete.restype = None
+_wasm_globaltype_delete.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_delete(arg0: pointer) -> None:
+    return _wasm_globaltype_delete(arg0)
+
+class wasm_globaltype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_globaltype_t))),
+    ]
+
+_wasm_globaltype_vec_new_empty = dll.wasm_globaltype_vec_new_empty
+_wasm_globaltype_vec_new_empty.restype = None
+_wasm_globaltype_vec_new_empty.argtypes = [POINTER(wasm_globaltype_vec_t)]
+def wasm_globaltype_vec_new_empty(out: pointer) -> None:
+    return _wasm_globaltype_vec_new_empty(out)
+
+_wasm_globaltype_vec_new_uninitialized = dll.wasm_globaltype_vec_new_uninitialized
+_wasm_globaltype_vec_new_uninitialized.restype = None
+_wasm_globaltype_vec_new_uninitialized.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t]
+def wasm_globaltype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_globaltype_vec_new_uninitialized(out, arg1)
+
+_wasm_globaltype_vec_new = dll.wasm_globaltype_vec_new
+_wasm_globaltype_vec_new.restype = None
+_wasm_globaltype_vec_new.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t, POINTER(POINTER(wasm_globaltype_t))]
+def wasm_globaltype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_globaltype_vec_new(out, arg1, arg2)
+
+_wasm_globaltype_vec_copy = dll.wasm_globaltype_vec_copy
+_wasm_globaltype_vec_copy.restype = None
+_wasm_globaltype_vec_copy.argtypes = [POINTER(wasm_globaltype_vec_t), POINTER(wasm_globaltype_vec_t)]
+def wasm_globaltype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_globaltype_vec_copy(out, arg1)
+
+_wasm_globaltype_vec_delete = dll.wasm_globaltype_vec_delete
+_wasm_globaltype_vec_delete.restype = None
+_wasm_globaltype_vec_delete.argtypes = [POINTER(wasm_globaltype_vec_t)]
+def wasm_globaltype_vec_delete(arg0: pointer) -> None:
+    return _wasm_globaltype_vec_delete(arg0)
+
+_wasm_globaltype_copy = dll.wasm_globaltype_copy
+_wasm_globaltype_copy.restype = POINTER(wasm_globaltype_t)
+_wasm_globaltype_copy.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_copy(arg0: pointer) -> pointer:
+    return _wasm_globaltype_copy(arg0)
+
+_wasm_globaltype_new = dll.wasm_globaltype_new
+_wasm_globaltype_new.restype = POINTER(wasm_globaltype_t)
+_wasm_globaltype_new.argtypes = [POINTER(wasm_valtype_t), wasm_mutability_t]
+def wasm_globaltype_new(arg0: pointer, arg1: wasm_mutability_t) -> pointer:
+    return _wasm_globaltype_new(arg0, arg1)
+
+_wasm_globaltype_content = dll.wasm_globaltype_content
+_wasm_globaltype_content.restype = POINTER(wasm_valtype_t)
+_wasm_globaltype_content.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_content(arg0: pointer) -> pointer:
+    return _wasm_globaltype_content(arg0)
+
+_wasm_globaltype_mutability = dll.wasm_globaltype_mutability
+_wasm_globaltype_mutability.restype = wasm_mutability_t
+_wasm_globaltype_mutability.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_mutability(arg0: pointer) -> wasm_mutability_t:
+    return _wasm_globaltype_mutability(arg0)
+
+class wasm_tabletype_t(Structure):
+    pass
+
+_wasm_tabletype_delete = dll.wasm_tabletype_delete
+_wasm_tabletype_delete.restype = None
+_wasm_tabletype_delete.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_delete(arg0: pointer) -> None:
+    return _wasm_tabletype_delete(arg0)
+
+class wasm_tabletype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_tabletype_t))),
+    ]
+
+_wasm_tabletype_vec_new_empty = dll.wasm_tabletype_vec_new_empty
+_wasm_tabletype_vec_new_empty.restype = None
+_wasm_tabletype_vec_new_empty.argtypes = [POINTER(wasm_tabletype_vec_t)]
+def wasm_tabletype_vec_new_empty(out: pointer) -> None:
+    return _wasm_tabletype_vec_new_empty(out)
+
+_wasm_tabletype_vec_new_uninitialized = dll.wasm_tabletype_vec_new_uninitialized
+_wasm_tabletype_vec_new_uninitialized.restype = None
+_wasm_tabletype_vec_new_uninitialized.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t]
+def wasm_tabletype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_tabletype_vec_new_uninitialized(out, arg1)
+
+_wasm_tabletype_vec_new = dll.wasm_tabletype_vec_new
+_wasm_tabletype_vec_new.restype = None
+_wasm_tabletype_vec_new.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t, POINTER(POINTER(wasm_tabletype_t))]
+def wasm_tabletype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_tabletype_vec_new(out, arg1, arg2)
+
+_wasm_tabletype_vec_copy = dll.wasm_tabletype_vec_copy
+_wasm_tabletype_vec_copy.restype = None
+_wasm_tabletype_vec_copy.argtypes = [POINTER(wasm_tabletype_vec_t), POINTER(wasm_tabletype_vec_t)]
+def wasm_tabletype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_tabletype_vec_copy(out, arg1)
+
+_wasm_tabletype_vec_delete = dll.wasm_tabletype_vec_delete
+_wasm_tabletype_vec_delete.restype = None
+_wasm_tabletype_vec_delete.argtypes = [POINTER(wasm_tabletype_vec_t)]
+def wasm_tabletype_vec_delete(arg0: pointer) -> None:
+    return _wasm_tabletype_vec_delete(arg0)
+
+_wasm_tabletype_copy = dll.wasm_tabletype_copy
+_wasm_tabletype_copy.restype = POINTER(wasm_tabletype_t)
+_wasm_tabletype_copy.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_copy(arg0: pointer) -> pointer:
+    return _wasm_tabletype_copy(arg0)
+
+_wasm_tabletype_new = dll.wasm_tabletype_new
+_wasm_tabletype_new.restype = POINTER(wasm_tabletype_t)
+_wasm_tabletype_new.argtypes = [POINTER(wasm_valtype_t), POINTER(wasm_limits_t)]
+def wasm_tabletype_new(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_tabletype_new(arg0, arg1)
+
+_wasm_tabletype_element = dll.wasm_tabletype_element
+_wasm_tabletype_element.restype = POINTER(wasm_valtype_t)
+_wasm_tabletype_element.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_element(arg0: pointer) -> pointer:
+    return _wasm_tabletype_element(arg0)
+
+_wasm_tabletype_limits = dll.wasm_tabletype_limits
+_wasm_tabletype_limits.restype = POINTER(wasm_limits_t)
+_wasm_tabletype_limits.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_limits(arg0: pointer) -> pointer:
+    return _wasm_tabletype_limits(arg0)
+
+class wasm_memorytype_t(Structure):
+    pass
+
+_wasm_memorytype_delete = dll.wasm_memorytype_delete
+_wasm_memorytype_delete.restype = None
+_wasm_memorytype_delete.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_delete(arg0: pointer) -> None:
+    return _wasm_memorytype_delete(arg0)
+
+class wasm_memorytype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_memorytype_t))),
+    ]
+
+_wasm_memorytype_vec_new_empty = dll.wasm_memorytype_vec_new_empty
+_wasm_memorytype_vec_new_empty.restype = None
+_wasm_memorytype_vec_new_empty.argtypes = [POINTER(wasm_memorytype_vec_t)]
+def wasm_memorytype_vec_new_empty(out: pointer) -> None:
+    return _wasm_memorytype_vec_new_empty(out)
+
+_wasm_memorytype_vec_new_uninitialized = dll.wasm_memorytype_vec_new_uninitialized
+_wasm_memorytype_vec_new_uninitialized.restype = None
+_wasm_memorytype_vec_new_uninitialized.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t]
+def wasm_memorytype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_memorytype_vec_new_uninitialized(out, arg1)
+
+_wasm_memorytype_vec_new = dll.wasm_memorytype_vec_new
+_wasm_memorytype_vec_new.restype = None
+_wasm_memorytype_vec_new.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t, POINTER(POINTER(wasm_memorytype_t))]
+def wasm_memorytype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_memorytype_vec_new(out, arg1, arg2)
+
+_wasm_memorytype_vec_copy = dll.wasm_memorytype_vec_copy
+_wasm_memorytype_vec_copy.restype = None
+_wasm_memorytype_vec_copy.argtypes = [POINTER(wasm_memorytype_vec_t), POINTER(wasm_memorytype_vec_t)]
+def wasm_memorytype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_memorytype_vec_copy(out, arg1)
+
+_wasm_memorytype_vec_delete = dll.wasm_memorytype_vec_delete
+_wasm_memorytype_vec_delete.restype = None
+_wasm_memorytype_vec_delete.argtypes = [POINTER(wasm_memorytype_vec_t)]
+def wasm_memorytype_vec_delete(arg0: pointer) -> None:
+    return _wasm_memorytype_vec_delete(arg0)
+
+_wasm_memorytype_copy = dll.wasm_memorytype_copy
+_wasm_memorytype_copy.restype = POINTER(wasm_memorytype_t)
+_wasm_memorytype_copy.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_copy(arg0: pointer) -> pointer:
+    return _wasm_memorytype_copy(arg0)
+
+_wasm_memorytype_new = dll.wasm_memorytype_new
+_wasm_memorytype_new.restype = POINTER(wasm_memorytype_t)
+_wasm_memorytype_new.argtypes = [POINTER(wasm_limits_t)]
+def wasm_memorytype_new(arg0: pointer) -> pointer:
+    return _wasm_memorytype_new(arg0)
+
+_wasm_memorytype_limits = dll.wasm_memorytype_limits
+_wasm_memorytype_limits.restype = POINTER(wasm_limits_t)
+_wasm_memorytype_limits.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_limits(arg0: pointer) -> pointer:
+    return _wasm_memorytype_limits(arg0)
+
+class wasm_externtype_t(Structure):
+    pass
+
+_wasm_externtype_delete = dll.wasm_externtype_delete
+_wasm_externtype_delete.restype = None
+_wasm_externtype_delete.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_delete(arg0: pointer) -> None:
+    return _wasm_externtype_delete(arg0)
+
+class wasm_externtype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_externtype_t))),
+    ]
+
+_wasm_externtype_vec_new_empty = dll.wasm_externtype_vec_new_empty
+_wasm_externtype_vec_new_empty.restype = None
+_wasm_externtype_vec_new_empty.argtypes = [POINTER(wasm_externtype_vec_t)]
+def wasm_externtype_vec_new_empty(out: pointer) -> None:
+    return _wasm_externtype_vec_new_empty(out)
+
+_wasm_externtype_vec_new_uninitialized = dll.wasm_externtype_vec_new_uninitialized
+_wasm_externtype_vec_new_uninitialized.restype = None
+_wasm_externtype_vec_new_uninitialized.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t]
+def wasm_externtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_externtype_vec_new_uninitialized(out, arg1)
+
+_wasm_externtype_vec_new = dll.wasm_externtype_vec_new
+_wasm_externtype_vec_new.restype = None
+_wasm_externtype_vec_new.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t, POINTER(POINTER(wasm_externtype_t))]
+def wasm_externtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_externtype_vec_new(out, arg1, arg2)
+
+_wasm_externtype_vec_copy = dll.wasm_externtype_vec_copy
+_wasm_externtype_vec_copy.restype = None
+_wasm_externtype_vec_copy.argtypes = [POINTER(wasm_externtype_vec_t), POINTER(wasm_externtype_vec_t)]
+def wasm_externtype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_externtype_vec_copy(out, arg1)
+
+_wasm_externtype_vec_delete = dll.wasm_externtype_vec_delete
+_wasm_externtype_vec_delete.restype = None
+_wasm_externtype_vec_delete.argtypes = [POINTER(wasm_externtype_vec_t)]
+def wasm_externtype_vec_delete(arg0: pointer) -> None:
+    return _wasm_externtype_vec_delete(arg0)
+
+_wasm_externtype_copy = dll.wasm_externtype_copy
+_wasm_externtype_copy.restype = POINTER(wasm_externtype_t)
+_wasm_externtype_copy.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_copy(arg0: pointer) -> pointer:
+    return _wasm_externtype_copy(arg0)
+
+wasm_externkind_t = c_uint8
+
+_wasm_externtype_kind = dll.wasm_externtype_kind
+_wasm_externtype_kind.restype = wasm_externkind_t
+_wasm_externtype_kind.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_kind(arg0: pointer) -> wasm_externkind_t:
+    return _wasm_externtype_kind(arg0)
+
+_wasm_functype_as_externtype = dll.wasm_functype_as_externtype
+_wasm_functype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_functype_as_externtype.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_functype_as_externtype(arg0)
+
+_wasm_globaltype_as_externtype = dll.wasm_globaltype_as_externtype
+_wasm_globaltype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_globaltype_as_externtype.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_globaltype_as_externtype(arg0)
+
+_wasm_tabletype_as_externtype = dll.wasm_tabletype_as_externtype
+_wasm_tabletype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_tabletype_as_externtype.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_tabletype_as_externtype(arg0)
+
+_wasm_memorytype_as_externtype = dll.wasm_memorytype_as_externtype
+_wasm_memorytype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasm_memorytype_as_externtype.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_as_externtype(arg0: pointer) -> pointer:
+    return _wasm_memorytype_as_externtype(arg0)
+
+_wasm_externtype_as_functype = dll.wasm_externtype_as_functype
+_wasm_externtype_as_functype.restype = POINTER(wasm_functype_t)
+_wasm_externtype_as_functype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_functype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_functype(arg0)
+
+_wasm_externtype_as_globaltype = dll.wasm_externtype_as_globaltype
+_wasm_externtype_as_globaltype.restype = POINTER(wasm_globaltype_t)
+_wasm_externtype_as_globaltype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_globaltype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_globaltype(arg0)
+
+_wasm_externtype_as_tabletype = dll.wasm_externtype_as_tabletype
+_wasm_externtype_as_tabletype.restype = POINTER(wasm_tabletype_t)
+_wasm_externtype_as_tabletype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_tabletype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_tabletype(arg0)
+
+_wasm_externtype_as_memorytype = dll.wasm_externtype_as_memorytype
+_wasm_externtype_as_memorytype.restype = POINTER(wasm_memorytype_t)
+_wasm_externtype_as_memorytype.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_memorytype(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_memorytype(arg0)
+
+_wasm_functype_as_externtype_const = dll.wasm_functype_as_externtype_const
+_wasm_functype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_functype_as_externtype_const.argtypes = [POINTER(wasm_functype_t)]
+def wasm_functype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_functype_as_externtype_const(arg0)
+
+_wasm_globaltype_as_externtype_const = dll.wasm_globaltype_as_externtype_const
+_wasm_globaltype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_globaltype_as_externtype_const.argtypes = [POINTER(wasm_globaltype_t)]
+def wasm_globaltype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_globaltype_as_externtype_const(arg0)
+
+_wasm_tabletype_as_externtype_const = dll.wasm_tabletype_as_externtype_const
+_wasm_tabletype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_tabletype_as_externtype_const.argtypes = [POINTER(wasm_tabletype_t)]
+def wasm_tabletype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_tabletype_as_externtype_const(arg0)
+
+_wasm_memorytype_as_externtype_const = dll.wasm_memorytype_as_externtype_const
+_wasm_memorytype_as_externtype_const.restype = POINTER(wasm_externtype_t)
+_wasm_memorytype_as_externtype_const.argtypes = [POINTER(wasm_memorytype_t)]
+def wasm_memorytype_as_externtype_const(arg0: pointer) -> pointer:
+    return _wasm_memorytype_as_externtype_const(arg0)
+
+_wasm_externtype_as_functype_const = dll.wasm_externtype_as_functype_const
+_wasm_externtype_as_functype_const.restype = POINTER(wasm_functype_t)
+_wasm_externtype_as_functype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_functype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_functype_const(arg0)
+
+_wasm_externtype_as_globaltype_const = dll.wasm_externtype_as_globaltype_const
+_wasm_externtype_as_globaltype_const.restype = POINTER(wasm_globaltype_t)
+_wasm_externtype_as_globaltype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_globaltype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_globaltype_const(arg0)
+
+_wasm_externtype_as_tabletype_const = dll.wasm_externtype_as_tabletype_const
+_wasm_externtype_as_tabletype_const.restype = POINTER(wasm_tabletype_t)
+_wasm_externtype_as_tabletype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_tabletype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_tabletype_const(arg0)
+
+_wasm_externtype_as_memorytype_const = dll.wasm_externtype_as_memorytype_const
+_wasm_externtype_as_memorytype_const.restype = POINTER(wasm_memorytype_t)
+_wasm_externtype_as_memorytype_const.argtypes = [POINTER(wasm_externtype_t)]
+def wasm_externtype_as_memorytype_const(arg0: pointer) -> pointer:
+    return _wasm_externtype_as_memorytype_const(arg0)
+
+class wasm_importtype_t(Structure):
+    pass
+
+_wasm_importtype_delete = dll.wasm_importtype_delete
+_wasm_importtype_delete.restype = None
+_wasm_importtype_delete.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_delete(arg0: pointer) -> None:
+    return _wasm_importtype_delete(arg0)
+
+class wasm_importtype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_importtype_t))),
+    ]
+
+_wasm_importtype_vec_new_empty = dll.wasm_importtype_vec_new_empty
+_wasm_importtype_vec_new_empty.restype = None
+_wasm_importtype_vec_new_empty.argtypes = [POINTER(wasm_importtype_vec_t)]
+def wasm_importtype_vec_new_empty(out: pointer) -> None:
+    return _wasm_importtype_vec_new_empty(out)
+
+_wasm_importtype_vec_new_uninitialized = dll.wasm_importtype_vec_new_uninitialized
+_wasm_importtype_vec_new_uninitialized.restype = None
+_wasm_importtype_vec_new_uninitialized.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t]
+def wasm_importtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_importtype_vec_new_uninitialized(out, arg1)
+
+_wasm_importtype_vec_new = dll.wasm_importtype_vec_new
+_wasm_importtype_vec_new.restype = None
+_wasm_importtype_vec_new.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t, POINTER(POINTER(wasm_importtype_t))]
+def wasm_importtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_importtype_vec_new(out, arg1, arg2)
+
+_wasm_importtype_vec_copy = dll.wasm_importtype_vec_copy
+_wasm_importtype_vec_copy.restype = None
+_wasm_importtype_vec_copy.argtypes = [POINTER(wasm_importtype_vec_t), POINTER(wasm_importtype_vec_t)]
+def wasm_importtype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_importtype_vec_copy(out, arg1)
+
+_wasm_importtype_vec_delete = dll.wasm_importtype_vec_delete
+_wasm_importtype_vec_delete.restype = None
+_wasm_importtype_vec_delete.argtypes = [POINTER(wasm_importtype_vec_t)]
+def wasm_importtype_vec_delete(arg0: pointer) -> None:
+    return _wasm_importtype_vec_delete(arg0)
+
+_wasm_importtype_copy = dll.wasm_importtype_copy
+_wasm_importtype_copy.restype = POINTER(wasm_importtype_t)
+_wasm_importtype_copy.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_copy(arg0: pointer) -> pointer:
+    return _wasm_importtype_copy(arg0)
+
+_wasm_importtype_new = dll.wasm_importtype_new
+_wasm_importtype_new.restype = POINTER(wasm_importtype_t)
+_wasm_importtype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
+def wasm_importtype_new(module: pointer, name: pointer, arg2: pointer) -> pointer:
+    return _wasm_importtype_new(module, name, arg2)
+
+_wasm_importtype_module = dll.wasm_importtype_module
+_wasm_importtype_module.restype = POINTER(wasm_name_t)
+_wasm_importtype_module.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_module(arg0: pointer) -> pointer:
+    return _wasm_importtype_module(arg0)
+
+_wasm_importtype_name = dll.wasm_importtype_name
+_wasm_importtype_name.restype = POINTER(wasm_name_t)
+_wasm_importtype_name.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_name(arg0: pointer) -> pointer:
+    return _wasm_importtype_name(arg0)
+
+_wasm_importtype_type = dll.wasm_importtype_type
+_wasm_importtype_type.restype = POINTER(wasm_externtype_t)
+_wasm_importtype_type.argtypes = [POINTER(wasm_importtype_t)]
+def wasm_importtype_type(arg0: pointer) -> pointer:
+    return _wasm_importtype_type(arg0)
+
+class wasm_exporttype_t(Structure):
+    pass
+
+_wasm_exporttype_delete = dll.wasm_exporttype_delete
+_wasm_exporttype_delete.restype = None
+_wasm_exporttype_delete.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_delete(arg0: pointer) -> None:
+    return _wasm_exporttype_delete(arg0)
+
+class wasm_exporttype_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_exporttype_t))),
+    ]
+
+_wasm_exporttype_vec_new_empty = dll.wasm_exporttype_vec_new_empty
+_wasm_exporttype_vec_new_empty.restype = None
+_wasm_exporttype_vec_new_empty.argtypes = [POINTER(wasm_exporttype_vec_t)]
+def wasm_exporttype_vec_new_empty(out: pointer) -> None:
+    return _wasm_exporttype_vec_new_empty(out)
+
+_wasm_exporttype_vec_new_uninitialized = dll.wasm_exporttype_vec_new_uninitialized
+_wasm_exporttype_vec_new_uninitialized.restype = None
+_wasm_exporttype_vec_new_uninitialized.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t]
+def wasm_exporttype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_exporttype_vec_new_uninitialized(out, arg1)
+
+_wasm_exporttype_vec_new = dll.wasm_exporttype_vec_new
+_wasm_exporttype_vec_new.restype = None
+_wasm_exporttype_vec_new.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t, POINTER(POINTER(wasm_exporttype_t))]
+def wasm_exporttype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_exporttype_vec_new(out, arg1, arg2)
+
+_wasm_exporttype_vec_copy = dll.wasm_exporttype_vec_copy
+_wasm_exporttype_vec_copy.restype = None
+_wasm_exporttype_vec_copy.argtypes = [POINTER(wasm_exporttype_vec_t), POINTER(wasm_exporttype_vec_t)]
+def wasm_exporttype_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_exporttype_vec_copy(out, arg1)
+
+_wasm_exporttype_vec_delete = dll.wasm_exporttype_vec_delete
+_wasm_exporttype_vec_delete.restype = None
+_wasm_exporttype_vec_delete.argtypes = [POINTER(wasm_exporttype_vec_t)]
+def wasm_exporttype_vec_delete(arg0: pointer) -> None:
+    return _wasm_exporttype_vec_delete(arg0)
+
+_wasm_exporttype_copy = dll.wasm_exporttype_copy
+_wasm_exporttype_copy.restype = POINTER(wasm_exporttype_t)
+_wasm_exporttype_copy.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_copy(arg0: pointer) -> pointer:
+    return _wasm_exporttype_copy(arg0)
+
+_wasm_exporttype_new = dll.wasm_exporttype_new
+_wasm_exporttype_new.restype = POINTER(wasm_exporttype_t)
+_wasm_exporttype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
+def wasm_exporttype_new(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_exporttype_new(arg0, arg1)
+
+_wasm_exporttype_name = dll.wasm_exporttype_name
+_wasm_exporttype_name.restype = POINTER(wasm_name_t)
+_wasm_exporttype_name.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_name(arg0: pointer) -> pointer:
+    return _wasm_exporttype_name(arg0)
+
+_wasm_exporttype_type = dll.wasm_exporttype_type
+_wasm_exporttype_type.restype = POINTER(wasm_externtype_t)
+_wasm_exporttype_type.argtypes = [POINTER(wasm_exporttype_t)]
+def wasm_exporttype_type(arg0: pointer) -> pointer:
+    return _wasm_exporttype_type(arg0)
+
+class wasm_ref_t(Structure):
+    pass
+
+_wasm_val_delete = dll.wasm_val_delete
+_wasm_val_delete.restype = None
+_wasm_val_delete.argtypes = [POINTER(wasm_val_t)]
+def wasm_val_delete(v: pointer) -> None:
+    return _wasm_val_delete(v)
+
+_wasm_val_copy = dll.wasm_val_copy
+_wasm_val_copy.restype = None
+_wasm_val_copy.argtypes = [POINTER(wasm_val_t), POINTER(wasm_val_t)]
+def wasm_val_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_val_copy(out, arg1)
+
+class wasm_val_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(wasm_val_t)),
+    ]
+
+_wasm_val_vec_new_empty = dll.wasm_val_vec_new_empty
+_wasm_val_vec_new_empty.restype = None
+_wasm_val_vec_new_empty.argtypes = [POINTER(wasm_val_vec_t)]
+def wasm_val_vec_new_empty(out: pointer) -> None:
+    return _wasm_val_vec_new_empty(out)
+
+_wasm_val_vec_new_uninitialized = dll.wasm_val_vec_new_uninitialized
+_wasm_val_vec_new_uninitialized.restype = None
+_wasm_val_vec_new_uninitialized.argtypes = [POINTER(wasm_val_vec_t), c_size_t]
+def wasm_val_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_val_vec_new_uninitialized(out, arg1)
+
+_wasm_val_vec_new = dll.wasm_val_vec_new
+_wasm_val_vec_new.restype = None
+_wasm_val_vec_new.argtypes = [POINTER(wasm_val_vec_t), c_size_t, POINTER(wasm_val_t)]
+def wasm_val_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_val_vec_new(out, arg1, arg2)
+
+_wasm_val_vec_copy = dll.wasm_val_vec_copy
+_wasm_val_vec_copy.restype = None
+_wasm_val_vec_copy.argtypes = [POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t)]
+def wasm_val_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_val_vec_copy(out, arg1)
+
+_wasm_val_vec_delete = dll.wasm_val_vec_delete
+_wasm_val_vec_delete.restype = None
+_wasm_val_vec_delete.argtypes = [POINTER(wasm_val_vec_t)]
+def wasm_val_vec_delete(arg0: pointer) -> None:
+    return _wasm_val_vec_delete(arg0)
+
+class wasm_ref_t(Structure):
+    pass
+
+_wasm_ref_delete = dll.wasm_ref_delete
+_wasm_ref_delete.restype = None
+_wasm_ref_delete.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_delete(arg0: pointer) -> None:
+    return _wasm_ref_delete(arg0)
+
+_wasm_ref_copy = dll.wasm_ref_copy
+_wasm_ref_copy.restype = POINTER(wasm_ref_t)
+_wasm_ref_copy.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_copy(arg0: pointer) -> pointer:
+    return _wasm_ref_copy(arg0)
+
+_wasm_ref_same = dll.wasm_ref_same
+_wasm_ref_same.restype = c_bool
+_wasm_ref_same.argtypes = [POINTER(wasm_ref_t), POINTER(wasm_ref_t)]
+def wasm_ref_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_ref_same(arg0, arg1)
+
+_wasm_ref_get_host_info = dll.wasm_ref_get_host_info
+_wasm_ref_get_host_info.restype = c_void_p
+_wasm_ref_get_host_info.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_ref_get_host_info(arg0)
+
+_wasm_ref_set_host_info = dll.wasm_ref_set_host_info
+_wasm_ref_set_host_info.restype = None
+_wasm_ref_set_host_info.argtypes = [POINTER(wasm_ref_t), c_void_p]
+def wasm_ref_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_ref_set_host_info(arg0, arg1)
+
+_wasm_ref_set_host_info_with_finalizer = dll.wasm_ref_set_host_info_with_finalizer
+_wasm_ref_set_host_info_with_finalizer.restype = None
+_wasm_ref_set_host_info_with_finalizer.argtypes = [POINTER(wasm_ref_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_ref_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_ref_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+class wasm_frame_t(Structure):
+    pass
+
+_wasm_frame_delete = dll.wasm_frame_delete
+_wasm_frame_delete.restype = None
+_wasm_frame_delete.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_delete(arg0: pointer) -> None:
+    return _wasm_frame_delete(arg0)
+
+class wasm_frame_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_frame_t))),
+    ]
+
+_wasm_frame_vec_new_empty = dll.wasm_frame_vec_new_empty
+_wasm_frame_vec_new_empty.restype = None
+_wasm_frame_vec_new_empty.argtypes = [POINTER(wasm_frame_vec_t)]
+def wasm_frame_vec_new_empty(out: pointer) -> None:
+    return _wasm_frame_vec_new_empty(out)
+
+_wasm_frame_vec_new_uninitialized = dll.wasm_frame_vec_new_uninitialized
+_wasm_frame_vec_new_uninitialized.restype = None
+_wasm_frame_vec_new_uninitialized.argtypes = [POINTER(wasm_frame_vec_t), c_size_t]
+def wasm_frame_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_frame_vec_new_uninitialized(out, arg1)
+
+_wasm_frame_vec_new = dll.wasm_frame_vec_new
+_wasm_frame_vec_new.restype = None
+_wasm_frame_vec_new.argtypes = [POINTER(wasm_frame_vec_t), c_size_t, POINTER(POINTER(wasm_frame_t))]
+def wasm_frame_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_frame_vec_new(out, arg1, arg2)
+
+_wasm_frame_vec_copy = dll.wasm_frame_vec_copy
+_wasm_frame_vec_copy.restype = None
+_wasm_frame_vec_copy.argtypes = [POINTER(wasm_frame_vec_t), POINTER(wasm_frame_vec_t)]
+def wasm_frame_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_frame_vec_copy(out, arg1)
+
+_wasm_frame_vec_delete = dll.wasm_frame_vec_delete
+_wasm_frame_vec_delete.restype = None
+_wasm_frame_vec_delete.argtypes = [POINTER(wasm_frame_vec_t)]
+def wasm_frame_vec_delete(arg0: pointer) -> None:
+    return _wasm_frame_vec_delete(arg0)
+
+_wasm_frame_func_index = dll.wasm_frame_func_index
+_wasm_frame_func_index.restype = c_uint32
+_wasm_frame_func_index.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_func_index(arg0: pointer) -> c_uint32:
+    return _wasm_frame_func_index(arg0)
+
+_wasm_frame_func_offset = dll.wasm_frame_func_offset
+_wasm_frame_func_offset.restype = c_size_t
+_wasm_frame_func_offset.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_func_offset(arg0: pointer) -> c_size_t:
+    return _wasm_frame_func_offset(arg0)
+
+_wasm_frame_module_offset = dll.wasm_frame_module_offset
+_wasm_frame_module_offset.restype = c_size_t
+_wasm_frame_module_offset.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_module_offset(arg0: pointer) -> c_size_t:
+    return _wasm_frame_module_offset(arg0)
+
+wasm_message_t = wasm_name_t
+
+class wasm_trap_t(Structure):
+    pass
+
+_wasm_trap_delete = dll.wasm_trap_delete
+_wasm_trap_delete.restype = None
+_wasm_trap_delete.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_delete(arg0: pointer) -> None:
+    return _wasm_trap_delete(arg0)
+
+_wasm_trap_copy = dll.wasm_trap_copy
+_wasm_trap_copy.restype = POINTER(wasm_trap_t)
+_wasm_trap_copy.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_copy(arg0: pointer) -> pointer:
+    return _wasm_trap_copy(arg0)
+
+_wasm_trap_same = dll.wasm_trap_same
+_wasm_trap_same.restype = c_bool
+_wasm_trap_same.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_trap_t)]
+def wasm_trap_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_trap_same(arg0, arg1)
+
+_wasm_trap_get_host_info = dll.wasm_trap_get_host_info
+_wasm_trap_get_host_info.restype = c_void_p
+_wasm_trap_get_host_info.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_trap_get_host_info(arg0)
+
+_wasm_trap_set_host_info = dll.wasm_trap_set_host_info
+_wasm_trap_set_host_info.restype = None
+_wasm_trap_set_host_info.argtypes = [POINTER(wasm_trap_t), c_void_p]
+def wasm_trap_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_trap_set_host_info(arg0, arg1)
+
+_wasm_trap_set_host_info_with_finalizer = dll.wasm_trap_set_host_info_with_finalizer
+_wasm_trap_set_host_info_with_finalizer.restype = None
+_wasm_trap_set_host_info_with_finalizer.argtypes = [POINTER(wasm_trap_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_trap_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_trap_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_trap_as_ref = dll.wasm_trap_as_ref
+_wasm_trap_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_trap_as_ref.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_as_ref(arg0: pointer) -> pointer:
+    return _wasm_trap_as_ref(arg0)
+
+_wasm_trap_as_ref_const = dll.wasm_trap_as_ref_const
+_wasm_trap_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_trap_as_ref_const.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_trap_as_ref_const(arg0)
+
+_wasm_trap_new = dll.wasm_trap_new
+_wasm_trap_new.restype = POINTER(wasm_trap_t)
+_wasm_trap_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_message_t)]
+def wasm_trap_new(store: pointer, arg1: pointer) -> pointer:
+    return _wasm_trap_new(store, arg1)
+
+_wasm_trap_message = dll.wasm_trap_message
+_wasm_trap_message.restype = None
+_wasm_trap_message.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_message_t)]
+def wasm_trap_message(arg0: pointer, out: pointer) -> None:
+    return _wasm_trap_message(arg0, out)
+
+_wasm_trap_origin = dll.wasm_trap_origin
+_wasm_trap_origin.restype = POINTER(wasm_frame_t)
+_wasm_trap_origin.argtypes = [POINTER(wasm_trap_t)]
+def wasm_trap_origin(arg0: pointer) -> pointer:
+    return _wasm_trap_origin(arg0)
+
+_wasm_trap_trace = dll.wasm_trap_trace
+_wasm_trap_trace.restype = None
+_wasm_trap_trace.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_frame_vec_t)]
+def wasm_trap_trace(arg0: pointer, out: pointer) -> None:
+    return _wasm_trap_trace(arg0, out)
+
+class wasm_foreign_t(Structure):
+    pass
+
+class wasm_module_t(Structure):
+    pass
+
+_wasm_module_delete = dll.wasm_module_delete
+_wasm_module_delete.restype = None
+_wasm_module_delete.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_delete(arg0: pointer) -> None:
+    return _wasm_module_delete(arg0)
+
+_wasm_module_copy = dll.wasm_module_copy
+_wasm_module_copy.restype = POINTER(wasm_module_t)
+_wasm_module_copy.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_copy(arg0: pointer) -> pointer:
+    return _wasm_module_copy(arg0)
+
+_wasm_module_same = dll.wasm_module_same
+_wasm_module_same.restype = c_bool
+_wasm_module_same.argtypes = [POINTER(wasm_module_t), POINTER(wasm_module_t)]
+def wasm_module_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_module_same(arg0, arg1)
+
+_wasm_module_get_host_info = dll.wasm_module_get_host_info
+_wasm_module_get_host_info.restype = c_void_p
+_wasm_module_get_host_info.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_module_get_host_info(arg0)
+
+_wasm_module_set_host_info = dll.wasm_module_set_host_info
+_wasm_module_set_host_info.restype = None
+_wasm_module_set_host_info.argtypes = [POINTER(wasm_module_t), c_void_p]
+def wasm_module_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_module_set_host_info(arg0, arg1)
+
+_wasm_module_set_host_info_with_finalizer = dll.wasm_module_set_host_info_with_finalizer
+_wasm_module_set_host_info_with_finalizer.restype = None
+_wasm_module_set_host_info_with_finalizer.argtypes = [POINTER(wasm_module_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_module_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_module_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_module_as_ref = dll.wasm_module_as_ref
+_wasm_module_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_module_as_ref.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_as_ref(arg0: pointer) -> pointer:
+    return _wasm_module_as_ref(arg0)
+
+_wasm_module_as_ref_const = dll.wasm_module_as_ref_const
+_wasm_module_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_module_as_ref_const.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_module_as_ref_const(arg0)
+
+class wasm_shared_module_t(Structure):
+    pass
+
+_wasm_shared_module_delete = dll.wasm_shared_module_delete
+_wasm_shared_module_delete.restype = None
+_wasm_shared_module_delete.argtypes = [POINTER(wasm_shared_module_t)]
+def wasm_shared_module_delete(arg0: pointer) -> None:
+    return _wasm_shared_module_delete(arg0)
+
+_wasm_module_share = dll.wasm_module_share
+_wasm_module_share.restype = POINTER(wasm_shared_module_t)
+_wasm_module_share.argtypes = [POINTER(wasm_module_t)]
+def wasm_module_share(arg0: pointer) -> pointer:
+    return _wasm_module_share(arg0)
+
+_wasm_module_obtain = dll.wasm_module_obtain
+_wasm_module_obtain.restype = POINTER(wasm_module_t)
+_wasm_module_obtain.argtypes = [POINTER(wasm_store_t), POINTER(wasm_shared_module_t)]
+def wasm_module_obtain(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_module_obtain(arg0, arg1)
+
+_wasm_module_new = dll.wasm_module_new
+_wasm_module_new.restype = POINTER(wasm_module_t)
+_wasm_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasm_module_new(arg0: pointer, binary: pointer) -> pointer:
+    return _wasm_module_new(arg0, binary)
+
+_wasm_module_validate = dll.wasm_module_validate
+_wasm_module_validate.restype = c_bool
+_wasm_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasm_module_validate(arg0: pointer, binary: pointer) -> c_bool:
+    return _wasm_module_validate(arg0, binary)
+
+_wasm_module_imports = dll.wasm_module_imports
+_wasm_module_imports.restype = None
+_wasm_module_imports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_importtype_vec_t)]
+def wasm_module_imports(arg0: pointer, out: pointer) -> None:
+    return _wasm_module_imports(arg0, out)
+
+_wasm_module_exports = dll.wasm_module_exports
+_wasm_module_exports.restype = None
+_wasm_module_exports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_exporttype_vec_t)]
+def wasm_module_exports(arg0: pointer, out: pointer) -> None:
+    return _wasm_module_exports(arg0, out)
+
+class wasm_func_t(Structure):
+    pass
+
+_wasm_func_delete = dll.wasm_func_delete
+_wasm_func_delete.restype = None
+_wasm_func_delete.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_delete(arg0: pointer) -> None:
+    return _wasm_func_delete(arg0)
+
+_wasm_func_copy = dll.wasm_func_copy
+_wasm_func_copy.restype = POINTER(wasm_func_t)
+_wasm_func_copy.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_copy(arg0: pointer) -> pointer:
+    return _wasm_func_copy(arg0)
+
+_wasm_func_same = dll.wasm_func_same
+_wasm_func_same.restype = c_bool
+_wasm_func_same.argtypes = [POINTER(wasm_func_t), POINTER(wasm_func_t)]
+def wasm_func_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_func_same(arg0, arg1)
+
+_wasm_func_get_host_info = dll.wasm_func_get_host_info
+_wasm_func_get_host_info.restype = c_void_p
+_wasm_func_get_host_info.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_func_get_host_info(arg0)
+
+_wasm_func_set_host_info = dll.wasm_func_set_host_info
+_wasm_func_set_host_info.restype = None
+_wasm_func_set_host_info.argtypes = [POINTER(wasm_func_t), c_void_p]
+def wasm_func_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_func_set_host_info(arg0, arg1)
+
+_wasm_func_set_host_info_with_finalizer = dll.wasm_func_set_host_info_with_finalizer
+_wasm_func_set_host_info_with_finalizer.restype = None
+_wasm_func_set_host_info_with_finalizer.argtypes = [POINTER(wasm_func_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_func_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_func_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_func_as_ref = dll.wasm_func_as_ref
+_wasm_func_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_func_as_ref.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_ref(arg0: pointer) -> pointer:
+    return _wasm_func_as_ref(arg0)
+
+_wasm_func_as_ref_const = dll.wasm_func_as_ref_const
+_wasm_func_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_func_as_ref_const.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_func_as_ref_const(arg0)
+
+wasm_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+wasm_func_callback_with_env_t = CFUNCTYPE(c_size_t, c_void_p, POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+_wasm_func_new = dll.wasm_func_new
+_wasm_func_new.restype = POINTER(wasm_func_t)
+_wasm_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_t]
+def wasm_func_new(arg0: pointer, arg1: pointer, arg2: wasm_func_callback_t) -> pointer:
+    return _wasm_func_new(arg0, arg1, arg2)
+
+_wasm_func_new_with_env = dll.wasm_func_new_with_env
+_wasm_func_new_with_env.restype = POINTER(wasm_func_t)
+_wasm_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_func_new_with_env(arg0: pointer, type: pointer, arg2: wasm_func_callback_with_env_t, env: pointer, finalizer: pointer) -> pointer:
+    return _wasm_func_new_with_env(arg0, type, arg2, env, finalizer)
+
+_wasm_func_type = dll.wasm_func_type
+_wasm_func_type.restype = POINTER(wasm_functype_t)
+_wasm_func_type.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_type(arg0: pointer) -> pointer:
+    return _wasm_func_type(arg0)
+
+_wasm_func_param_arity = dll.wasm_func_param_arity
+_wasm_func_param_arity.restype = c_size_t
+_wasm_func_param_arity.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_param_arity(arg0: pointer) -> c_size_t:
+    return _wasm_func_param_arity(arg0)
+
+_wasm_func_result_arity = dll.wasm_func_result_arity
+_wasm_func_result_arity.restype = c_size_t
+_wasm_func_result_arity.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_result_arity(arg0: pointer) -> c_size_t:
+    return _wasm_func_result_arity(arg0)
+
+_wasm_func_call = dll.wasm_func_call
+_wasm_func_call.restype = POINTER(wasm_trap_t)
+_wasm_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), POINTER(wasm_val_t)]
+def wasm_func_call(arg0: pointer, args: pointer, results: pointer) -> pointer:
+    return _wasm_func_call(arg0, args, results)
+
+class wasm_global_t(Structure):
+    pass
+
+_wasm_global_delete = dll.wasm_global_delete
+_wasm_global_delete.restype = None
+_wasm_global_delete.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_delete(arg0: pointer) -> None:
+    return _wasm_global_delete(arg0)
+
+_wasm_global_copy = dll.wasm_global_copy
+_wasm_global_copy.restype = POINTER(wasm_global_t)
+_wasm_global_copy.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_copy(arg0: pointer) -> pointer:
+    return _wasm_global_copy(arg0)
+
+_wasm_global_same = dll.wasm_global_same
+_wasm_global_same.restype = c_bool
+_wasm_global_same.argtypes = [POINTER(wasm_global_t), POINTER(wasm_global_t)]
+def wasm_global_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_global_same(arg0, arg1)
+
+_wasm_global_get_host_info = dll.wasm_global_get_host_info
+_wasm_global_get_host_info.restype = c_void_p
+_wasm_global_get_host_info.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_global_get_host_info(arg0)
+
+_wasm_global_set_host_info = dll.wasm_global_set_host_info
+_wasm_global_set_host_info.restype = None
+_wasm_global_set_host_info.argtypes = [POINTER(wasm_global_t), c_void_p]
+def wasm_global_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_global_set_host_info(arg0, arg1)
+
+_wasm_global_set_host_info_with_finalizer = dll.wasm_global_set_host_info_with_finalizer
+_wasm_global_set_host_info_with_finalizer.restype = None
+_wasm_global_set_host_info_with_finalizer.argtypes = [POINTER(wasm_global_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_global_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_global_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_global_as_ref = dll.wasm_global_as_ref
+_wasm_global_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_global_as_ref.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_ref(arg0: pointer) -> pointer:
+    return _wasm_global_as_ref(arg0)
+
+_wasm_global_as_ref_const = dll.wasm_global_as_ref_const
+_wasm_global_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_global_as_ref_const.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_global_as_ref_const(arg0)
+
+_wasm_global_new = dll.wasm_global_new
+_wasm_global_new.restype = POINTER(wasm_global_t)
+_wasm_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t)]
+def wasm_global_new(arg0: pointer, arg1: pointer, arg2: pointer) -> pointer:
+    return _wasm_global_new(arg0, arg1, arg2)
+
+_wasm_global_type = dll.wasm_global_type
+_wasm_global_type.restype = POINTER(wasm_globaltype_t)
+_wasm_global_type.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_type(arg0: pointer) -> pointer:
+    return _wasm_global_type(arg0)
+
+_wasm_global_get = dll.wasm_global_get
+_wasm_global_get.restype = None
+_wasm_global_get.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
+def wasm_global_get(arg0: pointer, out: pointer) -> None:
+    return _wasm_global_get(arg0, out)
+
+_wasm_global_set = dll.wasm_global_set
+_wasm_global_set.restype = None
+_wasm_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
+def wasm_global_set(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_global_set(arg0, arg1)
+
+class wasm_table_t(Structure):
+    pass
+
+_wasm_table_delete = dll.wasm_table_delete
+_wasm_table_delete.restype = None
+_wasm_table_delete.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_delete(arg0: pointer) -> None:
+    return _wasm_table_delete(arg0)
+
+_wasm_table_copy = dll.wasm_table_copy
+_wasm_table_copy.restype = POINTER(wasm_table_t)
+_wasm_table_copy.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_copy(arg0: pointer) -> pointer:
+    return _wasm_table_copy(arg0)
+
+_wasm_table_same = dll.wasm_table_same
+_wasm_table_same.restype = c_bool
+_wasm_table_same.argtypes = [POINTER(wasm_table_t), POINTER(wasm_table_t)]
+def wasm_table_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_table_same(arg0, arg1)
+
+_wasm_table_get_host_info = dll.wasm_table_get_host_info
+_wasm_table_get_host_info.restype = c_void_p
+_wasm_table_get_host_info.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_table_get_host_info(arg0)
+
+_wasm_table_set_host_info = dll.wasm_table_set_host_info
+_wasm_table_set_host_info.restype = None
+_wasm_table_set_host_info.argtypes = [POINTER(wasm_table_t), c_void_p]
+def wasm_table_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_table_set_host_info(arg0, arg1)
+
+_wasm_table_set_host_info_with_finalizer = dll.wasm_table_set_host_info_with_finalizer
+_wasm_table_set_host_info_with_finalizer.restype = None
+_wasm_table_set_host_info_with_finalizer.argtypes = [POINTER(wasm_table_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_table_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_table_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_table_as_ref = dll.wasm_table_as_ref
+_wasm_table_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_table_as_ref.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_ref(arg0: pointer) -> pointer:
+    return _wasm_table_as_ref(arg0)
+
+_wasm_table_as_ref_const = dll.wasm_table_as_ref_const
+_wasm_table_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_table_as_ref_const.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_table_as_ref_const(arg0)
+
+wasm_table_size_t = c_uint32
+
+_wasm_table_new = dll.wasm_table_new
+_wasm_table_new.restype = POINTER(wasm_table_t)
+_wasm_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_ref_t)]
+def wasm_table_new(arg0: pointer, arg1: pointer, init: pointer) -> pointer:
+    return _wasm_table_new(arg0, arg1, init)
+
+_wasm_table_type = dll.wasm_table_type
+_wasm_table_type.restype = POINTER(wasm_tabletype_t)
+_wasm_table_type.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_type(arg0: pointer) -> pointer:
+    return _wasm_table_type(arg0)
+
+_wasm_table_get = dll.wasm_table_get
+_wasm_table_get.restype = POINTER(wasm_ref_t)
+_wasm_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t]
+def wasm_table_get(arg0: pointer, index: wasm_table_size_t) -> pointer:
+    return _wasm_table_get(arg0, index)
+
+_wasm_table_set = dll.wasm_table_set
+_wasm_table_set.restype = c_bool
+_wasm_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
+def wasm_table_set(arg0: pointer, index: wasm_table_size_t, arg2: pointer) -> c_bool:
+    return _wasm_table_set(arg0, index, arg2)
+
+_wasm_table_size = dll.wasm_table_size
+_wasm_table_size.restype = wasm_table_size_t
+_wasm_table_size.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_size(arg0: pointer) -> wasm_table_size_t:
+    return _wasm_table_size(arg0)
+
+_wasm_table_grow = dll.wasm_table_grow
+_wasm_table_grow.restype = c_bool
+_wasm_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
+def wasm_table_grow(arg0: pointer, delta: wasm_table_size_t, init: pointer) -> c_bool:
+    return _wasm_table_grow(arg0, delta, init)
+
+class wasm_memory_t(Structure):
+    pass
+
+_wasm_memory_delete = dll.wasm_memory_delete
+_wasm_memory_delete.restype = None
+_wasm_memory_delete.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_delete(arg0: pointer) -> None:
+    return _wasm_memory_delete(arg0)
+
+_wasm_memory_copy = dll.wasm_memory_copy
+_wasm_memory_copy.restype = POINTER(wasm_memory_t)
+_wasm_memory_copy.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_copy(arg0: pointer) -> pointer:
+    return _wasm_memory_copy(arg0)
+
+_wasm_memory_same = dll.wasm_memory_same
+_wasm_memory_same.restype = c_bool
+_wasm_memory_same.argtypes = [POINTER(wasm_memory_t), POINTER(wasm_memory_t)]
+def wasm_memory_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_memory_same(arg0, arg1)
+
+_wasm_memory_get_host_info = dll.wasm_memory_get_host_info
+_wasm_memory_get_host_info.restype = c_void_p
+_wasm_memory_get_host_info.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_memory_get_host_info(arg0)
+
+_wasm_memory_set_host_info = dll.wasm_memory_set_host_info
+_wasm_memory_set_host_info.restype = None
+_wasm_memory_set_host_info.argtypes = [POINTER(wasm_memory_t), c_void_p]
+def wasm_memory_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_memory_set_host_info(arg0, arg1)
+
+_wasm_memory_set_host_info_with_finalizer = dll.wasm_memory_set_host_info_with_finalizer
+_wasm_memory_set_host_info_with_finalizer.restype = None
+_wasm_memory_set_host_info_with_finalizer.argtypes = [POINTER(wasm_memory_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_memory_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_memory_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_memory_as_ref = dll.wasm_memory_as_ref
+_wasm_memory_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_memory_as_ref.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_ref(arg0: pointer) -> pointer:
+    return _wasm_memory_as_ref(arg0)
+
+_wasm_memory_as_ref_const = dll.wasm_memory_as_ref_const
+_wasm_memory_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_memory_as_ref_const.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_memory_as_ref_const(arg0)
+
+wasm_memory_pages_t = c_uint32
+
+_wasm_memory_new = dll.wasm_memory_new
+_wasm_memory_new.restype = POINTER(wasm_memory_t)
+_wasm_memory_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_memorytype_t)]
+def wasm_memory_new(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasm_memory_new(arg0, arg1)
+
+_wasm_memory_type = dll.wasm_memory_type
+_wasm_memory_type.restype = POINTER(wasm_memorytype_t)
+_wasm_memory_type.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_type(arg0: pointer) -> pointer:
+    return _wasm_memory_type(arg0)
+
+_wasm_memory_data = dll.wasm_memory_data
+_wasm_memory_data.restype = POINTER(c_ubyte)
+_wasm_memory_data.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_data(arg0: pointer) -> pointer:
+    return _wasm_memory_data(arg0)
+
+_wasm_memory_data_size = dll.wasm_memory_data_size
+_wasm_memory_data_size.restype = c_size_t
+_wasm_memory_data_size.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_data_size(arg0: pointer) -> c_size_t:
+    return _wasm_memory_data_size(arg0)
+
+_wasm_memory_size = dll.wasm_memory_size
+_wasm_memory_size.restype = wasm_memory_pages_t
+_wasm_memory_size.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_size(arg0: pointer) -> wasm_memory_pages_t:
+    return _wasm_memory_size(arg0)
+
+_wasm_memory_grow = dll.wasm_memory_grow
+_wasm_memory_grow.restype = c_bool
+_wasm_memory_grow.argtypes = [POINTER(wasm_memory_t), wasm_memory_pages_t]
+def wasm_memory_grow(arg0: pointer, delta: wasm_memory_pages_t) -> c_bool:
+    return _wasm_memory_grow(arg0, delta)
+
+class wasm_extern_t(Structure):
+    pass
+
+_wasm_extern_delete = dll.wasm_extern_delete
+_wasm_extern_delete.restype = None
+_wasm_extern_delete.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_delete(arg0: pointer) -> None:
+    return _wasm_extern_delete(arg0)
+
+_wasm_extern_copy = dll.wasm_extern_copy
+_wasm_extern_copy.restype = POINTER(wasm_extern_t)
+_wasm_extern_copy.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_copy(arg0: pointer) -> pointer:
+    return _wasm_extern_copy(arg0)
+
+_wasm_extern_same = dll.wasm_extern_same
+_wasm_extern_same.restype = c_bool
+_wasm_extern_same.argtypes = [POINTER(wasm_extern_t), POINTER(wasm_extern_t)]
+def wasm_extern_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_extern_same(arg0, arg1)
+
+_wasm_extern_get_host_info = dll.wasm_extern_get_host_info
+_wasm_extern_get_host_info.restype = c_void_p
+_wasm_extern_get_host_info.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_extern_get_host_info(arg0)
+
+_wasm_extern_set_host_info = dll.wasm_extern_set_host_info
+_wasm_extern_set_host_info.restype = None
+_wasm_extern_set_host_info.argtypes = [POINTER(wasm_extern_t), c_void_p]
+def wasm_extern_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_extern_set_host_info(arg0, arg1)
+
+_wasm_extern_set_host_info_with_finalizer = dll.wasm_extern_set_host_info_with_finalizer
+_wasm_extern_set_host_info_with_finalizer.restype = None
+_wasm_extern_set_host_info_with_finalizer.argtypes = [POINTER(wasm_extern_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_extern_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_extern_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_extern_as_ref = dll.wasm_extern_as_ref
+_wasm_extern_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_extern_as_ref.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_ref(arg0: pointer) -> pointer:
+    return _wasm_extern_as_ref(arg0)
+
+_wasm_extern_as_ref_const = dll.wasm_extern_as_ref_const
+_wasm_extern_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_extern_as_ref_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_ref_const(arg0)
+
+class wasm_extern_vec_t(Structure):
+    _fields_ = [
+        ("size", c_size_t),
+        ("data", POINTER(POINTER(wasm_extern_t))),
+    ]
+
+_wasm_extern_vec_new_empty = dll.wasm_extern_vec_new_empty
+_wasm_extern_vec_new_empty.restype = None
+_wasm_extern_vec_new_empty.argtypes = [POINTER(wasm_extern_vec_t)]
+def wasm_extern_vec_new_empty(out: pointer) -> None:
+    return _wasm_extern_vec_new_empty(out)
+
+_wasm_extern_vec_new_uninitialized = dll.wasm_extern_vec_new_uninitialized
+_wasm_extern_vec_new_uninitialized.restype = None
+_wasm_extern_vec_new_uninitialized.argtypes = [POINTER(wasm_extern_vec_t), c_size_t]
+def wasm_extern_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+    return _wasm_extern_vec_new_uninitialized(out, arg1)
+
+_wasm_extern_vec_new = dll.wasm_extern_vec_new
+_wasm_extern_vec_new.restype = None
+_wasm_extern_vec_new.argtypes = [POINTER(wasm_extern_vec_t), c_size_t, POINTER(POINTER(wasm_extern_t))]
+def wasm_extern_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+    return _wasm_extern_vec_new(out, arg1, arg2)
+
+_wasm_extern_vec_copy = dll.wasm_extern_vec_copy
+_wasm_extern_vec_copy.restype = None
+_wasm_extern_vec_copy.argtypes = [POINTER(wasm_extern_vec_t), POINTER(wasm_extern_vec_t)]
+def wasm_extern_vec_copy(out: pointer, arg1: pointer) -> None:
+    return _wasm_extern_vec_copy(out, arg1)
+
+_wasm_extern_vec_delete = dll.wasm_extern_vec_delete
+_wasm_extern_vec_delete.restype = None
+_wasm_extern_vec_delete.argtypes = [POINTER(wasm_extern_vec_t)]
+def wasm_extern_vec_delete(arg0: pointer) -> None:
+    return _wasm_extern_vec_delete(arg0)
+
+_wasm_extern_kind = dll.wasm_extern_kind
+_wasm_extern_kind.restype = wasm_externkind_t
+_wasm_extern_kind.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_kind(arg0: pointer) -> wasm_externkind_t:
+    return _wasm_extern_kind(arg0)
+
+_wasm_extern_type = dll.wasm_extern_type
+_wasm_extern_type.restype = POINTER(wasm_externtype_t)
+_wasm_extern_type.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_type(arg0: pointer) -> pointer:
+    return _wasm_extern_type(arg0)
+
+_wasm_func_as_extern = dll.wasm_func_as_extern
+_wasm_func_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_func_as_extern.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_extern(arg0: pointer) -> pointer:
+    return _wasm_func_as_extern(arg0)
+
+_wasm_global_as_extern = dll.wasm_global_as_extern
+_wasm_global_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_global_as_extern.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_extern(arg0: pointer) -> pointer:
+    return _wasm_global_as_extern(arg0)
+
+_wasm_table_as_extern = dll.wasm_table_as_extern
+_wasm_table_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_table_as_extern.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_extern(arg0: pointer) -> pointer:
+    return _wasm_table_as_extern(arg0)
+
+_wasm_memory_as_extern = dll.wasm_memory_as_extern
+_wasm_memory_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_memory_as_extern.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_extern(arg0: pointer) -> pointer:
+    return _wasm_memory_as_extern(arg0)
+
+_wasm_extern_as_func = dll.wasm_extern_as_func
+_wasm_extern_as_func.restype = POINTER(wasm_func_t)
+_wasm_extern_as_func.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_func(arg0: pointer) -> pointer:
+    return _wasm_extern_as_func(arg0)
+
+_wasm_extern_as_global = dll.wasm_extern_as_global
+_wasm_extern_as_global.restype = POINTER(wasm_global_t)
+_wasm_extern_as_global.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_global(arg0: pointer) -> pointer:
+    return _wasm_extern_as_global(arg0)
+
+_wasm_extern_as_table = dll.wasm_extern_as_table
+_wasm_extern_as_table.restype = POINTER(wasm_table_t)
+_wasm_extern_as_table.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_table(arg0: pointer) -> pointer:
+    return _wasm_extern_as_table(arg0)
+
+_wasm_extern_as_memory = dll.wasm_extern_as_memory
+_wasm_extern_as_memory.restype = POINTER(wasm_memory_t)
+_wasm_extern_as_memory.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_memory(arg0: pointer) -> pointer:
+    return _wasm_extern_as_memory(arg0)
+
+_wasm_extern_as_func_const = dll.wasm_extern_as_func_const
+_wasm_extern_as_func_const.restype = POINTER(wasm_func_t)
+_wasm_extern_as_func_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_func_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_func_const(arg0)
+
+_wasm_extern_as_global_const = dll.wasm_extern_as_global_const
+_wasm_extern_as_global_const.restype = POINTER(wasm_global_t)
+_wasm_extern_as_global_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_global_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_global_const(arg0)
+
+_wasm_extern_as_table_const = dll.wasm_extern_as_table_const
+_wasm_extern_as_table_const.restype = POINTER(wasm_table_t)
+_wasm_extern_as_table_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_table_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_table_const(arg0)
+
+_wasm_extern_as_memory_const = dll.wasm_extern_as_memory_const
+_wasm_extern_as_memory_const.restype = POINTER(wasm_memory_t)
+_wasm_extern_as_memory_const.argtypes = [POINTER(wasm_extern_t)]
+def wasm_extern_as_memory_const(arg0: pointer) -> pointer:
+    return _wasm_extern_as_memory_const(arg0)
+
+class wasm_instance_t(Structure):
+    pass
+
+_wasm_instance_delete = dll.wasm_instance_delete
+_wasm_instance_delete.restype = None
+_wasm_instance_delete.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_delete(arg0: pointer) -> None:
+    return _wasm_instance_delete(arg0)
+
+_wasm_instance_copy = dll.wasm_instance_copy
+_wasm_instance_copy.restype = POINTER(wasm_instance_t)
+_wasm_instance_copy.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_copy(arg0: pointer) -> pointer:
+    return _wasm_instance_copy(arg0)
+
+_wasm_instance_same = dll.wasm_instance_same
+_wasm_instance_same.restype = c_bool
+_wasm_instance_same.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_instance_t)]
+def wasm_instance_same(arg0: pointer, arg1: pointer) -> c_bool:
+    return _wasm_instance_same(arg0, arg1)
+
+_wasm_instance_get_host_info = dll.wasm_instance_get_host_info
+_wasm_instance_get_host_info.restype = c_void_p
+_wasm_instance_get_host_info.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_get_host_info(arg0: pointer) -> pointer:
+    return _wasm_instance_get_host_info(arg0)
+
+_wasm_instance_set_host_info = dll.wasm_instance_set_host_info
+_wasm_instance_set_host_info.restype = None
+_wasm_instance_set_host_info.argtypes = [POINTER(wasm_instance_t), c_void_p]
+def wasm_instance_set_host_info(arg0: pointer, arg1: pointer) -> None:
+    return _wasm_instance_set_host_info(arg0, arg1)
+
+_wasm_instance_set_host_info_with_finalizer = dll.wasm_instance_set_host_info_with_finalizer
+_wasm_instance_set_host_info_with_finalizer.restype = None
+_wasm_instance_set_host_info_with_finalizer.argtypes = [POINTER(wasm_instance_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_instance_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+    return _wasm_instance_set_host_info_with_finalizer(arg0, arg1, arg2)
+
+_wasm_instance_as_ref = dll.wasm_instance_as_ref
+_wasm_instance_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_instance_as_ref.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_as_ref(arg0: pointer) -> pointer:
+    return _wasm_instance_as_ref(arg0)
+
+_wasm_instance_as_ref_const = dll.wasm_instance_as_ref_const
+_wasm_instance_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_instance_as_ref_const.argtypes = [POINTER(wasm_instance_t)]
+def wasm_instance_as_ref_const(arg0: pointer) -> pointer:
+    return _wasm_instance_as_ref_const(arg0)
+
+_wasm_instance_new = dll.wasm_instance_new
+_wasm_instance_new.restype = POINTER(wasm_instance_t)
+_wasm_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), POINTER(POINTER(wasm_trap_t))]
+def wasm_instance_new(arg0: pointer, arg1: pointer, imports: pointer, arg3: pointer) -> pointer:
+    return _wasm_instance_new(arg0, arg1, imports, arg3)
+
+_wasm_instance_exports = dll.wasm_instance_exports
+_wasm_instance_exports.restype = None
+_wasm_instance_exports.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_extern_vec_t)]
+def wasm_instance_exports(arg0: pointer, out: pointer) -> None:
+    return _wasm_instance_exports(arg0, out)
+
+class wasi_config_t(Structure):
+    pass
+
+_wasi_config_delete = dll.wasi_config_delete
+_wasi_config_delete.restype = None
+_wasi_config_delete.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_delete(arg0: pointer) -> None:
+    return _wasi_config_delete(arg0)
+
+_wasi_config_new = dll.wasi_config_new
+_wasi_config_new.restype = POINTER(wasi_config_t)
+_wasi_config_new.argtypes = []
+def wasi_config_new() -> pointer:
+    return _wasi_config_new()
+
+_wasi_config_set_argv = dll.wasi_config_set_argv
+_wasi_config_set_argv.restype = None
+_wasi_config_set_argv.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char))]
+def wasi_config_set_argv(config: pointer, argc: c_int, argv: pointer) -> None:
+    return _wasi_config_set_argv(config, argc, argv)
+
+_wasi_config_inherit_argv = dll.wasi_config_inherit_argv
+_wasi_config_inherit_argv.restype = None
+_wasi_config_inherit_argv.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_argv(config: pointer) -> None:
+    return _wasi_config_inherit_argv(config)
+
+_wasi_config_set_env = dll.wasi_config_set_env
+_wasi_config_set_env.restype = None
+_wasi_config_set_env.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char)), POINTER(POINTER(c_char))]
+def wasi_config_set_env(config: pointer, envc: c_int, names: pointer, values: pointer) -> None:
+    return _wasi_config_set_env(config, envc, names, values)
+
+_wasi_config_inherit_env = dll.wasi_config_inherit_env
+_wasi_config_inherit_env.restype = None
+_wasi_config_inherit_env.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_env(config: pointer) -> None:
+    return _wasi_config_inherit_env(config)
+
+_wasi_config_set_stdin_file = dll.wasi_config_set_stdin_file
+_wasi_config_set_stdin_file.restype = c_bool
+_wasi_config_set_stdin_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
+def wasi_config_set_stdin_file(config: pointer, path: pointer) -> c_bool:
+    return _wasi_config_set_stdin_file(config, path)
+
+_wasi_config_inherit_stdin = dll.wasi_config_inherit_stdin
+_wasi_config_inherit_stdin.restype = None
+_wasi_config_inherit_stdin.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_stdin(config: pointer) -> None:
+    return _wasi_config_inherit_stdin(config)
+
+_wasi_config_set_stdout_file = dll.wasi_config_set_stdout_file
+_wasi_config_set_stdout_file.restype = c_bool
+_wasi_config_set_stdout_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
+def wasi_config_set_stdout_file(config: pointer, path: pointer) -> c_bool:
+    return _wasi_config_set_stdout_file(config, path)
+
+_wasi_config_inherit_stdout = dll.wasi_config_inherit_stdout
+_wasi_config_inherit_stdout.restype = None
+_wasi_config_inherit_stdout.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_stdout(config: pointer) -> None:
+    return _wasi_config_inherit_stdout(config)
+
+_wasi_config_set_stderr_file = dll.wasi_config_set_stderr_file
+_wasi_config_set_stderr_file.restype = c_bool
+_wasi_config_set_stderr_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
+def wasi_config_set_stderr_file(config: pointer, path: pointer) -> c_bool:
+    return _wasi_config_set_stderr_file(config, path)
+
+_wasi_config_inherit_stderr = dll.wasi_config_inherit_stderr
+_wasi_config_inherit_stderr.restype = None
+_wasi_config_inherit_stderr.argtypes = [POINTER(wasi_config_t)]
+def wasi_config_inherit_stderr(config: pointer) -> None:
+    return _wasi_config_inherit_stderr(config)
+
+_wasi_config_preopen_dir = dll.wasi_config_preopen_dir
+_wasi_config_preopen_dir.restype = c_bool
+_wasi_config_preopen_dir.argtypes = [POINTER(wasi_config_t), POINTER(c_char), POINTER(c_char)]
+def wasi_config_preopen_dir(config: pointer, path: pointer, guest_path: pointer) -> c_bool:
+    return _wasi_config_preopen_dir(config, path, guest_path)
+
+class wasi_instance_t(Structure):
+    pass
+
+_wasi_instance_delete = dll.wasi_instance_delete
+_wasi_instance_delete.restype = None
+_wasi_instance_delete.argtypes = [POINTER(wasi_instance_t)]
+def wasi_instance_delete(arg0: pointer) -> None:
+    return _wasi_instance_delete(arg0)
+
+_wasi_instance_new = dll.wasi_instance_new
+_wasi_instance_new.restype = POINTER(wasi_instance_t)
+_wasi_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(c_char), POINTER(wasi_config_t), POINTER(POINTER(wasm_trap_t))]
+def wasi_instance_new(store: pointer, name: pointer, config: pointer, trap: pointer) -> pointer:
+    return _wasi_instance_new(store, name, config, trap)
+
+_wasi_instance_bind_import = dll.wasi_instance_bind_import
+_wasi_instance_bind_import.restype = POINTER(wasm_extern_t)
+_wasi_instance_bind_import.argtypes = [POINTER(wasi_instance_t), POINTER(wasm_importtype_t)]
+def wasi_instance_bind_import(instance: pointer, arg1: pointer) -> pointer:
+    return _wasi_instance_bind_import(instance, arg1)
+
+class wasmtime_error_t(Structure):
+    pass
+
+_wasmtime_error_delete = dll.wasmtime_error_delete
+_wasmtime_error_delete.restype = None
+_wasmtime_error_delete.argtypes = [POINTER(wasmtime_error_t)]
+def wasmtime_error_delete(arg0: pointer) -> None:
+    return _wasmtime_error_delete(arg0)
+
+_wasmtime_error_message = dll.wasmtime_error_message
+_wasmtime_error_message.restype = None
+_wasmtime_error_message.argtypes = [POINTER(wasmtime_error_t), POINTER(wasm_name_t)]
+def wasmtime_error_message(error: pointer, message: pointer) -> None:
+    return _wasmtime_error_message(error, message)
+
+wasmtime_strategy_t = c_uint8
+
+wasmtime_opt_level_t = c_uint8
+
+wasmtime_profiling_strategy_t = c_uint8
+
+_wasmtime_config_debug_info_set = dll.wasmtime_config_debug_info_set
+_wasmtime_config_debug_info_set.restype = None
+_wasmtime_config_debug_info_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_debug_info_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_debug_info_set(arg0, arg1)
+
+_wasmtime_config_interruptable_set = dll.wasmtime_config_interruptable_set
+_wasmtime_config_interruptable_set.restype = None
+_wasmtime_config_interruptable_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_interruptable_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_interruptable_set(arg0, arg1)
+
+_wasmtime_config_max_wasm_stack_set = dll.wasmtime_config_max_wasm_stack_set
+_wasmtime_config_max_wasm_stack_set.restype = None
+_wasmtime_config_max_wasm_stack_set.argtypes = [POINTER(wasm_config_t), c_size_t]
+def wasmtime_config_max_wasm_stack_set(arg0: pointer, arg1: c_size_t) -> None:
+    return _wasmtime_config_max_wasm_stack_set(arg0, arg1)
+
+_wasmtime_config_wasm_threads_set = dll.wasmtime_config_wasm_threads_set
+_wasmtime_config_wasm_threads_set.restype = None
+_wasmtime_config_wasm_threads_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_threads_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_threads_set(arg0, arg1)
+
+_wasmtime_config_wasm_reference_types_set = dll.wasmtime_config_wasm_reference_types_set
+_wasmtime_config_wasm_reference_types_set.restype = None
+_wasmtime_config_wasm_reference_types_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_reference_types_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_reference_types_set(arg0, arg1)
+
+_wasmtime_config_wasm_simd_set = dll.wasmtime_config_wasm_simd_set
+_wasmtime_config_wasm_simd_set.restype = None
+_wasmtime_config_wasm_simd_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_simd_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_simd_set(arg0, arg1)
+
+_wasmtime_config_wasm_bulk_memory_set = dll.wasmtime_config_wasm_bulk_memory_set
+_wasmtime_config_wasm_bulk_memory_set.restype = None
+_wasmtime_config_wasm_bulk_memory_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_bulk_memory_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_bulk_memory_set(arg0, arg1)
+
+_wasmtime_config_wasm_multi_value_set = dll.wasmtime_config_wasm_multi_value_set
+_wasmtime_config_wasm_multi_value_set.restype = None
+_wasmtime_config_wasm_multi_value_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_multi_value_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_wasm_multi_value_set(arg0, arg1)
+
+_wasmtime_config_strategy_set = dll.wasmtime_config_strategy_set
+_wasmtime_config_strategy_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_config_strategy_set.argtypes = [POINTER(wasm_config_t), wasmtime_strategy_t]
+def wasmtime_config_strategy_set(arg0: pointer, arg1: wasmtime_strategy_t) -> pointer:
+    return _wasmtime_config_strategy_set(arg0, arg1)
+
+_wasmtime_config_cranelift_debug_verifier_set = dll.wasmtime_config_cranelift_debug_verifier_set
+_wasmtime_config_cranelift_debug_verifier_set.restype = None
+_wasmtime_config_cranelift_debug_verifier_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_cranelift_debug_verifier_set(arg0: pointer, arg1: c_bool) -> None:
+    return _wasmtime_config_cranelift_debug_verifier_set(arg0, arg1)
+
+_wasmtime_config_cranelift_opt_level_set = dll.wasmtime_config_cranelift_opt_level_set
+_wasmtime_config_cranelift_opt_level_set.restype = None
+_wasmtime_config_cranelift_opt_level_set.argtypes = [POINTER(wasm_config_t), wasmtime_opt_level_t]
+def wasmtime_config_cranelift_opt_level_set(arg0: pointer, arg1: wasmtime_opt_level_t) -> None:
+    return _wasmtime_config_cranelift_opt_level_set(arg0, arg1)
+
+_wasmtime_config_profiler_set = dll.wasmtime_config_profiler_set
+_wasmtime_config_profiler_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_config_profiler_set.argtypes = [POINTER(wasm_config_t), wasmtime_profiling_strategy_t]
+def wasmtime_config_profiler_set(arg0: pointer, arg1: wasmtime_profiling_strategy_t) -> pointer:
+    return _wasmtime_config_profiler_set(arg0, arg1)
+
+_wasmtime_config_static_memory_maximum_size_set = dll.wasmtime_config_static_memory_maximum_size_set
+_wasmtime_config_static_memory_maximum_size_set.restype = None
+_wasmtime_config_static_memory_maximum_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
+def wasmtime_config_static_memory_maximum_size_set(arg0: pointer, arg1: c_uint64) -> None:
+    return _wasmtime_config_static_memory_maximum_size_set(arg0, arg1)
+
+_wasmtime_config_static_memory_guard_size_set = dll.wasmtime_config_static_memory_guard_size_set
+_wasmtime_config_static_memory_guard_size_set.restype = None
+_wasmtime_config_static_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
+def wasmtime_config_static_memory_guard_size_set(arg0: pointer, arg1: c_uint64) -> None:
+    return _wasmtime_config_static_memory_guard_size_set(arg0, arg1)
+
+_wasmtime_config_dynamic_memory_guard_size_set = dll.wasmtime_config_dynamic_memory_guard_size_set
+_wasmtime_config_dynamic_memory_guard_size_set.restype = None
+_wasmtime_config_dynamic_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
+def wasmtime_config_dynamic_memory_guard_size_set(arg0: pointer, arg1: c_uint64) -> None:
+    return _wasmtime_config_dynamic_memory_guard_size_set(arg0, arg1)
+
+_wasmtime_config_cache_config_load = dll.wasmtime_config_cache_config_load
+_wasmtime_config_cache_config_load.restype = POINTER(wasmtime_error_t)
+_wasmtime_config_cache_config_load.argtypes = [POINTER(wasm_config_t), POINTER(c_char)]
+def wasmtime_config_cache_config_load(arg0: pointer, arg1: pointer) -> pointer:
+    return _wasmtime_config_cache_config_load(arg0, arg1)
+
+_wasmtime_wat2wasm = dll.wasmtime_wat2wasm
+_wasmtime_wat2wasm.restype = POINTER(wasmtime_error_t)
+_wasmtime_wat2wasm.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
+def wasmtime_wat2wasm(wat: pointer, ret: pointer) -> pointer:
+    return _wasmtime_wat2wasm(wat, ret)
+
+class wasmtime_linker_t(Structure):
+    pass
+
+_wasmtime_linker_delete = dll.wasmtime_linker_delete
+_wasmtime_linker_delete.restype = None
+_wasmtime_linker_delete.argtypes = [POINTER(wasmtime_linker_t)]
+def wasmtime_linker_delete(arg0: pointer) -> None:
+    return _wasmtime_linker_delete(arg0)
+
+_wasmtime_linker_new = dll.wasmtime_linker_new
+_wasmtime_linker_new.restype = POINTER(wasmtime_linker_t)
+_wasmtime_linker_new.argtypes = [POINTER(wasm_store_t)]
+def wasmtime_linker_new(store: pointer) -> pointer:
+    return _wasmtime_linker_new(store)
+
+_wasmtime_linker_allow_shadowing = dll.wasmtime_linker_allow_shadowing
+_wasmtime_linker_allow_shadowing.restype = None
+_wasmtime_linker_allow_shadowing.argtypes = [POINTER(wasmtime_linker_t), c_bool]
+def wasmtime_linker_allow_shadowing(linker: pointer, allow_shadowing: c_bool) -> None:
+    return _wasmtime_linker_allow_shadowing(linker, allow_shadowing)
+
+_wasmtime_linker_define = dll.wasmtime_linker_define
+_wasmtime_linker_define.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_define.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_extern_t)]
+def wasmtime_linker_define(linker: pointer, module: pointer, name: pointer, item: pointer) -> pointer:
+    return _wasmtime_linker_define(linker, module, name, item)
+
+_wasmtime_linker_define_wasi = dll.wasmtime_linker_define_wasi
+_wasmtime_linker_define_wasi.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_define_wasi.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasi_instance_t)]
+def wasmtime_linker_define_wasi(linker: pointer, instance: pointer) -> pointer:
+    return _wasmtime_linker_define_wasi(linker, instance)
+
+_wasmtime_linker_define_instance = dll.wasmtime_linker_define_instance
+_wasmtime_linker_define_instance.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_define_instance.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_instance_t)]
+def wasmtime_linker_define_instance(linker: pointer, name: pointer, instance: pointer) -> pointer:
+    return _wasmtime_linker_define_instance(linker, name, instance)
+
+_wasmtime_linker_instantiate = dll.wasmtime_linker_instantiate
+_wasmtime_linker_instantiate.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_instantiate.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
+def wasmtime_linker_instantiate(linker: pointer, module: pointer, instance: pointer, trap: pointer) -> pointer:
+    return _wasmtime_linker_instantiate(linker, module, instance, trap)
+
+_wasmtime_linker_module = dll.wasmtime_linker_module
+_wasmtime_linker_module.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_module.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_module_t)]
+def wasmtime_linker_module(linker: pointer, name: pointer, module: pointer) -> pointer:
+    return _wasmtime_linker_module(linker, name, module)
+
+_wasmtime_linker_get_default = dll.wasmtime_linker_get_default
+_wasmtime_linker_get_default.restype = POINTER(wasmtime_error_t)
+_wasmtime_linker_get_default.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(POINTER(wasm_func_t))]
+def wasmtime_linker_get_default(linker: pointer, name: pointer, func: pointer) -> pointer:
+    return _wasmtime_linker_get_default(linker, name, func)
+
+class wasmtime_caller_t(Structure):
+    pass
+
+wasmtime_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_t), POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+wasmtime_func_callback_with_env_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_t), c_void_p, POINTER(wasm_val_t), POINTER(wasm_val_t))
+
+_wasmtime_func_new = dll.wasmtime_func_new
+_wasmtime_func_new.restype = POINTER(wasm_func_t)
+_wasmtime_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_t]
+def wasmtime_func_new(arg0: pointer, arg1: pointer, callback: wasmtime_func_callback_t) -> pointer:
+    return _wasmtime_func_new(arg0, arg1, callback)
+
+_wasmtime_func_new_with_env = dll.wasmtime_func_new_with_env
+_wasmtime_func_new_with_env.restype = POINTER(wasm_func_t)
+_wasmtime_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasmtime_func_new_with_env(store: pointer, type: pointer, callback: wasmtime_func_callback_with_env_t, env: pointer, finalizer: pointer) -> pointer:
+    return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)
+
+_wasmtime_caller_export_get = dll.wasmtime_caller_export_get
+_wasmtime_caller_export_get.restype = POINTER(wasm_extern_t)
+_wasmtime_caller_export_get.argtypes = [POINTER(wasmtime_caller_t), POINTER(wasm_name_t)]
+def wasmtime_caller_export_get(caller: pointer, name: pointer) -> pointer:
+    return _wasmtime_caller_export_get(caller, name)
+
+class wasmtime_interrupt_handle_t(Structure):
+    pass
+
+_wasmtime_interrupt_handle_delete = dll.wasmtime_interrupt_handle_delete
+_wasmtime_interrupt_handle_delete.restype = None
+_wasmtime_interrupt_handle_delete.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
+def wasmtime_interrupt_handle_delete(arg0: pointer) -> None:
+    return _wasmtime_interrupt_handle_delete(arg0)
+
+_wasmtime_interrupt_handle_new = dll.wasmtime_interrupt_handle_new
+_wasmtime_interrupt_handle_new.restype = POINTER(wasmtime_interrupt_handle_t)
+_wasmtime_interrupt_handle_new.argtypes = [POINTER(wasm_store_t)]
+def wasmtime_interrupt_handle_new(store: pointer) -> pointer:
+    return _wasmtime_interrupt_handle_new(store)
+
+_wasmtime_interrupt_handle_interrupt = dll.wasmtime_interrupt_handle_interrupt
+_wasmtime_interrupt_handle_interrupt.restype = None
+_wasmtime_interrupt_handle_interrupt.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
+def wasmtime_interrupt_handle_interrupt(handle: pointer) -> None:
+    return _wasmtime_interrupt_handle_interrupt(handle)
+
+_wasmtime_frame_func_name = dll.wasmtime_frame_func_name
+_wasmtime_frame_func_name.restype = POINTER(wasm_name_t)
+_wasmtime_frame_func_name.argtypes = [POINTER(wasm_frame_t)]
+def wasmtime_frame_func_name(arg0: pointer) -> pointer:
+    return _wasmtime_frame_func_name(arg0)
+
+_wasmtime_frame_module_name = dll.wasmtime_frame_module_name
+_wasmtime_frame_module_name.restype = POINTER(wasm_name_t)
+_wasmtime_frame_module_name.argtypes = [POINTER(wasm_frame_t)]
+def wasmtime_frame_module_name(arg0: pointer) -> pointer:
+    return _wasmtime_frame_module_name(arg0)
+
+_wasmtime_func_call = dll.wasmtime_func_call
+_wasmtime_func_call.restype = POINTER(wasmtime_error_t)
+_wasmtime_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), c_size_t, POINTER(wasm_val_t), c_size_t, POINTER(POINTER(wasm_trap_t))]
+def wasmtime_func_call(func: pointer, args: pointer, num_args: c_size_t, results: pointer, num_results: c_size_t, trap: pointer) -> pointer:
+    return _wasmtime_func_call(func, args, num_args, results, num_results, trap)
+
+_wasmtime_global_new = dll.wasmtime_global_new
+_wasmtime_global_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t), POINTER(POINTER(wasm_global_t))]
+def wasmtime_global_new(store: pointer, type: pointer, val: pointer, ret: pointer) -> pointer:
+    return _wasmtime_global_new(store, type, val, ret)
+
+_wasmtime_global_set = dll.wasmtime_global_set
+_wasmtime_global_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
+def wasmtime_global_set(arg0: pointer, val: pointer) -> pointer:
+    return _wasmtime_global_set(arg0, val)
+
+_wasmtime_instance_new = dll.wasmtime_instance_new
+_wasmtime_instance_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), c_size_t, POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
+def wasmtime_instance_new(store: pointer, module: pointer, imports: pointer, num_imports: c_size_t, instance: pointer, trap: pointer) -> pointer:
+    return _wasmtime_instance_new(store, module, imports, num_imports, instance, trap)
+
+_wasmtime_module_new = dll.wasmtime_module_new
+_wasmtime_module_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t), POINTER(POINTER(wasm_module_t))]
+def wasmtime_module_new(store: pointer, binary: pointer, ret: pointer) -> pointer:
+    return _wasmtime_module_new(store, binary, ret)
+
+_wasmtime_module_validate = dll.wasmtime_module_validate
+_wasmtime_module_validate.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasmtime_module_validate(store: pointer, binary: pointer) -> pointer:
+    return _wasmtime_module_validate(store, binary)
+
+_wasmtime_funcref_table_new = dll.wasmtime_funcref_table_new
+_wasmtime_funcref_table_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_funcref_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_func_t), POINTER(POINTER(wasm_table_t))]
+def wasmtime_funcref_table_new(store: pointer, element_ty: pointer, init: pointer, table: pointer) -> pointer:
+    return _wasmtime_funcref_table_new(store, element_ty, init, table)
+
+_wasmtime_funcref_table_get = dll.wasmtime_funcref_table_get
+_wasmtime_funcref_table_get.restype = c_bool
+_wasmtime_funcref_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(POINTER(wasm_func_t))]
+def wasmtime_funcref_table_get(table: pointer, index: wasm_table_size_t, func: pointer) -> c_bool:
+    return _wasmtime_funcref_table_get(table, index, func)
+
+_wasmtime_funcref_table_set = dll.wasmtime_funcref_table_set
+_wasmtime_funcref_table_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_funcref_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t)]
+def wasmtime_funcref_table_set(table: pointer, index: wasm_table_size_t, value: pointer) -> pointer:
+    return _wasmtime_funcref_table_set(table, index, value)
+
+_wasmtime_funcref_table_grow = dll.wasmtime_funcref_table_grow
+_wasmtime_funcref_table_grow.restype = POINTER(wasmtime_error_t)
+_wasmtime_funcref_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t), POINTER(wasm_table_size_t)]
+def wasmtime_funcref_table_grow(table: pointer, delta: wasm_table_size_t, init: pointer, prev_size: pointer) -> pointer:
+    return _wasmtime_funcref_table_grow(table, delta, init, prev_size)

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -4,6 +4,7 @@
 # instead edit `./bindgen.py` at the root of the repo
 
 from ctypes import *
+from typing import Any
 from ._ffi import dll, wasm_val_t
 
 wasm_byte_t = c_ubyte
@@ -17,31 +18,31 @@ class wasm_byte_vec_t(Structure):
 _wasm_byte_vec_new_empty = dll.wasm_byte_vec_new_empty
 _wasm_byte_vec_new_empty.restype = None
 _wasm_byte_vec_new_empty.argtypes = [POINTER(wasm_byte_vec_t)]
-def wasm_byte_vec_new_empty(out: pointer) -> None:
+def wasm_byte_vec_new_empty(out: Any) -> None:
     return _wasm_byte_vec_new_empty(out)
 
 _wasm_byte_vec_new_uninitialized = dll.wasm_byte_vec_new_uninitialized
 _wasm_byte_vec_new_uninitialized.restype = None
 _wasm_byte_vec_new_uninitialized.argtypes = [POINTER(wasm_byte_vec_t), c_size_t]
-def wasm_byte_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_byte_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_byte_vec_new_uninitialized(out, arg1)
 
 _wasm_byte_vec_new = dll.wasm_byte_vec_new
 _wasm_byte_vec_new.restype = None
 _wasm_byte_vec_new.argtypes = [POINTER(wasm_byte_vec_t), c_size_t, POINTER(wasm_byte_t)]
-def wasm_byte_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_byte_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_byte_vec_new(out, arg1, arg2)
 
 _wasm_byte_vec_copy = dll.wasm_byte_vec_copy
 _wasm_byte_vec_copy.restype = None
 _wasm_byte_vec_copy.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
-def wasm_byte_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_byte_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_byte_vec_copy(out, arg1)
 
 _wasm_byte_vec_delete = dll.wasm_byte_vec_delete
 _wasm_byte_vec_delete.restype = None
 _wasm_byte_vec_delete.argtypes = [POINTER(wasm_byte_vec_t)]
-def wasm_byte_vec_delete(arg0: pointer) -> None:
+def wasm_byte_vec_delete(arg0: Any) -> None:
     return _wasm_byte_vec_delete(arg0)
 
 wasm_name_t = wasm_byte_vec_t
@@ -52,7 +53,7 @@ class wasm_config_t(Structure):
 _wasm_config_delete = dll.wasm_config_delete
 _wasm_config_delete.restype = None
 _wasm_config_delete.argtypes = [POINTER(wasm_config_t)]
-def wasm_config_delete(arg0: pointer) -> None:
+def wasm_config_delete(arg0: Any) -> None:
     return _wasm_config_delete(arg0)
 
 _wasm_config_new = dll.wasm_config_new
@@ -67,7 +68,7 @@ class wasm_engine_t(Structure):
 _wasm_engine_delete = dll.wasm_engine_delete
 _wasm_engine_delete.restype = None
 _wasm_engine_delete.argtypes = [POINTER(wasm_engine_t)]
-def wasm_engine_delete(arg0: pointer) -> None:
+def wasm_engine_delete(arg0: Any) -> None:
     return _wasm_engine_delete(arg0)
 
 _wasm_engine_new = dll.wasm_engine_new
@@ -79,7 +80,7 @@ def wasm_engine_new() -> pointer:
 _wasm_engine_new_with_config = dll.wasm_engine_new_with_config
 _wasm_engine_new_with_config.restype = POINTER(wasm_engine_t)
 _wasm_engine_new_with_config.argtypes = [POINTER(wasm_config_t)]
-def wasm_engine_new_with_config(arg0: pointer) -> pointer:
+def wasm_engine_new_with_config(arg0: Any) -> pointer:
     return _wasm_engine_new_with_config(arg0)
 
 class wasm_store_t(Structure):
@@ -88,13 +89,13 @@ class wasm_store_t(Structure):
 _wasm_store_delete = dll.wasm_store_delete
 _wasm_store_delete.restype = None
 _wasm_store_delete.argtypes = [POINTER(wasm_store_t)]
-def wasm_store_delete(arg0: pointer) -> None:
+def wasm_store_delete(arg0: Any) -> None:
     return _wasm_store_delete(arg0)
 
 _wasm_store_new = dll.wasm_store_new
 _wasm_store_new.restype = POINTER(wasm_store_t)
 _wasm_store_new.argtypes = [POINTER(wasm_engine_t)]
-def wasm_store_new(arg0: pointer) -> pointer:
+def wasm_store_new(arg0: Any) -> pointer:
     return _wasm_store_new(arg0)
 
 wasm_mutability_t = c_uint8
@@ -111,7 +112,7 @@ class wasm_valtype_t(Structure):
 _wasm_valtype_delete = dll.wasm_valtype_delete
 _wasm_valtype_delete.restype = None
 _wasm_valtype_delete.argtypes = [POINTER(wasm_valtype_t)]
-def wasm_valtype_delete(arg0: pointer) -> None:
+def wasm_valtype_delete(arg0: Any) -> None:
     return _wasm_valtype_delete(arg0)
 
 class wasm_valtype_vec_t(Structure):
@@ -123,37 +124,37 @@ class wasm_valtype_vec_t(Structure):
 _wasm_valtype_vec_new_empty = dll.wasm_valtype_vec_new_empty
 _wasm_valtype_vec_new_empty.restype = None
 _wasm_valtype_vec_new_empty.argtypes = [POINTER(wasm_valtype_vec_t)]
-def wasm_valtype_vec_new_empty(out: pointer) -> None:
+def wasm_valtype_vec_new_empty(out: Any) -> None:
     return _wasm_valtype_vec_new_empty(out)
 
 _wasm_valtype_vec_new_uninitialized = dll.wasm_valtype_vec_new_uninitialized
 _wasm_valtype_vec_new_uninitialized.restype = None
 _wasm_valtype_vec_new_uninitialized.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t]
-def wasm_valtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_valtype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_valtype_vec_new_uninitialized(out, arg1)
 
 _wasm_valtype_vec_new = dll.wasm_valtype_vec_new
 _wasm_valtype_vec_new.restype = None
 _wasm_valtype_vec_new.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t, POINTER(POINTER(wasm_valtype_t))]
-def wasm_valtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_valtype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_valtype_vec_new(out, arg1, arg2)
 
 _wasm_valtype_vec_copy = dll.wasm_valtype_vec_copy
 _wasm_valtype_vec_copy.restype = None
 _wasm_valtype_vec_copy.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
-def wasm_valtype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_valtype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_valtype_vec_copy(out, arg1)
 
 _wasm_valtype_vec_delete = dll.wasm_valtype_vec_delete
 _wasm_valtype_vec_delete.restype = None
 _wasm_valtype_vec_delete.argtypes = [POINTER(wasm_valtype_vec_t)]
-def wasm_valtype_vec_delete(arg0: pointer) -> None:
+def wasm_valtype_vec_delete(arg0: Any) -> None:
     return _wasm_valtype_vec_delete(arg0)
 
 _wasm_valtype_copy = dll.wasm_valtype_copy
 _wasm_valtype_copy.restype = POINTER(wasm_valtype_t)
 _wasm_valtype_copy.argtypes = [POINTER(wasm_valtype_t)]
-def wasm_valtype_copy(arg0: pointer) -> pointer:
+def wasm_valtype_copy(arg0: Any) -> pointer:
     return _wasm_valtype_copy(arg0)
 
 wasm_valkind_t = c_uint8
@@ -161,13 +162,13 @@ wasm_valkind_t = c_uint8
 _wasm_valtype_new = dll.wasm_valtype_new
 _wasm_valtype_new.restype = POINTER(wasm_valtype_t)
 _wasm_valtype_new.argtypes = [wasm_valkind_t]
-def wasm_valtype_new(arg0: wasm_valkind_t) -> pointer:
+def wasm_valtype_new(arg0: Any) -> pointer:
     return _wasm_valtype_new(arg0)
 
 _wasm_valtype_kind = dll.wasm_valtype_kind
 _wasm_valtype_kind.restype = wasm_valkind_t
 _wasm_valtype_kind.argtypes = [POINTER(wasm_valtype_t)]
-def wasm_valtype_kind(arg0: pointer) -> wasm_valkind_t:
+def wasm_valtype_kind(arg0: Any) -> wasm_valkind_t:
     return _wasm_valtype_kind(arg0)
 
 class wasm_functype_t(Structure):
@@ -176,7 +177,7 @@ class wasm_functype_t(Structure):
 _wasm_functype_delete = dll.wasm_functype_delete
 _wasm_functype_delete.restype = None
 _wasm_functype_delete.argtypes = [POINTER(wasm_functype_t)]
-def wasm_functype_delete(arg0: pointer) -> None:
+def wasm_functype_delete(arg0: Any) -> None:
     return _wasm_functype_delete(arg0)
 
 class wasm_functype_vec_t(Structure):
@@ -188,55 +189,55 @@ class wasm_functype_vec_t(Structure):
 _wasm_functype_vec_new_empty = dll.wasm_functype_vec_new_empty
 _wasm_functype_vec_new_empty.restype = None
 _wasm_functype_vec_new_empty.argtypes = [POINTER(wasm_functype_vec_t)]
-def wasm_functype_vec_new_empty(out: pointer) -> None:
+def wasm_functype_vec_new_empty(out: Any) -> None:
     return _wasm_functype_vec_new_empty(out)
 
 _wasm_functype_vec_new_uninitialized = dll.wasm_functype_vec_new_uninitialized
 _wasm_functype_vec_new_uninitialized.restype = None
 _wasm_functype_vec_new_uninitialized.argtypes = [POINTER(wasm_functype_vec_t), c_size_t]
-def wasm_functype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_functype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_functype_vec_new_uninitialized(out, arg1)
 
 _wasm_functype_vec_new = dll.wasm_functype_vec_new
 _wasm_functype_vec_new.restype = None
 _wasm_functype_vec_new.argtypes = [POINTER(wasm_functype_vec_t), c_size_t, POINTER(POINTER(wasm_functype_t))]
-def wasm_functype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_functype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_functype_vec_new(out, arg1, arg2)
 
 _wasm_functype_vec_copy = dll.wasm_functype_vec_copy
 _wasm_functype_vec_copy.restype = None
 _wasm_functype_vec_copy.argtypes = [POINTER(wasm_functype_vec_t), POINTER(wasm_functype_vec_t)]
-def wasm_functype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_functype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_functype_vec_copy(out, arg1)
 
 _wasm_functype_vec_delete = dll.wasm_functype_vec_delete
 _wasm_functype_vec_delete.restype = None
 _wasm_functype_vec_delete.argtypes = [POINTER(wasm_functype_vec_t)]
-def wasm_functype_vec_delete(arg0: pointer) -> None:
+def wasm_functype_vec_delete(arg0: Any) -> None:
     return _wasm_functype_vec_delete(arg0)
 
 _wasm_functype_copy = dll.wasm_functype_copy
 _wasm_functype_copy.restype = POINTER(wasm_functype_t)
 _wasm_functype_copy.argtypes = [POINTER(wasm_functype_t)]
-def wasm_functype_copy(arg0: pointer) -> pointer:
+def wasm_functype_copy(arg0: Any) -> pointer:
     return _wasm_functype_copy(arg0)
 
 _wasm_functype_new = dll.wasm_functype_new
 _wasm_functype_new.restype = POINTER(wasm_functype_t)
 _wasm_functype_new.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
-def wasm_functype_new(params: pointer, results: pointer) -> pointer:
+def wasm_functype_new(params: Any, results: Any) -> pointer:
     return _wasm_functype_new(params, results)
 
 _wasm_functype_params = dll.wasm_functype_params
 _wasm_functype_params.restype = POINTER(wasm_valtype_vec_t)
 _wasm_functype_params.argtypes = [POINTER(wasm_functype_t)]
-def wasm_functype_params(arg0: pointer) -> pointer:
+def wasm_functype_params(arg0: Any) -> pointer:
     return _wasm_functype_params(arg0)
 
 _wasm_functype_results = dll.wasm_functype_results
 _wasm_functype_results.restype = POINTER(wasm_valtype_vec_t)
 _wasm_functype_results.argtypes = [POINTER(wasm_functype_t)]
-def wasm_functype_results(arg0: pointer) -> pointer:
+def wasm_functype_results(arg0: Any) -> pointer:
     return _wasm_functype_results(arg0)
 
 class wasm_globaltype_t(Structure):
@@ -245,7 +246,7 @@ class wasm_globaltype_t(Structure):
 _wasm_globaltype_delete = dll.wasm_globaltype_delete
 _wasm_globaltype_delete.restype = None
 _wasm_globaltype_delete.argtypes = [POINTER(wasm_globaltype_t)]
-def wasm_globaltype_delete(arg0: pointer) -> None:
+def wasm_globaltype_delete(arg0: Any) -> None:
     return _wasm_globaltype_delete(arg0)
 
 class wasm_globaltype_vec_t(Structure):
@@ -257,55 +258,55 @@ class wasm_globaltype_vec_t(Structure):
 _wasm_globaltype_vec_new_empty = dll.wasm_globaltype_vec_new_empty
 _wasm_globaltype_vec_new_empty.restype = None
 _wasm_globaltype_vec_new_empty.argtypes = [POINTER(wasm_globaltype_vec_t)]
-def wasm_globaltype_vec_new_empty(out: pointer) -> None:
+def wasm_globaltype_vec_new_empty(out: Any) -> None:
     return _wasm_globaltype_vec_new_empty(out)
 
 _wasm_globaltype_vec_new_uninitialized = dll.wasm_globaltype_vec_new_uninitialized
 _wasm_globaltype_vec_new_uninitialized.restype = None
 _wasm_globaltype_vec_new_uninitialized.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t]
-def wasm_globaltype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_globaltype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_globaltype_vec_new_uninitialized(out, arg1)
 
 _wasm_globaltype_vec_new = dll.wasm_globaltype_vec_new
 _wasm_globaltype_vec_new.restype = None
 _wasm_globaltype_vec_new.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t, POINTER(POINTER(wasm_globaltype_t))]
-def wasm_globaltype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_globaltype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_globaltype_vec_new(out, arg1, arg2)
 
 _wasm_globaltype_vec_copy = dll.wasm_globaltype_vec_copy
 _wasm_globaltype_vec_copy.restype = None
 _wasm_globaltype_vec_copy.argtypes = [POINTER(wasm_globaltype_vec_t), POINTER(wasm_globaltype_vec_t)]
-def wasm_globaltype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_globaltype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_globaltype_vec_copy(out, arg1)
 
 _wasm_globaltype_vec_delete = dll.wasm_globaltype_vec_delete
 _wasm_globaltype_vec_delete.restype = None
 _wasm_globaltype_vec_delete.argtypes = [POINTER(wasm_globaltype_vec_t)]
-def wasm_globaltype_vec_delete(arg0: pointer) -> None:
+def wasm_globaltype_vec_delete(arg0: Any) -> None:
     return _wasm_globaltype_vec_delete(arg0)
 
 _wasm_globaltype_copy = dll.wasm_globaltype_copy
 _wasm_globaltype_copy.restype = POINTER(wasm_globaltype_t)
 _wasm_globaltype_copy.argtypes = [POINTER(wasm_globaltype_t)]
-def wasm_globaltype_copy(arg0: pointer) -> pointer:
+def wasm_globaltype_copy(arg0: Any) -> pointer:
     return _wasm_globaltype_copy(arg0)
 
 _wasm_globaltype_new = dll.wasm_globaltype_new
 _wasm_globaltype_new.restype = POINTER(wasm_globaltype_t)
 _wasm_globaltype_new.argtypes = [POINTER(wasm_valtype_t), wasm_mutability_t]
-def wasm_globaltype_new(arg0: pointer, arg1: wasm_mutability_t) -> pointer:
+def wasm_globaltype_new(arg0: Any, arg1: Any) -> pointer:
     return _wasm_globaltype_new(arg0, arg1)
 
 _wasm_globaltype_content = dll.wasm_globaltype_content
 _wasm_globaltype_content.restype = POINTER(wasm_valtype_t)
 _wasm_globaltype_content.argtypes = [POINTER(wasm_globaltype_t)]
-def wasm_globaltype_content(arg0: pointer) -> pointer:
+def wasm_globaltype_content(arg0: Any) -> pointer:
     return _wasm_globaltype_content(arg0)
 
 _wasm_globaltype_mutability = dll.wasm_globaltype_mutability
 _wasm_globaltype_mutability.restype = wasm_mutability_t
 _wasm_globaltype_mutability.argtypes = [POINTER(wasm_globaltype_t)]
-def wasm_globaltype_mutability(arg0: pointer) -> wasm_mutability_t:
+def wasm_globaltype_mutability(arg0: Any) -> wasm_mutability_t:
     return _wasm_globaltype_mutability(arg0)
 
 class wasm_tabletype_t(Structure):
@@ -314,7 +315,7 @@ class wasm_tabletype_t(Structure):
 _wasm_tabletype_delete = dll.wasm_tabletype_delete
 _wasm_tabletype_delete.restype = None
 _wasm_tabletype_delete.argtypes = [POINTER(wasm_tabletype_t)]
-def wasm_tabletype_delete(arg0: pointer) -> None:
+def wasm_tabletype_delete(arg0: Any) -> None:
     return _wasm_tabletype_delete(arg0)
 
 class wasm_tabletype_vec_t(Structure):
@@ -326,55 +327,55 @@ class wasm_tabletype_vec_t(Structure):
 _wasm_tabletype_vec_new_empty = dll.wasm_tabletype_vec_new_empty
 _wasm_tabletype_vec_new_empty.restype = None
 _wasm_tabletype_vec_new_empty.argtypes = [POINTER(wasm_tabletype_vec_t)]
-def wasm_tabletype_vec_new_empty(out: pointer) -> None:
+def wasm_tabletype_vec_new_empty(out: Any) -> None:
     return _wasm_tabletype_vec_new_empty(out)
 
 _wasm_tabletype_vec_new_uninitialized = dll.wasm_tabletype_vec_new_uninitialized
 _wasm_tabletype_vec_new_uninitialized.restype = None
 _wasm_tabletype_vec_new_uninitialized.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t]
-def wasm_tabletype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_tabletype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_tabletype_vec_new_uninitialized(out, arg1)
 
 _wasm_tabletype_vec_new = dll.wasm_tabletype_vec_new
 _wasm_tabletype_vec_new.restype = None
 _wasm_tabletype_vec_new.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t, POINTER(POINTER(wasm_tabletype_t))]
-def wasm_tabletype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_tabletype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_tabletype_vec_new(out, arg1, arg2)
 
 _wasm_tabletype_vec_copy = dll.wasm_tabletype_vec_copy
 _wasm_tabletype_vec_copy.restype = None
 _wasm_tabletype_vec_copy.argtypes = [POINTER(wasm_tabletype_vec_t), POINTER(wasm_tabletype_vec_t)]
-def wasm_tabletype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_tabletype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_tabletype_vec_copy(out, arg1)
 
 _wasm_tabletype_vec_delete = dll.wasm_tabletype_vec_delete
 _wasm_tabletype_vec_delete.restype = None
 _wasm_tabletype_vec_delete.argtypes = [POINTER(wasm_tabletype_vec_t)]
-def wasm_tabletype_vec_delete(arg0: pointer) -> None:
+def wasm_tabletype_vec_delete(arg0: Any) -> None:
     return _wasm_tabletype_vec_delete(arg0)
 
 _wasm_tabletype_copy = dll.wasm_tabletype_copy
 _wasm_tabletype_copy.restype = POINTER(wasm_tabletype_t)
 _wasm_tabletype_copy.argtypes = [POINTER(wasm_tabletype_t)]
-def wasm_tabletype_copy(arg0: pointer) -> pointer:
+def wasm_tabletype_copy(arg0: Any) -> pointer:
     return _wasm_tabletype_copy(arg0)
 
 _wasm_tabletype_new = dll.wasm_tabletype_new
 _wasm_tabletype_new.restype = POINTER(wasm_tabletype_t)
 _wasm_tabletype_new.argtypes = [POINTER(wasm_valtype_t), POINTER(wasm_limits_t)]
-def wasm_tabletype_new(arg0: pointer, arg1: pointer) -> pointer:
+def wasm_tabletype_new(arg0: Any, arg1: Any) -> pointer:
     return _wasm_tabletype_new(arg0, arg1)
 
 _wasm_tabletype_element = dll.wasm_tabletype_element
 _wasm_tabletype_element.restype = POINTER(wasm_valtype_t)
 _wasm_tabletype_element.argtypes = [POINTER(wasm_tabletype_t)]
-def wasm_tabletype_element(arg0: pointer) -> pointer:
+def wasm_tabletype_element(arg0: Any) -> pointer:
     return _wasm_tabletype_element(arg0)
 
 _wasm_tabletype_limits = dll.wasm_tabletype_limits
 _wasm_tabletype_limits.restype = POINTER(wasm_limits_t)
 _wasm_tabletype_limits.argtypes = [POINTER(wasm_tabletype_t)]
-def wasm_tabletype_limits(arg0: pointer) -> pointer:
+def wasm_tabletype_limits(arg0: Any) -> pointer:
     return _wasm_tabletype_limits(arg0)
 
 class wasm_memorytype_t(Structure):
@@ -383,7 +384,7 @@ class wasm_memorytype_t(Structure):
 _wasm_memorytype_delete = dll.wasm_memorytype_delete
 _wasm_memorytype_delete.restype = None
 _wasm_memorytype_delete.argtypes = [POINTER(wasm_memorytype_t)]
-def wasm_memorytype_delete(arg0: pointer) -> None:
+def wasm_memorytype_delete(arg0: Any) -> None:
     return _wasm_memorytype_delete(arg0)
 
 class wasm_memorytype_vec_t(Structure):
@@ -395,49 +396,49 @@ class wasm_memorytype_vec_t(Structure):
 _wasm_memorytype_vec_new_empty = dll.wasm_memorytype_vec_new_empty
 _wasm_memorytype_vec_new_empty.restype = None
 _wasm_memorytype_vec_new_empty.argtypes = [POINTER(wasm_memorytype_vec_t)]
-def wasm_memorytype_vec_new_empty(out: pointer) -> None:
+def wasm_memorytype_vec_new_empty(out: Any) -> None:
     return _wasm_memorytype_vec_new_empty(out)
 
 _wasm_memorytype_vec_new_uninitialized = dll.wasm_memorytype_vec_new_uninitialized
 _wasm_memorytype_vec_new_uninitialized.restype = None
 _wasm_memorytype_vec_new_uninitialized.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t]
-def wasm_memorytype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_memorytype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_memorytype_vec_new_uninitialized(out, arg1)
 
 _wasm_memorytype_vec_new = dll.wasm_memorytype_vec_new
 _wasm_memorytype_vec_new.restype = None
 _wasm_memorytype_vec_new.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t, POINTER(POINTER(wasm_memorytype_t))]
-def wasm_memorytype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_memorytype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_memorytype_vec_new(out, arg1, arg2)
 
 _wasm_memorytype_vec_copy = dll.wasm_memorytype_vec_copy
 _wasm_memorytype_vec_copy.restype = None
 _wasm_memorytype_vec_copy.argtypes = [POINTER(wasm_memorytype_vec_t), POINTER(wasm_memorytype_vec_t)]
-def wasm_memorytype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_memorytype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_memorytype_vec_copy(out, arg1)
 
 _wasm_memorytype_vec_delete = dll.wasm_memorytype_vec_delete
 _wasm_memorytype_vec_delete.restype = None
 _wasm_memorytype_vec_delete.argtypes = [POINTER(wasm_memorytype_vec_t)]
-def wasm_memorytype_vec_delete(arg0: pointer) -> None:
+def wasm_memorytype_vec_delete(arg0: Any) -> None:
     return _wasm_memorytype_vec_delete(arg0)
 
 _wasm_memorytype_copy = dll.wasm_memorytype_copy
 _wasm_memorytype_copy.restype = POINTER(wasm_memorytype_t)
 _wasm_memorytype_copy.argtypes = [POINTER(wasm_memorytype_t)]
-def wasm_memorytype_copy(arg0: pointer) -> pointer:
+def wasm_memorytype_copy(arg0: Any) -> pointer:
     return _wasm_memorytype_copy(arg0)
 
 _wasm_memorytype_new = dll.wasm_memorytype_new
 _wasm_memorytype_new.restype = POINTER(wasm_memorytype_t)
 _wasm_memorytype_new.argtypes = [POINTER(wasm_limits_t)]
-def wasm_memorytype_new(arg0: pointer) -> pointer:
+def wasm_memorytype_new(arg0: Any) -> pointer:
     return _wasm_memorytype_new(arg0)
 
 _wasm_memorytype_limits = dll.wasm_memorytype_limits
 _wasm_memorytype_limits.restype = POINTER(wasm_limits_t)
 _wasm_memorytype_limits.argtypes = [POINTER(wasm_memorytype_t)]
-def wasm_memorytype_limits(arg0: pointer) -> pointer:
+def wasm_memorytype_limits(arg0: Any) -> pointer:
     return _wasm_memorytype_limits(arg0)
 
 class wasm_externtype_t(Structure):
@@ -446,7 +447,7 @@ class wasm_externtype_t(Structure):
 _wasm_externtype_delete = dll.wasm_externtype_delete
 _wasm_externtype_delete.restype = None
 _wasm_externtype_delete.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_delete(arg0: pointer) -> None:
+def wasm_externtype_delete(arg0: Any) -> None:
     return _wasm_externtype_delete(arg0)
 
 class wasm_externtype_vec_t(Structure):
@@ -458,37 +459,37 @@ class wasm_externtype_vec_t(Structure):
 _wasm_externtype_vec_new_empty = dll.wasm_externtype_vec_new_empty
 _wasm_externtype_vec_new_empty.restype = None
 _wasm_externtype_vec_new_empty.argtypes = [POINTER(wasm_externtype_vec_t)]
-def wasm_externtype_vec_new_empty(out: pointer) -> None:
+def wasm_externtype_vec_new_empty(out: Any) -> None:
     return _wasm_externtype_vec_new_empty(out)
 
 _wasm_externtype_vec_new_uninitialized = dll.wasm_externtype_vec_new_uninitialized
 _wasm_externtype_vec_new_uninitialized.restype = None
 _wasm_externtype_vec_new_uninitialized.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t]
-def wasm_externtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_externtype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_externtype_vec_new_uninitialized(out, arg1)
 
 _wasm_externtype_vec_new = dll.wasm_externtype_vec_new
 _wasm_externtype_vec_new.restype = None
 _wasm_externtype_vec_new.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t, POINTER(POINTER(wasm_externtype_t))]
-def wasm_externtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_externtype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_externtype_vec_new(out, arg1, arg2)
 
 _wasm_externtype_vec_copy = dll.wasm_externtype_vec_copy
 _wasm_externtype_vec_copy.restype = None
 _wasm_externtype_vec_copy.argtypes = [POINTER(wasm_externtype_vec_t), POINTER(wasm_externtype_vec_t)]
-def wasm_externtype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_externtype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_externtype_vec_copy(out, arg1)
 
 _wasm_externtype_vec_delete = dll.wasm_externtype_vec_delete
 _wasm_externtype_vec_delete.restype = None
 _wasm_externtype_vec_delete.argtypes = [POINTER(wasm_externtype_vec_t)]
-def wasm_externtype_vec_delete(arg0: pointer) -> None:
+def wasm_externtype_vec_delete(arg0: Any) -> None:
     return _wasm_externtype_vec_delete(arg0)
 
 _wasm_externtype_copy = dll.wasm_externtype_copy
 _wasm_externtype_copy.restype = POINTER(wasm_externtype_t)
 _wasm_externtype_copy.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_copy(arg0: pointer) -> pointer:
+def wasm_externtype_copy(arg0: Any) -> pointer:
     return _wasm_externtype_copy(arg0)
 
 wasm_externkind_t = c_uint8
@@ -496,103 +497,103 @@ wasm_externkind_t = c_uint8
 _wasm_externtype_kind = dll.wasm_externtype_kind
 _wasm_externtype_kind.restype = wasm_externkind_t
 _wasm_externtype_kind.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_kind(arg0: pointer) -> wasm_externkind_t:
+def wasm_externtype_kind(arg0: Any) -> wasm_externkind_t:
     return _wasm_externtype_kind(arg0)
 
 _wasm_functype_as_externtype = dll.wasm_functype_as_externtype
 _wasm_functype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_functype_as_externtype.argtypes = [POINTER(wasm_functype_t)]
-def wasm_functype_as_externtype(arg0: pointer) -> pointer:
+def wasm_functype_as_externtype(arg0: Any) -> pointer:
     return _wasm_functype_as_externtype(arg0)
 
 _wasm_globaltype_as_externtype = dll.wasm_globaltype_as_externtype
 _wasm_globaltype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_globaltype_as_externtype.argtypes = [POINTER(wasm_globaltype_t)]
-def wasm_globaltype_as_externtype(arg0: pointer) -> pointer:
+def wasm_globaltype_as_externtype(arg0: Any) -> pointer:
     return _wasm_globaltype_as_externtype(arg0)
 
 _wasm_tabletype_as_externtype = dll.wasm_tabletype_as_externtype
 _wasm_tabletype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_tabletype_as_externtype.argtypes = [POINTER(wasm_tabletype_t)]
-def wasm_tabletype_as_externtype(arg0: pointer) -> pointer:
+def wasm_tabletype_as_externtype(arg0: Any) -> pointer:
     return _wasm_tabletype_as_externtype(arg0)
 
 _wasm_memorytype_as_externtype = dll.wasm_memorytype_as_externtype
 _wasm_memorytype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_memorytype_as_externtype.argtypes = [POINTER(wasm_memorytype_t)]
-def wasm_memorytype_as_externtype(arg0: pointer) -> pointer:
+def wasm_memorytype_as_externtype(arg0: Any) -> pointer:
     return _wasm_memorytype_as_externtype(arg0)
 
 _wasm_externtype_as_functype = dll.wasm_externtype_as_functype
 _wasm_externtype_as_functype.restype = POINTER(wasm_functype_t)
 _wasm_externtype_as_functype.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_functype(arg0: pointer) -> pointer:
+def wasm_externtype_as_functype(arg0: Any) -> pointer:
     return _wasm_externtype_as_functype(arg0)
 
 _wasm_externtype_as_globaltype = dll.wasm_externtype_as_globaltype
 _wasm_externtype_as_globaltype.restype = POINTER(wasm_globaltype_t)
 _wasm_externtype_as_globaltype.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_globaltype(arg0: pointer) -> pointer:
+def wasm_externtype_as_globaltype(arg0: Any) -> pointer:
     return _wasm_externtype_as_globaltype(arg0)
 
 _wasm_externtype_as_tabletype = dll.wasm_externtype_as_tabletype
 _wasm_externtype_as_tabletype.restype = POINTER(wasm_tabletype_t)
 _wasm_externtype_as_tabletype.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_tabletype(arg0: pointer) -> pointer:
+def wasm_externtype_as_tabletype(arg0: Any) -> pointer:
     return _wasm_externtype_as_tabletype(arg0)
 
 _wasm_externtype_as_memorytype = dll.wasm_externtype_as_memorytype
 _wasm_externtype_as_memorytype.restype = POINTER(wasm_memorytype_t)
 _wasm_externtype_as_memorytype.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_memorytype(arg0: pointer) -> pointer:
+def wasm_externtype_as_memorytype(arg0: Any) -> pointer:
     return _wasm_externtype_as_memorytype(arg0)
 
 _wasm_functype_as_externtype_const = dll.wasm_functype_as_externtype_const
 _wasm_functype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_functype_as_externtype_const.argtypes = [POINTER(wasm_functype_t)]
-def wasm_functype_as_externtype_const(arg0: pointer) -> pointer:
+def wasm_functype_as_externtype_const(arg0: Any) -> pointer:
     return _wasm_functype_as_externtype_const(arg0)
 
 _wasm_globaltype_as_externtype_const = dll.wasm_globaltype_as_externtype_const
 _wasm_globaltype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_globaltype_as_externtype_const.argtypes = [POINTER(wasm_globaltype_t)]
-def wasm_globaltype_as_externtype_const(arg0: pointer) -> pointer:
+def wasm_globaltype_as_externtype_const(arg0: Any) -> pointer:
     return _wasm_globaltype_as_externtype_const(arg0)
 
 _wasm_tabletype_as_externtype_const = dll.wasm_tabletype_as_externtype_const
 _wasm_tabletype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_tabletype_as_externtype_const.argtypes = [POINTER(wasm_tabletype_t)]
-def wasm_tabletype_as_externtype_const(arg0: pointer) -> pointer:
+def wasm_tabletype_as_externtype_const(arg0: Any) -> pointer:
     return _wasm_tabletype_as_externtype_const(arg0)
 
 _wasm_memorytype_as_externtype_const = dll.wasm_memorytype_as_externtype_const
 _wasm_memorytype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_memorytype_as_externtype_const.argtypes = [POINTER(wasm_memorytype_t)]
-def wasm_memorytype_as_externtype_const(arg0: pointer) -> pointer:
+def wasm_memorytype_as_externtype_const(arg0: Any) -> pointer:
     return _wasm_memorytype_as_externtype_const(arg0)
 
 _wasm_externtype_as_functype_const = dll.wasm_externtype_as_functype_const
 _wasm_externtype_as_functype_const.restype = POINTER(wasm_functype_t)
 _wasm_externtype_as_functype_const.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_functype_const(arg0: pointer) -> pointer:
+def wasm_externtype_as_functype_const(arg0: Any) -> pointer:
     return _wasm_externtype_as_functype_const(arg0)
 
 _wasm_externtype_as_globaltype_const = dll.wasm_externtype_as_globaltype_const
 _wasm_externtype_as_globaltype_const.restype = POINTER(wasm_globaltype_t)
 _wasm_externtype_as_globaltype_const.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_globaltype_const(arg0: pointer) -> pointer:
+def wasm_externtype_as_globaltype_const(arg0: Any) -> pointer:
     return _wasm_externtype_as_globaltype_const(arg0)
 
 _wasm_externtype_as_tabletype_const = dll.wasm_externtype_as_tabletype_const
 _wasm_externtype_as_tabletype_const.restype = POINTER(wasm_tabletype_t)
 _wasm_externtype_as_tabletype_const.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_tabletype_const(arg0: pointer) -> pointer:
+def wasm_externtype_as_tabletype_const(arg0: Any) -> pointer:
     return _wasm_externtype_as_tabletype_const(arg0)
 
 _wasm_externtype_as_memorytype_const = dll.wasm_externtype_as_memorytype_const
 _wasm_externtype_as_memorytype_const.restype = POINTER(wasm_memorytype_t)
 _wasm_externtype_as_memorytype_const.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_memorytype_const(arg0: pointer) -> pointer:
+def wasm_externtype_as_memorytype_const(arg0: Any) -> pointer:
     return _wasm_externtype_as_memorytype_const(arg0)
 
 class wasm_importtype_t(Structure):
@@ -601,7 +602,7 @@ class wasm_importtype_t(Structure):
 _wasm_importtype_delete = dll.wasm_importtype_delete
 _wasm_importtype_delete.restype = None
 _wasm_importtype_delete.argtypes = [POINTER(wasm_importtype_t)]
-def wasm_importtype_delete(arg0: pointer) -> None:
+def wasm_importtype_delete(arg0: Any) -> None:
     return _wasm_importtype_delete(arg0)
 
 class wasm_importtype_vec_t(Structure):
@@ -613,61 +614,61 @@ class wasm_importtype_vec_t(Structure):
 _wasm_importtype_vec_new_empty = dll.wasm_importtype_vec_new_empty
 _wasm_importtype_vec_new_empty.restype = None
 _wasm_importtype_vec_new_empty.argtypes = [POINTER(wasm_importtype_vec_t)]
-def wasm_importtype_vec_new_empty(out: pointer) -> None:
+def wasm_importtype_vec_new_empty(out: Any) -> None:
     return _wasm_importtype_vec_new_empty(out)
 
 _wasm_importtype_vec_new_uninitialized = dll.wasm_importtype_vec_new_uninitialized
 _wasm_importtype_vec_new_uninitialized.restype = None
 _wasm_importtype_vec_new_uninitialized.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t]
-def wasm_importtype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_importtype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_importtype_vec_new_uninitialized(out, arg1)
 
 _wasm_importtype_vec_new = dll.wasm_importtype_vec_new
 _wasm_importtype_vec_new.restype = None
 _wasm_importtype_vec_new.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t, POINTER(POINTER(wasm_importtype_t))]
-def wasm_importtype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_importtype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_importtype_vec_new(out, arg1, arg2)
 
 _wasm_importtype_vec_copy = dll.wasm_importtype_vec_copy
 _wasm_importtype_vec_copy.restype = None
 _wasm_importtype_vec_copy.argtypes = [POINTER(wasm_importtype_vec_t), POINTER(wasm_importtype_vec_t)]
-def wasm_importtype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_importtype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_importtype_vec_copy(out, arg1)
 
 _wasm_importtype_vec_delete = dll.wasm_importtype_vec_delete
 _wasm_importtype_vec_delete.restype = None
 _wasm_importtype_vec_delete.argtypes = [POINTER(wasm_importtype_vec_t)]
-def wasm_importtype_vec_delete(arg0: pointer) -> None:
+def wasm_importtype_vec_delete(arg0: Any) -> None:
     return _wasm_importtype_vec_delete(arg0)
 
 _wasm_importtype_copy = dll.wasm_importtype_copy
 _wasm_importtype_copy.restype = POINTER(wasm_importtype_t)
 _wasm_importtype_copy.argtypes = [POINTER(wasm_importtype_t)]
-def wasm_importtype_copy(arg0: pointer) -> pointer:
+def wasm_importtype_copy(arg0: Any) -> pointer:
     return _wasm_importtype_copy(arg0)
 
 _wasm_importtype_new = dll.wasm_importtype_new
 _wasm_importtype_new.restype = POINTER(wasm_importtype_t)
 _wasm_importtype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
-def wasm_importtype_new(module: pointer, name: pointer, arg2: pointer) -> pointer:
+def wasm_importtype_new(module: Any, name: Any, arg2: Any) -> pointer:
     return _wasm_importtype_new(module, name, arg2)
 
 _wasm_importtype_module = dll.wasm_importtype_module
 _wasm_importtype_module.restype = POINTER(wasm_name_t)
 _wasm_importtype_module.argtypes = [POINTER(wasm_importtype_t)]
-def wasm_importtype_module(arg0: pointer) -> pointer:
+def wasm_importtype_module(arg0: Any) -> pointer:
     return _wasm_importtype_module(arg0)
 
 _wasm_importtype_name = dll.wasm_importtype_name
 _wasm_importtype_name.restype = POINTER(wasm_name_t)
 _wasm_importtype_name.argtypes = [POINTER(wasm_importtype_t)]
-def wasm_importtype_name(arg0: pointer) -> pointer:
+def wasm_importtype_name(arg0: Any) -> pointer:
     return _wasm_importtype_name(arg0)
 
 _wasm_importtype_type = dll.wasm_importtype_type
 _wasm_importtype_type.restype = POINTER(wasm_externtype_t)
 _wasm_importtype_type.argtypes = [POINTER(wasm_importtype_t)]
-def wasm_importtype_type(arg0: pointer) -> pointer:
+def wasm_importtype_type(arg0: Any) -> pointer:
     return _wasm_importtype_type(arg0)
 
 class wasm_exporttype_t(Structure):
@@ -676,7 +677,7 @@ class wasm_exporttype_t(Structure):
 _wasm_exporttype_delete = dll.wasm_exporttype_delete
 _wasm_exporttype_delete.restype = None
 _wasm_exporttype_delete.argtypes = [POINTER(wasm_exporttype_t)]
-def wasm_exporttype_delete(arg0: pointer) -> None:
+def wasm_exporttype_delete(arg0: Any) -> None:
     return _wasm_exporttype_delete(arg0)
 
 class wasm_exporttype_vec_t(Structure):
@@ -688,55 +689,55 @@ class wasm_exporttype_vec_t(Structure):
 _wasm_exporttype_vec_new_empty = dll.wasm_exporttype_vec_new_empty
 _wasm_exporttype_vec_new_empty.restype = None
 _wasm_exporttype_vec_new_empty.argtypes = [POINTER(wasm_exporttype_vec_t)]
-def wasm_exporttype_vec_new_empty(out: pointer) -> None:
+def wasm_exporttype_vec_new_empty(out: Any) -> None:
     return _wasm_exporttype_vec_new_empty(out)
 
 _wasm_exporttype_vec_new_uninitialized = dll.wasm_exporttype_vec_new_uninitialized
 _wasm_exporttype_vec_new_uninitialized.restype = None
 _wasm_exporttype_vec_new_uninitialized.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t]
-def wasm_exporttype_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_exporttype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_exporttype_vec_new_uninitialized(out, arg1)
 
 _wasm_exporttype_vec_new = dll.wasm_exporttype_vec_new
 _wasm_exporttype_vec_new.restype = None
 _wasm_exporttype_vec_new.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t, POINTER(POINTER(wasm_exporttype_t))]
-def wasm_exporttype_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_exporttype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_exporttype_vec_new(out, arg1, arg2)
 
 _wasm_exporttype_vec_copy = dll.wasm_exporttype_vec_copy
 _wasm_exporttype_vec_copy.restype = None
 _wasm_exporttype_vec_copy.argtypes = [POINTER(wasm_exporttype_vec_t), POINTER(wasm_exporttype_vec_t)]
-def wasm_exporttype_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_exporttype_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_exporttype_vec_copy(out, arg1)
 
 _wasm_exporttype_vec_delete = dll.wasm_exporttype_vec_delete
 _wasm_exporttype_vec_delete.restype = None
 _wasm_exporttype_vec_delete.argtypes = [POINTER(wasm_exporttype_vec_t)]
-def wasm_exporttype_vec_delete(arg0: pointer) -> None:
+def wasm_exporttype_vec_delete(arg0: Any) -> None:
     return _wasm_exporttype_vec_delete(arg0)
 
 _wasm_exporttype_copy = dll.wasm_exporttype_copy
 _wasm_exporttype_copy.restype = POINTER(wasm_exporttype_t)
 _wasm_exporttype_copy.argtypes = [POINTER(wasm_exporttype_t)]
-def wasm_exporttype_copy(arg0: pointer) -> pointer:
+def wasm_exporttype_copy(arg0: Any) -> pointer:
     return _wasm_exporttype_copy(arg0)
 
 _wasm_exporttype_new = dll.wasm_exporttype_new
 _wasm_exporttype_new.restype = POINTER(wasm_exporttype_t)
 _wasm_exporttype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
-def wasm_exporttype_new(arg0: pointer, arg1: pointer) -> pointer:
+def wasm_exporttype_new(arg0: Any, arg1: Any) -> pointer:
     return _wasm_exporttype_new(arg0, arg1)
 
 _wasm_exporttype_name = dll.wasm_exporttype_name
 _wasm_exporttype_name.restype = POINTER(wasm_name_t)
 _wasm_exporttype_name.argtypes = [POINTER(wasm_exporttype_t)]
-def wasm_exporttype_name(arg0: pointer) -> pointer:
+def wasm_exporttype_name(arg0: Any) -> pointer:
     return _wasm_exporttype_name(arg0)
 
 _wasm_exporttype_type = dll.wasm_exporttype_type
 _wasm_exporttype_type.restype = POINTER(wasm_externtype_t)
 _wasm_exporttype_type.argtypes = [POINTER(wasm_exporttype_t)]
-def wasm_exporttype_type(arg0: pointer) -> pointer:
+def wasm_exporttype_type(arg0: Any) -> pointer:
     return _wasm_exporttype_type(arg0)
 
 class wasm_ref_t(Structure):
@@ -745,13 +746,13 @@ class wasm_ref_t(Structure):
 _wasm_val_delete = dll.wasm_val_delete
 _wasm_val_delete.restype = None
 _wasm_val_delete.argtypes = [POINTER(wasm_val_t)]
-def wasm_val_delete(v: pointer) -> None:
+def wasm_val_delete(v: Any) -> None:
     return _wasm_val_delete(v)
 
 _wasm_val_copy = dll.wasm_val_copy
 _wasm_val_copy.restype = None
 _wasm_val_copy.argtypes = [POINTER(wasm_val_t), POINTER(wasm_val_t)]
-def wasm_val_copy(out: pointer, arg1: pointer) -> None:
+def wasm_val_copy(out: Any, arg1: Any) -> None:
     return _wasm_val_copy(out, arg1)
 
 class wasm_val_vec_t(Structure):
@@ -763,67 +764,67 @@ class wasm_val_vec_t(Structure):
 _wasm_val_vec_new_empty = dll.wasm_val_vec_new_empty
 _wasm_val_vec_new_empty.restype = None
 _wasm_val_vec_new_empty.argtypes = [POINTER(wasm_val_vec_t)]
-def wasm_val_vec_new_empty(out: pointer) -> None:
+def wasm_val_vec_new_empty(out: Any) -> None:
     return _wasm_val_vec_new_empty(out)
 
 _wasm_val_vec_new_uninitialized = dll.wasm_val_vec_new_uninitialized
 _wasm_val_vec_new_uninitialized.restype = None
 _wasm_val_vec_new_uninitialized.argtypes = [POINTER(wasm_val_vec_t), c_size_t]
-def wasm_val_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_val_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_val_vec_new_uninitialized(out, arg1)
 
 _wasm_val_vec_new = dll.wasm_val_vec_new
 _wasm_val_vec_new.restype = None
 _wasm_val_vec_new.argtypes = [POINTER(wasm_val_vec_t), c_size_t, POINTER(wasm_val_t)]
-def wasm_val_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_val_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_val_vec_new(out, arg1, arg2)
 
 _wasm_val_vec_copy = dll.wasm_val_vec_copy
 _wasm_val_vec_copy.restype = None
 _wasm_val_vec_copy.argtypes = [POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t)]
-def wasm_val_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_val_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_val_vec_copy(out, arg1)
 
 _wasm_val_vec_delete = dll.wasm_val_vec_delete
 _wasm_val_vec_delete.restype = None
 _wasm_val_vec_delete.argtypes = [POINTER(wasm_val_vec_t)]
-def wasm_val_vec_delete(arg0: pointer) -> None:
+def wasm_val_vec_delete(arg0: Any) -> None:
     return _wasm_val_vec_delete(arg0)
 
 _wasm_ref_delete = dll.wasm_ref_delete
 _wasm_ref_delete.restype = None
 _wasm_ref_delete.argtypes = [POINTER(wasm_ref_t)]
-def wasm_ref_delete(arg0: pointer) -> None:
+def wasm_ref_delete(arg0: Any) -> None:
     return _wasm_ref_delete(arg0)
 
 _wasm_ref_copy = dll.wasm_ref_copy
 _wasm_ref_copy.restype = POINTER(wasm_ref_t)
 _wasm_ref_copy.argtypes = [POINTER(wasm_ref_t)]
-def wasm_ref_copy(arg0: pointer) -> pointer:
+def wasm_ref_copy(arg0: Any) -> pointer:
     return _wasm_ref_copy(arg0)
 
 _wasm_ref_same = dll.wasm_ref_same
 _wasm_ref_same.restype = c_bool
 _wasm_ref_same.argtypes = [POINTER(wasm_ref_t), POINTER(wasm_ref_t)]
-def wasm_ref_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_ref_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_ref_same(arg0, arg1)
 
 _wasm_ref_get_host_info = dll.wasm_ref_get_host_info
 _wasm_ref_get_host_info.restype = c_void_p
 _wasm_ref_get_host_info.argtypes = [POINTER(wasm_ref_t)]
-def wasm_ref_get_host_info(arg0: pointer) -> pointer:
+def wasm_ref_get_host_info(arg0: Any) -> pointer:
     return _wasm_ref_get_host_info(arg0)
 
 _wasm_ref_set_host_info = dll.wasm_ref_set_host_info
 _wasm_ref_set_host_info.restype = None
 _wasm_ref_set_host_info.argtypes = [POINTER(wasm_ref_t), c_void_p]
-def wasm_ref_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_ref_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_ref_set_host_info(arg0, arg1)
 
 _wasm_ref_set_host_info_with_finalizer = dll.wasm_ref_set_host_info_with_finalizer
 _wasm_ref_set_host_info_with_finalizer.restype = None
 _wasm_ref_set_host_info_with_finalizer.argtypes = [POINTER(wasm_ref_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_ref_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_ref_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_ref_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 class wasm_frame_t(Structure):
@@ -832,7 +833,7 @@ class wasm_frame_t(Structure):
 _wasm_frame_delete = dll.wasm_frame_delete
 _wasm_frame_delete.restype = None
 _wasm_frame_delete.argtypes = [POINTER(wasm_frame_t)]
-def wasm_frame_delete(arg0: pointer) -> None:
+def wasm_frame_delete(arg0: Any) -> None:
     return _wasm_frame_delete(arg0)
 
 class wasm_frame_vec_t(Structure):
@@ -844,49 +845,49 @@ class wasm_frame_vec_t(Structure):
 _wasm_frame_vec_new_empty = dll.wasm_frame_vec_new_empty
 _wasm_frame_vec_new_empty.restype = None
 _wasm_frame_vec_new_empty.argtypes = [POINTER(wasm_frame_vec_t)]
-def wasm_frame_vec_new_empty(out: pointer) -> None:
+def wasm_frame_vec_new_empty(out: Any) -> None:
     return _wasm_frame_vec_new_empty(out)
 
 _wasm_frame_vec_new_uninitialized = dll.wasm_frame_vec_new_uninitialized
 _wasm_frame_vec_new_uninitialized.restype = None
 _wasm_frame_vec_new_uninitialized.argtypes = [POINTER(wasm_frame_vec_t), c_size_t]
-def wasm_frame_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_frame_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_frame_vec_new_uninitialized(out, arg1)
 
 _wasm_frame_vec_new = dll.wasm_frame_vec_new
 _wasm_frame_vec_new.restype = None
 _wasm_frame_vec_new.argtypes = [POINTER(wasm_frame_vec_t), c_size_t, POINTER(POINTER(wasm_frame_t))]
-def wasm_frame_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_frame_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_frame_vec_new(out, arg1, arg2)
 
 _wasm_frame_vec_copy = dll.wasm_frame_vec_copy
 _wasm_frame_vec_copy.restype = None
 _wasm_frame_vec_copy.argtypes = [POINTER(wasm_frame_vec_t), POINTER(wasm_frame_vec_t)]
-def wasm_frame_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_frame_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_frame_vec_copy(out, arg1)
 
 _wasm_frame_vec_delete = dll.wasm_frame_vec_delete
 _wasm_frame_vec_delete.restype = None
 _wasm_frame_vec_delete.argtypes = [POINTER(wasm_frame_vec_t)]
-def wasm_frame_vec_delete(arg0: pointer) -> None:
+def wasm_frame_vec_delete(arg0: Any) -> None:
     return _wasm_frame_vec_delete(arg0)
 
 _wasm_frame_func_index = dll.wasm_frame_func_index
 _wasm_frame_func_index.restype = c_uint32
 _wasm_frame_func_index.argtypes = [POINTER(wasm_frame_t)]
-def wasm_frame_func_index(arg0: pointer) -> c_uint32:
+def wasm_frame_func_index(arg0: Any) -> int:
     return _wasm_frame_func_index(arg0)
 
 _wasm_frame_func_offset = dll.wasm_frame_func_offset
 _wasm_frame_func_offset.restype = c_size_t
 _wasm_frame_func_offset.argtypes = [POINTER(wasm_frame_t)]
-def wasm_frame_func_offset(arg0: pointer) -> c_size_t:
+def wasm_frame_func_offset(arg0: Any) -> int:
     return _wasm_frame_func_offset(arg0)
 
 _wasm_frame_module_offset = dll.wasm_frame_module_offset
 _wasm_frame_module_offset.restype = c_size_t
 _wasm_frame_module_offset.argtypes = [POINTER(wasm_frame_t)]
-def wasm_frame_module_offset(arg0: pointer) -> c_size_t:
+def wasm_frame_module_offset(arg0: Any) -> int:
     return _wasm_frame_module_offset(arg0)
 
 wasm_message_t = wasm_name_t
@@ -897,73 +898,73 @@ class wasm_trap_t(Structure):
 _wasm_trap_delete = dll.wasm_trap_delete
 _wasm_trap_delete.restype = None
 _wasm_trap_delete.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_delete(arg0: pointer) -> None:
+def wasm_trap_delete(arg0: Any) -> None:
     return _wasm_trap_delete(arg0)
 
 _wasm_trap_copy = dll.wasm_trap_copy
 _wasm_trap_copy.restype = POINTER(wasm_trap_t)
 _wasm_trap_copy.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_copy(arg0: pointer) -> pointer:
+def wasm_trap_copy(arg0: Any) -> pointer:
     return _wasm_trap_copy(arg0)
 
 _wasm_trap_same = dll.wasm_trap_same
 _wasm_trap_same.restype = c_bool
 _wasm_trap_same.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_trap_t)]
-def wasm_trap_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_trap_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_trap_same(arg0, arg1)
 
 _wasm_trap_get_host_info = dll.wasm_trap_get_host_info
 _wasm_trap_get_host_info.restype = c_void_p
 _wasm_trap_get_host_info.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_get_host_info(arg0: pointer) -> pointer:
+def wasm_trap_get_host_info(arg0: Any) -> pointer:
     return _wasm_trap_get_host_info(arg0)
 
 _wasm_trap_set_host_info = dll.wasm_trap_set_host_info
 _wasm_trap_set_host_info.restype = None
 _wasm_trap_set_host_info.argtypes = [POINTER(wasm_trap_t), c_void_p]
-def wasm_trap_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_trap_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_trap_set_host_info(arg0, arg1)
 
 _wasm_trap_set_host_info_with_finalizer = dll.wasm_trap_set_host_info_with_finalizer
 _wasm_trap_set_host_info_with_finalizer.restype = None
 _wasm_trap_set_host_info_with_finalizer.argtypes = [POINTER(wasm_trap_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_trap_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_trap_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_trap_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_trap_as_ref = dll.wasm_trap_as_ref
 _wasm_trap_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_trap_as_ref.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_as_ref(arg0: pointer) -> pointer:
+def wasm_trap_as_ref(arg0: Any) -> pointer:
     return _wasm_trap_as_ref(arg0)
 
 _wasm_trap_as_ref_const = dll.wasm_trap_as_ref_const
 _wasm_trap_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_trap_as_ref_const.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_as_ref_const(arg0: pointer) -> pointer:
+def wasm_trap_as_ref_const(arg0: Any) -> pointer:
     return _wasm_trap_as_ref_const(arg0)
 
 _wasm_trap_new = dll.wasm_trap_new
 _wasm_trap_new.restype = POINTER(wasm_trap_t)
 _wasm_trap_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_message_t)]
-def wasm_trap_new(store: pointer, arg1: pointer) -> pointer:
+def wasm_trap_new(store: Any, arg1: Any) -> pointer:
     return _wasm_trap_new(store, arg1)
 
 _wasm_trap_message = dll.wasm_trap_message
 _wasm_trap_message.restype = None
 _wasm_trap_message.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_message_t)]
-def wasm_trap_message(arg0: pointer, out: pointer) -> None:
+def wasm_trap_message(arg0: Any, out: Any) -> None:
     return _wasm_trap_message(arg0, out)
 
 _wasm_trap_origin = dll.wasm_trap_origin
 _wasm_trap_origin.restype = POINTER(wasm_frame_t)
 _wasm_trap_origin.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_origin(arg0: pointer) -> pointer:
+def wasm_trap_origin(arg0: Any) -> pointer:
     return _wasm_trap_origin(arg0)
 
 _wasm_trap_trace = dll.wasm_trap_trace
 _wasm_trap_trace.restype = None
 _wasm_trap_trace.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_frame_vec_t)]
-def wasm_trap_trace(arg0: pointer, out: pointer) -> None:
+def wasm_trap_trace(arg0: Any, out: Any) -> None:
     return _wasm_trap_trace(arg0, out)
 
 class wasm_foreign_t(Structure):
@@ -975,49 +976,49 @@ class wasm_module_t(Structure):
 _wasm_module_delete = dll.wasm_module_delete
 _wasm_module_delete.restype = None
 _wasm_module_delete.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_delete(arg0: pointer) -> None:
+def wasm_module_delete(arg0: Any) -> None:
     return _wasm_module_delete(arg0)
 
 _wasm_module_copy = dll.wasm_module_copy
 _wasm_module_copy.restype = POINTER(wasm_module_t)
 _wasm_module_copy.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_copy(arg0: pointer) -> pointer:
+def wasm_module_copy(arg0: Any) -> pointer:
     return _wasm_module_copy(arg0)
 
 _wasm_module_same = dll.wasm_module_same
 _wasm_module_same.restype = c_bool
 _wasm_module_same.argtypes = [POINTER(wasm_module_t), POINTER(wasm_module_t)]
-def wasm_module_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_module_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_module_same(arg0, arg1)
 
 _wasm_module_get_host_info = dll.wasm_module_get_host_info
 _wasm_module_get_host_info.restype = c_void_p
 _wasm_module_get_host_info.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_get_host_info(arg0: pointer) -> pointer:
+def wasm_module_get_host_info(arg0: Any) -> pointer:
     return _wasm_module_get_host_info(arg0)
 
 _wasm_module_set_host_info = dll.wasm_module_set_host_info
 _wasm_module_set_host_info.restype = None
 _wasm_module_set_host_info.argtypes = [POINTER(wasm_module_t), c_void_p]
-def wasm_module_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_module_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_module_set_host_info(arg0, arg1)
 
 _wasm_module_set_host_info_with_finalizer = dll.wasm_module_set_host_info_with_finalizer
 _wasm_module_set_host_info_with_finalizer.restype = None
 _wasm_module_set_host_info_with_finalizer.argtypes = [POINTER(wasm_module_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_module_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_module_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_module_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_module_as_ref = dll.wasm_module_as_ref
 _wasm_module_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_module_as_ref.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_as_ref(arg0: pointer) -> pointer:
+def wasm_module_as_ref(arg0: Any) -> pointer:
     return _wasm_module_as_ref(arg0)
 
 _wasm_module_as_ref_const = dll.wasm_module_as_ref_const
 _wasm_module_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_module_as_ref_const.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_as_ref_const(arg0: pointer) -> pointer:
+def wasm_module_as_ref_const(arg0: Any) -> pointer:
     return _wasm_module_as_ref_const(arg0)
 
 class wasm_shared_module_t(Structure):
@@ -1026,43 +1027,43 @@ class wasm_shared_module_t(Structure):
 _wasm_shared_module_delete = dll.wasm_shared_module_delete
 _wasm_shared_module_delete.restype = None
 _wasm_shared_module_delete.argtypes = [POINTER(wasm_shared_module_t)]
-def wasm_shared_module_delete(arg0: pointer) -> None:
+def wasm_shared_module_delete(arg0: Any) -> None:
     return _wasm_shared_module_delete(arg0)
 
 _wasm_module_share = dll.wasm_module_share
 _wasm_module_share.restype = POINTER(wasm_shared_module_t)
 _wasm_module_share.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_share(arg0: pointer) -> pointer:
+def wasm_module_share(arg0: Any) -> pointer:
     return _wasm_module_share(arg0)
 
 _wasm_module_obtain = dll.wasm_module_obtain
 _wasm_module_obtain.restype = POINTER(wasm_module_t)
 _wasm_module_obtain.argtypes = [POINTER(wasm_store_t), POINTER(wasm_shared_module_t)]
-def wasm_module_obtain(arg0: pointer, arg1: pointer) -> pointer:
+def wasm_module_obtain(arg0: Any, arg1: Any) -> pointer:
     return _wasm_module_obtain(arg0, arg1)
 
 _wasm_module_new = dll.wasm_module_new
 _wasm_module_new.restype = POINTER(wasm_module_t)
 _wasm_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
-def wasm_module_new(arg0: pointer, binary: pointer) -> pointer:
+def wasm_module_new(arg0: Any, binary: Any) -> pointer:
     return _wasm_module_new(arg0, binary)
 
 _wasm_module_validate = dll.wasm_module_validate
 _wasm_module_validate.restype = c_bool
 _wasm_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
-def wasm_module_validate(arg0: pointer, binary: pointer) -> c_bool:
+def wasm_module_validate(arg0: Any, binary: Any) -> c_bool:
     return _wasm_module_validate(arg0, binary)
 
 _wasm_module_imports = dll.wasm_module_imports
 _wasm_module_imports.restype = None
 _wasm_module_imports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_importtype_vec_t)]
-def wasm_module_imports(arg0: pointer, out: pointer) -> None:
+def wasm_module_imports(arg0: Any, out: Any) -> None:
     return _wasm_module_imports(arg0, out)
 
 _wasm_module_exports = dll.wasm_module_exports
 _wasm_module_exports.restype = None
 _wasm_module_exports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_exporttype_vec_t)]
-def wasm_module_exports(arg0: pointer, out: pointer) -> None:
+def wasm_module_exports(arg0: Any, out: Any) -> None:
     return _wasm_module_exports(arg0, out)
 
 class wasm_func_t(Structure):
@@ -1071,49 +1072,49 @@ class wasm_func_t(Structure):
 _wasm_func_delete = dll.wasm_func_delete
 _wasm_func_delete.restype = None
 _wasm_func_delete.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_delete(arg0: pointer) -> None:
+def wasm_func_delete(arg0: Any) -> None:
     return _wasm_func_delete(arg0)
 
 _wasm_func_copy = dll.wasm_func_copy
 _wasm_func_copy.restype = POINTER(wasm_func_t)
 _wasm_func_copy.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_copy(arg0: pointer) -> pointer:
+def wasm_func_copy(arg0: Any) -> pointer:
     return _wasm_func_copy(arg0)
 
 _wasm_func_same = dll.wasm_func_same
 _wasm_func_same.restype = c_bool
 _wasm_func_same.argtypes = [POINTER(wasm_func_t), POINTER(wasm_func_t)]
-def wasm_func_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_func_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_func_same(arg0, arg1)
 
 _wasm_func_get_host_info = dll.wasm_func_get_host_info
 _wasm_func_get_host_info.restype = c_void_p
 _wasm_func_get_host_info.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_get_host_info(arg0: pointer) -> pointer:
+def wasm_func_get_host_info(arg0: Any) -> pointer:
     return _wasm_func_get_host_info(arg0)
 
 _wasm_func_set_host_info = dll.wasm_func_set_host_info
 _wasm_func_set_host_info.restype = None
 _wasm_func_set_host_info.argtypes = [POINTER(wasm_func_t), c_void_p]
-def wasm_func_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_func_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_func_set_host_info(arg0, arg1)
 
 _wasm_func_set_host_info_with_finalizer = dll.wasm_func_set_host_info_with_finalizer
 _wasm_func_set_host_info_with_finalizer.restype = None
 _wasm_func_set_host_info_with_finalizer.argtypes = [POINTER(wasm_func_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_func_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_func_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_func_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_func_as_ref = dll.wasm_func_as_ref
 _wasm_func_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_func_as_ref.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_as_ref(arg0: pointer) -> pointer:
+def wasm_func_as_ref(arg0: Any) -> pointer:
     return _wasm_func_as_ref(arg0)
 
 _wasm_func_as_ref_const = dll.wasm_func_as_ref_const
 _wasm_func_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_func_as_ref_const.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_as_ref_const(arg0: pointer) -> pointer:
+def wasm_func_as_ref_const(arg0: Any) -> pointer:
     return _wasm_func_as_ref_const(arg0)
 
 wasm_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasm_val_t), POINTER(wasm_val_t))
@@ -1123,37 +1124,37 @@ wasm_func_callback_with_env_t = CFUNCTYPE(c_size_t, c_void_p, POINTER(wasm_val_t
 _wasm_func_new = dll.wasm_func_new
 _wasm_func_new.restype = POINTER(wasm_func_t)
 _wasm_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_t]
-def wasm_func_new(arg0: pointer, arg1: pointer, arg2: pointer) -> pointer:
+def wasm_func_new(arg0: Any, arg1: Any, arg2: Any) -> pointer:
     return _wasm_func_new(arg0, arg1, arg2)
 
 _wasm_func_new_with_env = dll.wasm_func_new_with_env
 _wasm_func_new_with_env.restype = POINTER(wasm_func_t)
 _wasm_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_func_new_with_env(arg0: pointer, type: pointer, arg2: pointer, env: pointer, finalizer: pointer) -> pointer:
+def wasm_func_new_with_env(arg0: Any, type: Any, arg2: Any, env: Any, finalizer: Any) -> pointer:
     return _wasm_func_new_with_env(arg0, type, arg2, env, finalizer)
 
 _wasm_func_type = dll.wasm_func_type
 _wasm_func_type.restype = POINTER(wasm_functype_t)
 _wasm_func_type.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_type(arg0: pointer) -> pointer:
+def wasm_func_type(arg0: Any) -> pointer:
     return _wasm_func_type(arg0)
 
 _wasm_func_param_arity = dll.wasm_func_param_arity
 _wasm_func_param_arity.restype = c_size_t
 _wasm_func_param_arity.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_param_arity(arg0: pointer) -> c_size_t:
+def wasm_func_param_arity(arg0: Any) -> int:
     return _wasm_func_param_arity(arg0)
 
 _wasm_func_result_arity = dll.wasm_func_result_arity
 _wasm_func_result_arity.restype = c_size_t
 _wasm_func_result_arity.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_result_arity(arg0: pointer) -> c_size_t:
+def wasm_func_result_arity(arg0: Any) -> int:
     return _wasm_func_result_arity(arg0)
 
 _wasm_func_call = dll.wasm_func_call
 _wasm_func_call.restype = POINTER(wasm_trap_t)
 _wasm_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), POINTER(wasm_val_t)]
-def wasm_func_call(arg0: pointer, args: pointer, results: pointer) -> pointer:
+def wasm_func_call(arg0: Any, args: Any, results: Any) -> pointer:
     return _wasm_func_call(arg0, args, results)
 
 class wasm_global_t(Structure):
@@ -1162,73 +1163,73 @@ class wasm_global_t(Structure):
 _wasm_global_delete = dll.wasm_global_delete
 _wasm_global_delete.restype = None
 _wasm_global_delete.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_delete(arg0: pointer) -> None:
+def wasm_global_delete(arg0: Any) -> None:
     return _wasm_global_delete(arg0)
 
 _wasm_global_copy = dll.wasm_global_copy
 _wasm_global_copy.restype = POINTER(wasm_global_t)
 _wasm_global_copy.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_copy(arg0: pointer) -> pointer:
+def wasm_global_copy(arg0: Any) -> pointer:
     return _wasm_global_copy(arg0)
 
 _wasm_global_same = dll.wasm_global_same
 _wasm_global_same.restype = c_bool
 _wasm_global_same.argtypes = [POINTER(wasm_global_t), POINTER(wasm_global_t)]
-def wasm_global_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_global_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_global_same(arg0, arg1)
 
 _wasm_global_get_host_info = dll.wasm_global_get_host_info
 _wasm_global_get_host_info.restype = c_void_p
 _wasm_global_get_host_info.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_get_host_info(arg0: pointer) -> pointer:
+def wasm_global_get_host_info(arg0: Any) -> pointer:
     return _wasm_global_get_host_info(arg0)
 
 _wasm_global_set_host_info = dll.wasm_global_set_host_info
 _wasm_global_set_host_info.restype = None
 _wasm_global_set_host_info.argtypes = [POINTER(wasm_global_t), c_void_p]
-def wasm_global_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_global_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_global_set_host_info(arg0, arg1)
 
 _wasm_global_set_host_info_with_finalizer = dll.wasm_global_set_host_info_with_finalizer
 _wasm_global_set_host_info_with_finalizer.restype = None
 _wasm_global_set_host_info_with_finalizer.argtypes = [POINTER(wasm_global_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_global_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_global_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_global_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_global_as_ref = dll.wasm_global_as_ref
 _wasm_global_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_global_as_ref.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_as_ref(arg0: pointer) -> pointer:
+def wasm_global_as_ref(arg0: Any) -> pointer:
     return _wasm_global_as_ref(arg0)
 
 _wasm_global_as_ref_const = dll.wasm_global_as_ref_const
 _wasm_global_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_global_as_ref_const.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_as_ref_const(arg0: pointer) -> pointer:
+def wasm_global_as_ref_const(arg0: Any) -> pointer:
     return _wasm_global_as_ref_const(arg0)
 
 _wasm_global_new = dll.wasm_global_new
 _wasm_global_new.restype = POINTER(wasm_global_t)
 _wasm_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t)]
-def wasm_global_new(arg0: pointer, arg1: pointer, arg2: pointer) -> pointer:
+def wasm_global_new(arg0: Any, arg1: Any, arg2: Any) -> pointer:
     return _wasm_global_new(arg0, arg1, arg2)
 
 _wasm_global_type = dll.wasm_global_type
 _wasm_global_type.restype = POINTER(wasm_globaltype_t)
 _wasm_global_type.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_type(arg0: pointer) -> pointer:
+def wasm_global_type(arg0: Any) -> pointer:
     return _wasm_global_type(arg0)
 
 _wasm_global_get = dll.wasm_global_get
 _wasm_global_get.restype = None
 _wasm_global_get.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
-def wasm_global_get(arg0: pointer, out: pointer) -> None:
+def wasm_global_get(arg0: Any, out: Any) -> None:
     return _wasm_global_get(arg0, out)
 
 _wasm_global_set = dll.wasm_global_set
 _wasm_global_set.restype = None
 _wasm_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
-def wasm_global_set(arg0: pointer, arg1: pointer) -> None:
+def wasm_global_set(arg0: Any, arg1: Any) -> None:
     return _wasm_global_set(arg0, arg1)
 
 class wasm_table_t(Structure):
@@ -1237,49 +1238,49 @@ class wasm_table_t(Structure):
 _wasm_table_delete = dll.wasm_table_delete
 _wasm_table_delete.restype = None
 _wasm_table_delete.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_delete(arg0: pointer) -> None:
+def wasm_table_delete(arg0: Any) -> None:
     return _wasm_table_delete(arg0)
 
 _wasm_table_copy = dll.wasm_table_copy
 _wasm_table_copy.restype = POINTER(wasm_table_t)
 _wasm_table_copy.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_copy(arg0: pointer) -> pointer:
+def wasm_table_copy(arg0: Any) -> pointer:
     return _wasm_table_copy(arg0)
 
 _wasm_table_same = dll.wasm_table_same
 _wasm_table_same.restype = c_bool
 _wasm_table_same.argtypes = [POINTER(wasm_table_t), POINTER(wasm_table_t)]
-def wasm_table_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_table_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_table_same(arg0, arg1)
 
 _wasm_table_get_host_info = dll.wasm_table_get_host_info
 _wasm_table_get_host_info.restype = c_void_p
 _wasm_table_get_host_info.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_get_host_info(arg0: pointer) -> pointer:
+def wasm_table_get_host_info(arg0: Any) -> pointer:
     return _wasm_table_get_host_info(arg0)
 
 _wasm_table_set_host_info = dll.wasm_table_set_host_info
 _wasm_table_set_host_info.restype = None
 _wasm_table_set_host_info.argtypes = [POINTER(wasm_table_t), c_void_p]
-def wasm_table_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_table_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_table_set_host_info(arg0, arg1)
 
 _wasm_table_set_host_info_with_finalizer = dll.wasm_table_set_host_info_with_finalizer
 _wasm_table_set_host_info_with_finalizer.restype = None
 _wasm_table_set_host_info_with_finalizer.argtypes = [POINTER(wasm_table_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_table_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_table_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_table_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_table_as_ref = dll.wasm_table_as_ref
 _wasm_table_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_table_as_ref.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_as_ref(arg0: pointer) -> pointer:
+def wasm_table_as_ref(arg0: Any) -> pointer:
     return _wasm_table_as_ref(arg0)
 
 _wasm_table_as_ref_const = dll.wasm_table_as_ref_const
 _wasm_table_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_table_as_ref_const.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_as_ref_const(arg0: pointer) -> pointer:
+def wasm_table_as_ref_const(arg0: Any) -> pointer:
     return _wasm_table_as_ref_const(arg0)
 
 wasm_table_size_t = c_uint32
@@ -1287,37 +1288,37 @@ wasm_table_size_t = c_uint32
 _wasm_table_new = dll.wasm_table_new
 _wasm_table_new.restype = POINTER(wasm_table_t)
 _wasm_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_ref_t)]
-def wasm_table_new(arg0: pointer, arg1: pointer, init: pointer) -> pointer:
+def wasm_table_new(arg0: Any, arg1: Any, init: Any) -> pointer:
     return _wasm_table_new(arg0, arg1, init)
 
 _wasm_table_type = dll.wasm_table_type
 _wasm_table_type.restype = POINTER(wasm_tabletype_t)
 _wasm_table_type.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_type(arg0: pointer) -> pointer:
+def wasm_table_type(arg0: Any) -> pointer:
     return _wasm_table_type(arg0)
 
 _wasm_table_get = dll.wasm_table_get
 _wasm_table_get.restype = POINTER(wasm_ref_t)
 _wasm_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t]
-def wasm_table_get(arg0: pointer, index: wasm_table_size_t) -> pointer:
+def wasm_table_get(arg0: Any, index: Any) -> pointer:
     return _wasm_table_get(arg0, index)
 
 _wasm_table_set = dll.wasm_table_set
 _wasm_table_set.restype = c_bool
 _wasm_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
-def wasm_table_set(arg0: pointer, index: wasm_table_size_t, arg2: pointer) -> c_bool:
+def wasm_table_set(arg0: Any, index: Any, arg2: Any) -> c_bool:
     return _wasm_table_set(arg0, index, arg2)
 
 _wasm_table_size = dll.wasm_table_size
 _wasm_table_size.restype = wasm_table_size_t
 _wasm_table_size.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_size(arg0: pointer) -> wasm_table_size_t:
+def wasm_table_size(arg0: Any) -> int:
     return _wasm_table_size(arg0)
 
 _wasm_table_grow = dll.wasm_table_grow
 _wasm_table_grow.restype = c_bool
 _wasm_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
-def wasm_table_grow(arg0: pointer, delta: wasm_table_size_t, init: pointer) -> c_bool:
+def wasm_table_grow(arg0: Any, delta: Any, init: Any) -> c_bool:
     return _wasm_table_grow(arg0, delta, init)
 
 class wasm_memory_t(Structure):
@@ -1326,49 +1327,49 @@ class wasm_memory_t(Structure):
 _wasm_memory_delete = dll.wasm_memory_delete
 _wasm_memory_delete.restype = None
 _wasm_memory_delete.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_delete(arg0: pointer) -> None:
+def wasm_memory_delete(arg0: Any) -> None:
     return _wasm_memory_delete(arg0)
 
 _wasm_memory_copy = dll.wasm_memory_copy
 _wasm_memory_copy.restype = POINTER(wasm_memory_t)
 _wasm_memory_copy.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_copy(arg0: pointer) -> pointer:
+def wasm_memory_copy(arg0: Any) -> pointer:
     return _wasm_memory_copy(arg0)
 
 _wasm_memory_same = dll.wasm_memory_same
 _wasm_memory_same.restype = c_bool
 _wasm_memory_same.argtypes = [POINTER(wasm_memory_t), POINTER(wasm_memory_t)]
-def wasm_memory_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_memory_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_memory_same(arg0, arg1)
 
 _wasm_memory_get_host_info = dll.wasm_memory_get_host_info
 _wasm_memory_get_host_info.restype = c_void_p
 _wasm_memory_get_host_info.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_get_host_info(arg0: pointer) -> pointer:
+def wasm_memory_get_host_info(arg0: Any) -> pointer:
     return _wasm_memory_get_host_info(arg0)
 
 _wasm_memory_set_host_info = dll.wasm_memory_set_host_info
 _wasm_memory_set_host_info.restype = None
 _wasm_memory_set_host_info.argtypes = [POINTER(wasm_memory_t), c_void_p]
-def wasm_memory_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_memory_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_memory_set_host_info(arg0, arg1)
 
 _wasm_memory_set_host_info_with_finalizer = dll.wasm_memory_set_host_info_with_finalizer
 _wasm_memory_set_host_info_with_finalizer.restype = None
 _wasm_memory_set_host_info_with_finalizer.argtypes = [POINTER(wasm_memory_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_memory_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_memory_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_memory_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_memory_as_ref = dll.wasm_memory_as_ref
 _wasm_memory_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_memory_as_ref.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_as_ref(arg0: pointer) -> pointer:
+def wasm_memory_as_ref(arg0: Any) -> pointer:
     return _wasm_memory_as_ref(arg0)
 
 _wasm_memory_as_ref_const = dll.wasm_memory_as_ref_const
 _wasm_memory_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_memory_as_ref_const.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_as_ref_const(arg0: pointer) -> pointer:
+def wasm_memory_as_ref_const(arg0: Any) -> pointer:
     return _wasm_memory_as_ref_const(arg0)
 
 wasm_memory_pages_t = c_uint32
@@ -1376,37 +1377,37 @@ wasm_memory_pages_t = c_uint32
 _wasm_memory_new = dll.wasm_memory_new
 _wasm_memory_new.restype = POINTER(wasm_memory_t)
 _wasm_memory_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_memorytype_t)]
-def wasm_memory_new(arg0: pointer, arg1: pointer) -> pointer:
+def wasm_memory_new(arg0: Any, arg1: Any) -> pointer:
     return _wasm_memory_new(arg0, arg1)
 
 _wasm_memory_type = dll.wasm_memory_type
 _wasm_memory_type.restype = POINTER(wasm_memorytype_t)
 _wasm_memory_type.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_type(arg0: pointer) -> pointer:
+def wasm_memory_type(arg0: Any) -> pointer:
     return _wasm_memory_type(arg0)
 
 _wasm_memory_data = dll.wasm_memory_data
 _wasm_memory_data.restype = POINTER(c_ubyte)
 _wasm_memory_data.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_data(arg0: pointer) -> pointer:
+def wasm_memory_data(arg0: Any) -> pointer:
     return _wasm_memory_data(arg0)
 
 _wasm_memory_data_size = dll.wasm_memory_data_size
 _wasm_memory_data_size.restype = c_size_t
 _wasm_memory_data_size.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_data_size(arg0: pointer) -> c_size_t:
+def wasm_memory_data_size(arg0: Any) -> int:
     return _wasm_memory_data_size(arg0)
 
 _wasm_memory_size = dll.wasm_memory_size
 _wasm_memory_size.restype = wasm_memory_pages_t
 _wasm_memory_size.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_size(arg0: pointer) -> wasm_memory_pages_t:
+def wasm_memory_size(arg0: Any) -> int:
     return _wasm_memory_size(arg0)
 
 _wasm_memory_grow = dll.wasm_memory_grow
 _wasm_memory_grow.restype = c_bool
 _wasm_memory_grow.argtypes = [POINTER(wasm_memory_t), wasm_memory_pages_t]
-def wasm_memory_grow(arg0: pointer, delta: wasm_memory_pages_t) -> c_bool:
+def wasm_memory_grow(arg0: Any, delta: Any) -> c_bool:
     return _wasm_memory_grow(arg0, delta)
 
 class wasm_extern_t(Structure):
@@ -1415,49 +1416,49 @@ class wasm_extern_t(Structure):
 _wasm_extern_delete = dll.wasm_extern_delete
 _wasm_extern_delete.restype = None
 _wasm_extern_delete.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_delete(arg0: pointer) -> None:
+def wasm_extern_delete(arg0: Any) -> None:
     return _wasm_extern_delete(arg0)
 
 _wasm_extern_copy = dll.wasm_extern_copy
 _wasm_extern_copy.restype = POINTER(wasm_extern_t)
 _wasm_extern_copy.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_copy(arg0: pointer) -> pointer:
+def wasm_extern_copy(arg0: Any) -> pointer:
     return _wasm_extern_copy(arg0)
 
 _wasm_extern_same = dll.wasm_extern_same
 _wasm_extern_same.restype = c_bool
 _wasm_extern_same.argtypes = [POINTER(wasm_extern_t), POINTER(wasm_extern_t)]
-def wasm_extern_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_extern_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_extern_same(arg0, arg1)
 
 _wasm_extern_get_host_info = dll.wasm_extern_get_host_info
 _wasm_extern_get_host_info.restype = c_void_p
 _wasm_extern_get_host_info.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_get_host_info(arg0: pointer) -> pointer:
+def wasm_extern_get_host_info(arg0: Any) -> pointer:
     return _wasm_extern_get_host_info(arg0)
 
 _wasm_extern_set_host_info = dll.wasm_extern_set_host_info
 _wasm_extern_set_host_info.restype = None
 _wasm_extern_set_host_info.argtypes = [POINTER(wasm_extern_t), c_void_p]
-def wasm_extern_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_extern_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_extern_set_host_info(arg0, arg1)
 
 _wasm_extern_set_host_info_with_finalizer = dll.wasm_extern_set_host_info_with_finalizer
 _wasm_extern_set_host_info_with_finalizer.restype = None
 _wasm_extern_set_host_info_with_finalizer.argtypes = [POINTER(wasm_extern_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_extern_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_extern_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_extern_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_extern_as_ref = dll.wasm_extern_as_ref
 _wasm_extern_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_extern_as_ref.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_ref(arg0: pointer) -> pointer:
+def wasm_extern_as_ref(arg0: Any) -> pointer:
     return _wasm_extern_as_ref(arg0)
 
 _wasm_extern_as_ref_const = dll.wasm_extern_as_ref_const
 _wasm_extern_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_extern_as_ref_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_ref_const(arg0: pointer) -> pointer:
+def wasm_extern_as_ref_const(arg0: Any) -> pointer:
     return _wasm_extern_as_ref_const(arg0)
 
 class wasm_extern_vec_t(Structure):
@@ -1469,115 +1470,115 @@ class wasm_extern_vec_t(Structure):
 _wasm_extern_vec_new_empty = dll.wasm_extern_vec_new_empty
 _wasm_extern_vec_new_empty.restype = None
 _wasm_extern_vec_new_empty.argtypes = [POINTER(wasm_extern_vec_t)]
-def wasm_extern_vec_new_empty(out: pointer) -> None:
+def wasm_extern_vec_new_empty(out: Any) -> None:
     return _wasm_extern_vec_new_empty(out)
 
 _wasm_extern_vec_new_uninitialized = dll.wasm_extern_vec_new_uninitialized
 _wasm_extern_vec_new_uninitialized.restype = None
 _wasm_extern_vec_new_uninitialized.argtypes = [POINTER(wasm_extern_vec_t), c_size_t]
-def wasm_extern_vec_new_uninitialized(out: pointer, arg1: c_size_t) -> None:
+def wasm_extern_vec_new_uninitialized(out: Any, arg1: Any) -> None:
     return _wasm_extern_vec_new_uninitialized(out, arg1)
 
 _wasm_extern_vec_new = dll.wasm_extern_vec_new
 _wasm_extern_vec_new.restype = None
 _wasm_extern_vec_new.argtypes = [POINTER(wasm_extern_vec_t), c_size_t, POINTER(POINTER(wasm_extern_t))]
-def wasm_extern_vec_new(out: pointer, arg1: c_size_t, arg2: pointer) -> None:
+def wasm_extern_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_extern_vec_new(out, arg1, arg2)
 
 _wasm_extern_vec_copy = dll.wasm_extern_vec_copy
 _wasm_extern_vec_copy.restype = None
 _wasm_extern_vec_copy.argtypes = [POINTER(wasm_extern_vec_t), POINTER(wasm_extern_vec_t)]
-def wasm_extern_vec_copy(out: pointer, arg1: pointer) -> None:
+def wasm_extern_vec_copy(out: Any, arg1: Any) -> None:
     return _wasm_extern_vec_copy(out, arg1)
 
 _wasm_extern_vec_delete = dll.wasm_extern_vec_delete
 _wasm_extern_vec_delete.restype = None
 _wasm_extern_vec_delete.argtypes = [POINTER(wasm_extern_vec_t)]
-def wasm_extern_vec_delete(arg0: pointer) -> None:
+def wasm_extern_vec_delete(arg0: Any) -> None:
     return _wasm_extern_vec_delete(arg0)
 
 _wasm_extern_kind = dll.wasm_extern_kind
 _wasm_extern_kind.restype = wasm_externkind_t
 _wasm_extern_kind.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_kind(arg0: pointer) -> wasm_externkind_t:
+def wasm_extern_kind(arg0: Any) -> wasm_externkind_t:
     return _wasm_extern_kind(arg0)
 
 _wasm_extern_type = dll.wasm_extern_type
 _wasm_extern_type.restype = POINTER(wasm_externtype_t)
 _wasm_extern_type.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_type(arg0: pointer) -> pointer:
+def wasm_extern_type(arg0: Any) -> pointer:
     return _wasm_extern_type(arg0)
 
 _wasm_func_as_extern = dll.wasm_func_as_extern
 _wasm_func_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_func_as_extern.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_as_extern(arg0: pointer) -> pointer:
+def wasm_func_as_extern(arg0: Any) -> pointer:
     return _wasm_func_as_extern(arg0)
 
 _wasm_global_as_extern = dll.wasm_global_as_extern
 _wasm_global_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_global_as_extern.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_as_extern(arg0: pointer) -> pointer:
+def wasm_global_as_extern(arg0: Any) -> pointer:
     return _wasm_global_as_extern(arg0)
 
 _wasm_table_as_extern = dll.wasm_table_as_extern
 _wasm_table_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_table_as_extern.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_as_extern(arg0: pointer) -> pointer:
+def wasm_table_as_extern(arg0: Any) -> pointer:
     return _wasm_table_as_extern(arg0)
 
 _wasm_memory_as_extern = dll.wasm_memory_as_extern
 _wasm_memory_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_memory_as_extern.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_as_extern(arg0: pointer) -> pointer:
+def wasm_memory_as_extern(arg0: Any) -> pointer:
     return _wasm_memory_as_extern(arg0)
 
 _wasm_extern_as_func = dll.wasm_extern_as_func
 _wasm_extern_as_func.restype = POINTER(wasm_func_t)
 _wasm_extern_as_func.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_func(arg0: pointer) -> pointer:
+def wasm_extern_as_func(arg0: Any) -> pointer:
     return _wasm_extern_as_func(arg0)
 
 _wasm_extern_as_global = dll.wasm_extern_as_global
 _wasm_extern_as_global.restype = POINTER(wasm_global_t)
 _wasm_extern_as_global.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_global(arg0: pointer) -> pointer:
+def wasm_extern_as_global(arg0: Any) -> pointer:
     return _wasm_extern_as_global(arg0)
 
 _wasm_extern_as_table = dll.wasm_extern_as_table
 _wasm_extern_as_table.restype = POINTER(wasm_table_t)
 _wasm_extern_as_table.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_table(arg0: pointer) -> pointer:
+def wasm_extern_as_table(arg0: Any) -> pointer:
     return _wasm_extern_as_table(arg0)
 
 _wasm_extern_as_memory = dll.wasm_extern_as_memory
 _wasm_extern_as_memory.restype = POINTER(wasm_memory_t)
 _wasm_extern_as_memory.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_memory(arg0: pointer) -> pointer:
+def wasm_extern_as_memory(arg0: Any) -> pointer:
     return _wasm_extern_as_memory(arg0)
 
 _wasm_extern_as_func_const = dll.wasm_extern_as_func_const
 _wasm_extern_as_func_const.restype = POINTER(wasm_func_t)
 _wasm_extern_as_func_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_func_const(arg0: pointer) -> pointer:
+def wasm_extern_as_func_const(arg0: Any) -> pointer:
     return _wasm_extern_as_func_const(arg0)
 
 _wasm_extern_as_global_const = dll.wasm_extern_as_global_const
 _wasm_extern_as_global_const.restype = POINTER(wasm_global_t)
 _wasm_extern_as_global_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_global_const(arg0: pointer) -> pointer:
+def wasm_extern_as_global_const(arg0: Any) -> pointer:
     return _wasm_extern_as_global_const(arg0)
 
 _wasm_extern_as_table_const = dll.wasm_extern_as_table_const
 _wasm_extern_as_table_const.restype = POINTER(wasm_table_t)
 _wasm_extern_as_table_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_table_const(arg0: pointer) -> pointer:
+def wasm_extern_as_table_const(arg0: Any) -> pointer:
     return _wasm_extern_as_table_const(arg0)
 
 _wasm_extern_as_memory_const = dll.wasm_extern_as_memory_const
 _wasm_extern_as_memory_const.restype = POINTER(wasm_memory_t)
 _wasm_extern_as_memory_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_memory_const(arg0: pointer) -> pointer:
+def wasm_extern_as_memory_const(arg0: Any) -> pointer:
     return _wasm_extern_as_memory_const(arg0)
 
 class wasm_instance_t(Structure):
@@ -1586,61 +1587,61 @@ class wasm_instance_t(Structure):
 _wasm_instance_delete = dll.wasm_instance_delete
 _wasm_instance_delete.restype = None
 _wasm_instance_delete.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_delete(arg0: pointer) -> None:
+def wasm_instance_delete(arg0: Any) -> None:
     return _wasm_instance_delete(arg0)
 
 _wasm_instance_copy = dll.wasm_instance_copy
 _wasm_instance_copy.restype = POINTER(wasm_instance_t)
 _wasm_instance_copy.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_copy(arg0: pointer) -> pointer:
+def wasm_instance_copy(arg0: Any) -> pointer:
     return _wasm_instance_copy(arg0)
 
 _wasm_instance_same = dll.wasm_instance_same
 _wasm_instance_same.restype = c_bool
 _wasm_instance_same.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_instance_t)]
-def wasm_instance_same(arg0: pointer, arg1: pointer) -> c_bool:
+def wasm_instance_same(arg0: Any, arg1: Any) -> c_bool:
     return _wasm_instance_same(arg0, arg1)
 
 _wasm_instance_get_host_info = dll.wasm_instance_get_host_info
 _wasm_instance_get_host_info.restype = c_void_p
 _wasm_instance_get_host_info.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_get_host_info(arg0: pointer) -> pointer:
+def wasm_instance_get_host_info(arg0: Any) -> pointer:
     return _wasm_instance_get_host_info(arg0)
 
 _wasm_instance_set_host_info = dll.wasm_instance_set_host_info
 _wasm_instance_set_host_info.restype = None
 _wasm_instance_set_host_info.argtypes = [POINTER(wasm_instance_t), c_void_p]
-def wasm_instance_set_host_info(arg0: pointer, arg1: pointer) -> None:
+def wasm_instance_set_host_info(arg0: Any, arg1: Any) -> None:
     return _wasm_instance_set_host_info(arg0, arg1)
 
 _wasm_instance_set_host_info_with_finalizer = dll.wasm_instance_set_host_info_with_finalizer
 _wasm_instance_set_host_info_with_finalizer.restype = None
 _wasm_instance_set_host_info_with_finalizer.argtypes = [POINTER(wasm_instance_t), c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasm_instance_set_host_info_with_finalizer(arg0: pointer, arg1: pointer, arg2: pointer) -> None:
+def wasm_instance_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
     return _wasm_instance_set_host_info_with_finalizer(arg0, arg1, arg2)
 
 _wasm_instance_as_ref = dll.wasm_instance_as_ref
 _wasm_instance_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_instance_as_ref.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_as_ref(arg0: pointer) -> pointer:
+def wasm_instance_as_ref(arg0: Any) -> pointer:
     return _wasm_instance_as_ref(arg0)
 
 _wasm_instance_as_ref_const = dll.wasm_instance_as_ref_const
 _wasm_instance_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_instance_as_ref_const.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_as_ref_const(arg0: pointer) -> pointer:
+def wasm_instance_as_ref_const(arg0: Any) -> pointer:
     return _wasm_instance_as_ref_const(arg0)
 
 _wasm_instance_new = dll.wasm_instance_new
 _wasm_instance_new.restype = POINTER(wasm_instance_t)
 _wasm_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), POINTER(POINTER(wasm_trap_t))]
-def wasm_instance_new(arg0: pointer, arg1: pointer, imports: pointer, arg3: pointer) -> pointer:
+def wasm_instance_new(arg0: Any, arg1: Any, imports: Any, arg3: Any) -> pointer:
     return _wasm_instance_new(arg0, arg1, imports, arg3)
 
 _wasm_instance_exports = dll.wasm_instance_exports
 _wasm_instance_exports.restype = None
 _wasm_instance_exports.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_extern_vec_t)]
-def wasm_instance_exports(arg0: pointer, out: pointer) -> None:
+def wasm_instance_exports(arg0: Any, out: Any) -> None:
     return _wasm_instance_exports(arg0, out)
 
 class wasi_config_t(Structure):
@@ -1649,7 +1650,7 @@ class wasi_config_t(Structure):
 _wasi_config_delete = dll.wasi_config_delete
 _wasi_config_delete.restype = None
 _wasi_config_delete.argtypes = [POINTER(wasi_config_t)]
-def wasi_config_delete(arg0: pointer) -> None:
+def wasi_config_delete(arg0: Any) -> None:
     return _wasi_config_delete(arg0)
 
 _wasi_config_new = dll.wasi_config_new
@@ -1661,67 +1662,67 @@ def wasi_config_new() -> pointer:
 _wasi_config_set_argv = dll.wasi_config_set_argv
 _wasi_config_set_argv.restype = None
 _wasi_config_set_argv.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char))]
-def wasi_config_set_argv(config: pointer, argc: c_int, argv: pointer) -> None:
+def wasi_config_set_argv(config: Any, argc: Any, argv: Any) -> None:
     return _wasi_config_set_argv(config, argc, argv)
 
 _wasi_config_inherit_argv = dll.wasi_config_inherit_argv
 _wasi_config_inherit_argv.restype = None
 _wasi_config_inherit_argv.argtypes = [POINTER(wasi_config_t)]
-def wasi_config_inherit_argv(config: pointer) -> None:
+def wasi_config_inherit_argv(config: Any) -> None:
     return _wasi_config_inherit_argv(config)
 
 _wasi_config_set_env = dll.wasi_config_set_env
 _wasi_config_set_env.restype = None
 _wasi_config_set_env.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char)), POINTER(POINTER(c_char))]
-def wasi_config_set_env(config: pointer, envc: c_int, names: pointer, values: pointer) -> None:
+def wasi_config_set_env(config: Any, envc: Any, names: Any, values: Any) -> None:
     return _wasi_config_set_env(config, envc, names, values)
 
 _wasi_config_inherit_env = dll.wasi_config_inherit_env
 _wasi_config_inherit_env.restype = None
 _wasi_config_inherit_env.argtypes = [POINTER(wasi_config_t)]
-def wasi_config_inherit_env(config: pointer) -> None:
+def wasi_config_inherit_env(config: Any) -> None:
     return _wasi_config_inherit_env(config)
 
 _wasi_config_set_stdin_file = dll.wasi_config_set_stdin_file
 _wasi_config_set_stdin_file.restype = c_bool
 _wasi_config_set_stdin_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
-def wasi_config_set_stdin_file(config: pointer, path: pointer) -> c_bool:
+def wasi_config_set_stdin_file(config: Any, path: Any) -> c_bool:
     return _wasi_config_set_stdin_file(config, path)
 
 _wasi_config_inherit_stdin = dll.wasi_config_inherit_stdin
 _wasi_config_inherit_stdin.restype = None
 _wasi_config_inherit_stdin.argtypes = [POINTER(wasi_config_t)]
-def wasi_config_inherit_stdin(config: pointer) -> None:
+def wasi_config_inherit_stdin(config: Any) -> None:
     return _wasi_config_inherit_stdin(config)
 
 _wasi_config_set_stdout_file = dll.wasi_config_set_stdout_file
 _wasi_config_set_stdout_file.restype = c_bool
 _wasi_config_set_stdout_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
-def wasi_config_set_stdout_file(config: pointer, path: pointer) -> c_bool:
+def wasi_config_set_stdout_file(config: Any, path: Any) -> c_bool:
     return _wasi_config_set_stdout_file(config, path)
 
 _wasi_config_inherit_stdout = dll.wasi_config_inherit_stdout
 _wasi_config_inherit_stdout.restype = None
 _wasi_config_inherit_stdout.argtypes = [POINTER(wasi_config_t)]
-def wasi_config_inherit_stdout(config: pointer) -> None:
+def wasi_config_inherit_stdout(config: Any) -> None:
     return _wasi_config_inherit_stdout(config)
 
 _wasi_config_set_stderr_file = dll.wasi_config_set_stderr_file
 _wasi_config_set_stderr_file.restype = c_bool
 _wasi_config_set_stderr_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
-def wasi_config_set_stderr_file(config: pointer, path: pointer) -> c_bool:
+def wasi_config_set_stderr_file(config: Any, path: Any) -> c_bool:
     return _wasi_config_set_stderr_file(config, path)
 
 _wasi_config_inherit_stderr = dll.wasi_config_inherit_stderr
 _wasi_config_inherit_stderr.restype = None
 _wasi_config_inherit_stderr.argtypes = [POINTER(wasi_config_t)]
-def wasi_config_inherit_stderr(config: pointer) -> None:
+def wasi_config_inherit_stderr(config: Any) -> None:
     return _wasi_config_inherit_stderr(config)
 
 _wasi_config_preopen_dir = dll.wasi_config_preopen_dir
 _wasi_config_preopen_dir.restype = c_bool
 _wasi_config_preopen_dir.argtypes = [POINTER(wasi_config_t), POINTER(c_char), POINTER(c_char)]
-def wasi_config_preopen_dir(config: pointer, path: pointer, guest_path: pointer) -> c_bool:
+def wasi_config_preopen_dir(config: Any, path: Any, guest_path: Any) -> c_bool:
     return _wasi_config_preopen_dir(config, path, guest_path)
 
 class wasi_instance_t(Structure):
@@ -1730,19 +1731,19 @@ class wasi_instance_t(Structure):
 _wasi_instance_delete = dll.wasi_instance_delete
 _wasi_instance_delete.restype = None
 _wasi_instance_delete.argtypes = [POINTER(wasi_instance_t)]
-def wasi_instance_delete(arg0: pointer) -> None:
+def wasi_instance_delete(arg0: Any) -> None:
     return _wasi_instance_delete(arg0)
 
 _wasi_instance_new = dll.wasi_instance_new
 _wasi_instance_new.restype = POINTER(wasi_instance_t)
 _wasi_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(c_char), POINTER(wasi_config_t), POINTER(POINTER(wasm_trap_t))]
-def wasi_instance_new(store: pointer, name: pointer, config: pointer, trap: pointer) -> pointer:
+def wasi_instance_new(store: Any, name: Any, config: Any, trap: Any) -> pointer:
     return _wasi_instance_new(store, name, config, trap)
 
 _wasi_instance_bind_import = dll.wasi_instance_bind_import
 _wasi_instance_bind_import.restype = POINTER(wasm_extern_t)
 _wasi_instance_bind_import.argtypes = [POINTER(wasi_instance_t), POINTER(wasm_importtype_t)]
-def wasi_instance_bind_import(instance: pointer, arg1: pointer) -> pointer:
+def wasi_instance_bind_import(instance: Any, arg1: Any) -> pointer:
     return _wasi_instance_bind_import(instance, arg1)
 
 class wasmtime_error_t(Structure):
@@ -1751,13 +1752,13 @@ class wasmtime_error_t(Structure):
 _wasmtime_error_delete = dll.wasmtime_error_delete
 _wasmtime_error_delete.restype = None
 _wasmtime_error_delete.argtypes = [POINTER(wasmtime_error_t)]
-def wasmtime_error_delete(arg0: pointer) -> None:
+def wasmtime_error_delete(arg0: Any) -> None:
     return _wasmtime_error_delete(arg0)
 
 _wasmtime_error_message = dll.wasmtime_error_message
 _wasmtime_error_message.restype = None
 _wasmtime_error_message.argtypes = [POINTER(wasmtime_error_t), POINTER(wasm_name_t)]
-def wasmtime_error_message(error: pointer, message: pointer) -> None:
+def wasmtime_error_message(error: Any, message: Any) -> None:
     return _wasmtime_error_message(error, message)
 
 wasmtime_strategy_t = c_uint8
@@ -1769,103 +1770,103 @@ wasmtime_profiling_strategy_t = c_uint8
 _wasmtime_config_debug_info_set = dll.wasmtime_config_debug_info_set
 _wasmtime_config_debug_info_set.restype = None
 _wasmtime_config_debug_info_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_debug_info_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_debug_info_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_debug_info_set(arg0, arg1)
 
 _wasmtime_config_interruptable_set = dll.wasmtime_config_interruptable_set
 _wasmtime_config_interruptable_set.restype = None
 _wasmtime_config_interruptable_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_interruptable_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_interruptable_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_interruptable_set(arg0, arg1)
 
 _wasmtime_config_max_wasm_stack_set = dll.wasmtime_config_max_wasm_stack_set
 _wasmtime_config_max_wasm_stack_set.restype = None
 _wasmtime_config_max_wasm_stack_set.argtypes = [POINTER(wasm_config_t), c_size_t]
-def wasmtime_config_max_wasm_stack_set(arg0: pointer, arg1: c_size_t) -> None:
+def wasmtime_config_max_wasm_stack_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_max_wasm_stack_set(arg0, arg1)
 
 _wasmtime_config_wasm_threads_set = dll.wasmtime_config_wasm_threads_set
 _wasmtime_config_wasm_threads_set.restype = None
 _wasmtime_config_wasm_threads_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_wasm_threads_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_wasm_threads_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_wasm_threads_set(arg0, arg1)
 
 _wasmtime_config_wasm_reference_types_set = dll.wasmtime_config_wasm_reference_types_set
 _wasmtime_config_wasm_reference_types_set.restype = None
 _wasmtime_config_wasm_reference_types_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_wasm_reference_types_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_wasm_reference_types_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_wasm_reference_types_set(arg0, arg1)
 
 _wasmtime_config_wasm_simd_set = dll.wasmtime_config_wasm_simd_set
 _wasmtime_config_wasm_simd_set.restype = None
 _wasmtime_config_wasm_simd_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_wasm_simd_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_wasm_simd_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_wasm_simd_set(arg0, arg1)
 
 _wasmtime_config_wasm_bulk_memory_set = dll.wasmtime_config_wasm_bulk_memory_set
 _wasmtime_config_wasm_bulk_memory_set.restype = None
 _wasmtime_config_wasm_bulk_memory_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_wasm_bulk_memory_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_wasm_bulk_memory_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_wasm_bulk_memory_set(arg0, arg1)
 
 _wasmtime_config_wasm_multi_value_set = dll.wasmtime_config_wasm_multi_value_set
 _wasmtime_config_wasm_multi_value_set.restype = None
 _wasmtime_config_wasm_multi_value_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_wasm_multi_value_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_wasm_multi_value_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_wasm_multi_value_set(arg0, arg1)
 
 _wasmtime_config_strategy_set = dll.wasmtime_config_strategy_set
 _wasmtime_config_strategy_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_config_strategy_set.argtypes = [POINTER(wasm_config_t), wasmtime_strategy_t]
-def wasmtime_config_strategy_set(arg0: pointer, arg1: wasmtime_strategy_t) -> pointer:
+def wasmtime_config_strategy_set(arg0: Any, arg1: Any) -> pointer:
     return _wasmtime_config_strategy_set(arg0, arg1)
 
 _wasmtime_config_cranelift_debug_verifier_set = dll.wasmtime_config_cranelift_debug_verifier_set
 _wasmtime_config_cranelift_debug_verifier_set.restype = None
 _wasmtime_config_cranelift_debug_verifier_set.argtypes = [POINTER(wasm_config_t), c_bool]
-def wasmtime_config_cranelift_debug_verifier_set(arg0: pointer, arg1: c_bool) -> None:
+def wasmtime_config_cranelift_debug_verifier_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_cranelift_debug_verifier_set(arg0, arg1)
 
 _wasmtime_config_cranelift_opt_level_set = dll.wasmtime_config_cranelift_opt_level_set
 _wasmtime_config_cranelift_opt_level_set.restype = None
 _wasmtime_config_cranelift_opt_level_set.argtypes = [POINTER(wasm_config_t), wasmtime_opt_level_t]
-def wasmtime_config_cranelift_opt_level_set(arg0: pointer, arg1: wasmtime_opt_level_t) -> None:
+def wasmtime_config_cranelift_opt_level_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_cranelift_opt_level_set(arg0, arg1)
 
 _wasmtime_config_profiler_set = dll.wasmtime_config_profiler_set
 _wasmtime_config_profiler_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_config_profiler_set.argtypes = [POINTER(wasm_config_t), wasmtime_profiling_strategy_t]
-def wasmtime_config_profiler_set(arg0: pointer, arg1: wasmtime_profiling_strategy_t) -> pointer:
+def wasmtime_config_profiler_set(arg0: Any, arg1: Any) -> pointer:
     return _wasmtime_config_profiler_set(arg0, arg1)
 
 _wasmtime_config_static_memory_maximum_size_set = dll.wasmtime_config_static_memory_maximum_size_set
 _wasmtime_config_static_memory_maximum_size_set.restype = None
 _wasmtime_config_static_memory_maximum_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
-def wasmtime_config_static_memory_maximum_size_set(arg0: pointer, arg1: c_uint64) -> None:
+def wasmtime_config_static_memory_maximum_size_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_static_memory_maximum_size_set(arg0, arg1)
 
 _wasmtime_config_static_memory_guard_size_set = dll.wasmtime_config_static_memory_guard_size_set
 _wasmtime_config_static_memory_guard_size_set.restype = None
 _wasmtime_config_static_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
-def wasmtime_config_static_memory_guard_size_set(arg0: pointer, arg1: c_uint64) -> None:
+def wasmtime_config_static_memory_guard_size_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_static_memory_guard_size_set(arg0, arg1)
 
 _wasmtime_config_dynamic_memory_guard_size_set = dll.wasmtime_config_dynamic_memory_guard_size_set
 _wasmtime_config_dynamic_memory_guard_size_set.restype = None
 _wasmtime_config_dynamic_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
-def wasmtime_config_dynamic_memory_guard_size_set(arg0: pointer, arg1: c_uint64) -> None:
+def wasmtime_config_dynamic_memory_guard_size_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_dynamic_memory_guard_size_set(arg0, arg1)
 
 _wasmtime_config_cache_config_load = dll.wasmtime_config_cache_config_load
 _wasmtime_config_cache_config_load.restype = POINTER(wasmtime_error_t)
 _wasmtime_config_cache_config_load.argtypes = [POINTER(wasm_config_t), POINTER(c_char)]
-def wasmtime_config_cache_config_load(arg0: pointer, arg1: pointer) -> pointer:
+def wasmtime_config_cache_config_load(arg0: Any, arg1: Any) -> pointer:
     return _wasmtime_config_cache_config_load(arg0, arg1)
 
 _wasmtime_wat2wasm = dll.wasmtime_wat2wasm
 _wasmtime_wat2wasm.restype = POINTER(wasmtime_error_t)
 _wasmtime_wat2wasm.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
-def wasmtime_wat2wasm(wat: pointer, ret: pointer) -> pointer:
+def wasmtime_wat2wasm(wat: Any, ret: Any) -> pointer:
     return _wasmtime_wat2wasm(wat, ret)
 
 class wasmtime_linker_t(Structure):
@@ -1874,55 +1875,55 @@ class wasmtime_linker_t(Structure):
 _wasmtime_linker_delete = dll.wasmtime_linker_delete
 _wasmtime_linker_delete.restype = None
 _wasmtime_linker_delete.argtypes = [POINTER(wasmtime_linker_t)]
-def wasmtime_linker_delete(arg0: pointer) -> None:
+def wasmtime_linker_delete(arg0: Any) -> None:
     return _wasmtime_linker_delete(arg0)
 
 _wasmtime_linker_new = dll.wasmtime_linker_new
 _wasmtime_linker_new.restype = POINTER(wasmtime_linker_t)
 _wasmtime_linker_new.argtypes = [POINTER(wasm_store_t)]
-def wasmtime_linker_new(store: pointer) -> pointer:
+def wasmtime_linker_new(store: Any) -> pointer:
     return _wasmtime_linker_new(store)
 
 _wasmtime_linker_allow_shadowing = dll.wasmtime_linker_allow_shadowing
 _wasmtime_linker_allow_shadowing.restype = None
 _wasmtime_linker_allow_shadowing.argtypes = [POINTER(wasmtime_linker_t), c_bool]
-def wasmtime_linker_allow_shadowing(linker: pointer, allow_shadowing: c_bool) -> None:
+def wasmtime_linker_allow_shadowing(linker: Any, allow_shadowing: Any) -> None:
     return _wasmtime_linker_allow_shadowing(linker, allow_shadowing)
 
 _wasmtime_linker_define = dll.wasmtime_linker_define
 _wasmtime_linker_define.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_define.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_extern_t)]
-def wasmtime_linker_define(linker: pointer, module: pointer, name: pointer, item: pointer) -> pointer:
+def wasmtime_linker_define(linker: Any, module: Any, name: Any, item: Any) -> pointer:
     return _wasmtime_linker_define(linker, module, name, item)
 
 _wasmtime_linker_define_wasi = dll.wasmtime_linker_define_wasi
 _wasmtime_linker_define_wasi.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_define_wasi.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasi_instance_t)]
-def wasmtime_linker_define_wasi(linker: pointer, instance: pointer) -> pointer:
+def wasmtime_linker_define_wasi(linker: Any, instance: Any) -> pointer:
     return _wasmtime_linker_define_wasi(linker, instance)
 
 _wasmtime_linker_define_instance = dll.wasmtime_linker_define_instance
 _wasmtime_linker_define_instance.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_define_instance.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_instance_t)]
-def wasmtime_linker_define_instance(linker: pointer, name: pointer, instance: pointer) -> pointer:
+def wasmtime_linker_define_instance(linker: Any, name: Any, instance: Any) -> pointer:
     return _wasmtime_linker_define_instance(linker, name, instance)
 
 _wasmtime_linker_instantiate = dll.wasmtime_linker_instantiate
 _wasmtime_linker_instantiate.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_instantiate.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
-def wasmtime_linker_instantiate(linker: pointer, module: pointer, instance: pointer, trap: pointer) -> pointer:
+def wasmtime_linker_instantiate(linker: Any, module: Any, instance: Any, trap: Any) -> pointer:
     return _wasmtime_linker_instantiate(linker, module, instance, trap)
 
 _wasmtime_linker_module = dll.wasmtime_linker_module
 _wasmtime_linker_module.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_module.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_module_t)]
-def wasmtime_linker_module(linker: pointer, name: pointer, module: pointer) -> pointer:
+def wasmtime_linker_module(linker: Any, name: Any, module: Any) -> pointer:
     return _wasmtime_linker_module(linker, name, module)
 
 _wasmtime_linker_get_default = dll.wasmtime_linker_get_default
 _wasmtime_linker_get_default.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_get_default.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(POINTER(wasm_func_t))]
-def wasmtime_linker_get_default(linker: pointer, name: pointer, func: pointer) -> pointer:
+def wasmtime_linker_get_default(linker: Any, name: Any, func: Any) -> pointer:
     return _wasmtime_linker_get_default(linker, name, func)
 
 class wasmtime_caller_t(Structure):
@@ -1935,19 +1936,19 @@ wasmtime_func_callback_with_env_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_
 _wasmtime_func_new = dll.wasmtime_func_new
 _wasmtime_func_new.restype = POINTER(wasm_func_t)
 _wasmtime_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_t]
-def wasmtime_func_new(arg0: pointer, arg1: pointer, callback: pointer) -> pointer:
+def wasmtime_func_new(arg0: Any, arg1: Any, callback: Any) -> pointer:
     return _wasmtime_func_new(arg0, arg1, callback)
 
 _wasmtime_func_new_with_env = dll.wasmtime_func_new_with_env
 _wasmtime_func_new_with_env.restype = POINTER(wasm_func_t)
 _wasmtime_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasmtime_func_new_with_env(store: pointer, type: pointer, callback: pointer, env: pointer, finalizer: pointer) -> pointer:
+def wasmtime_func_new_with_env(store: Any, type: Any, callback: Any, env: Any, finalizer: Any) -> pointer:
     return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)
 
 _wasmtime_caller_export_get = dll.wasmtime_caller_export_get
 _wasmtime_caller_export_get.restype = POINTER(wasm_extern_t)
 _wasmtime_caller_export_get.argtypes = [POINTER(wasmtime_caller_t), POINTER(wasm_name_t)]
-def wasmtime_caller_export_get(caller: pointer, name: pointer) -> pointer:
+def wasmtime_caller_export_get(caller: Any, name: Any) -> pointer:
     return _wasmtime_caller_export_get(caller, name)
 
 class wasmtime_interrupt_handle_t(Structure):
@@ -1956,89 +1957,89 @@ class wasmtime_interrupt_handle_t(Structure):
 _wasmtime_interrupt_handle_delete = dll.wasmtime_interrupt_handle_delete
 _wasmtime_interrupt_handle_delete.restype = None
 _wasmtime_interrupt_handle_delete.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
-def wasmtime_interrupt_handle_delete(arg0: pointer) -> None:
+def wasmtime_interrupt_handle_delete(arg0: Any) -> None:
     return _wasmtime_interrupt_handle_delete(arg0)
 
 _wasmtime_interrupt_handle_new = dll.wasmtime_interrupt_handle_new
 _wasmtime_interrupt_handle_new.restype = POINTER(wasmtime_interrupt_handle_t)
 _wasmtime_interrupt_handle_new.argtypes = [POINTER(wasm_store_t)]
-def wasmtime_interrupt_handle_new(store: pointer) -> pointer:
+def wasmtime_interrupt_handle_new(store: Any) -> pointer:
     return _wasmtime_interrupt_handle_new(store)
 
 _wasmtime_interrupt_handle_interrupt = dll.wasmtime_interrupt_handle_interrupt
 _wasmtime_interrupt_handle_interrupt.restype = None
 _wasmtime_interrupt_handle_interrupt.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
-def wasmtime_interrupt_handle_interrupt(handle: pointer) -> None:
+def wasmtime_interrupt_handle_interrupt(handle: Any) -> None:
     return _wasmtime_interrupt_handle_interrupt(handle)
 
 _wasmtime_frame_func_name = dll.wasmtime_frame_func_name
 _wasmtime_frame_func_name.restype = POINTER(wasm_name_t)
 _wasmtime_frame_func_name.argtypes = [POINTER(wasm_frame_t)]
-def wasmtime_frame_func_name(arg0: pointer) -> pointer:
+def wasmtime_frame_func_name(arg0: Any) -> pointer:
     return _wasmtime_frame_func_name(arg0)
 
 _wasmtime_frame_module_name = dll.wasmtime_frame_module_name
 _wasmtime_frame_module_name.restype = POINTER(wasm_name_t)
 _wasmtime_frame_module_name.argtypes = [POINTER(wasm_frame_t)]
-def wasmtime_frame_module_name(arg0: pointer) -> pointer:
+def wasmtime_frame_module_name(arg0: Any) -> pointer:
     return _wasmtime_frame_module_name(arg0)
 
 _wasmtime_func_call = dll.wasmtime_func_call
 _wasmtime_func_call.restype = POINTER(wasmtime_error_t)
 _wasmtime_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), c_size_t, POINTER(wasm_val_t), c_size_t, POINTER(POINTER(wasm_trap_t))]
-def wasmtime_func_call(func: pointer, args: pointer, num_args: c_size_t, results: pointer, num_results: c_size_t, trap: pointer) -> pointer:
+def wasmtime_func_call(func: Any, args: Any, num_args: Any, results: Any, num_results: Any, trap: Any) -> pointer:
     return _wasmtime_func_call(func, args, num_args, results, num_results, trap)
 
 _wasmtime_global_new = dll.wasmtime_global_new
 _wasmtime_global_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t), POINTER(POINTER(wasm_global_t))]
-def wasmtime_global_new(store: pointer, type: pointer, val: pointer, ret: pointer) -> pointer:
+def wasmtime_global_new(store: Any, type: Any, val: Any, ret: Any) -> pointer:
     return _wasmtime_global_new(store, type, val, ret)
 
 _wasmtime_global_set = dll.wasmtime_global_set
 _wasmtime_global_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
-def wasmtime_global_set(arg0: pointer, val: pointer) -> pointer:
+def wasmtime_global_set(arg0: Any, val: Any) -> pointer:
     return _wasmtime_global_set(arg0, val)
 
 _wasmtime_instance_new = dll.wasmtime_instance_new
 _wasmtime_instance_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), c_size_t, POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
-def wasmtime_instance_new(store: pointer, module: pointer, imports: pointer, num_imports: c_size_t, instance: pointer, trap: pointer) -> pointer:
+def wasmtime_instance_new(store: Any, module: Any, imports: Any, num_imports: Any, instance: Any, trap: Any) -> pointer:
     return _wasmtime_instance_new(store, module, imports, num_imports, instance, trap)
 
 _wasmtime_module_new = dll.wasmtime_module_new
 _wasmtime_module_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t), POINTER(POINTER(wasm_module_t))]
-def wasmtime_module_new(store: pointer, binary: pointer, ret: pointer) -> pointer:
+def wasmtime_module_new(store: Any, binary: Any, ret: Any) -> pointer:
     return _wasmtime_module_new(store, binary, ret)
 
 _wasmtime_module_validate = dll.wasmtime_module_validate
 _wasmtime_module_validate.restype = POINTER(wasmtime_error_t)
 _wasmtime_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
-def wasmtime_module_validate(store: pointer, binary: pointer) -> pointer:
+def wasmtime_module_validate(store: Any, binary: Any) -> pointer:
     return _wasmtime_module_validate(store, binary)
 
 _wasmtime_funcref_table_new = dll.wasmtime_funcref_table_new
 _wasmtime_funcref_table_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_funcref_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_func_t), POINTER(POINTER(wasm_table_t))]
-def wasmtime_funcref_table_new(store: pointer, element_ty: pointer, init: pointer, table: pointer) -> pointer:
+def wasmtime_funcref_table_new(store: Any, element_ty: Any, init: Any, table: Any) -> pointer:
     return _wasmtime_funcref_table_new(store, element_ty, init, table)
 
 _wasmtime_funcref_table_get = dll.wasmtime_funcref_table_get
 _wasmtime_funcref_table_get.restype = c_bool
 _wasmtime_funcref_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(POINTER(wasm_func_t))]
-def wasmtime_funcref_table_get(table: pointer, index: wasm_table_size_t, func: pointer) -> c_bool:
+def wasmtime_funcref_table_get(table: Any, index: Any, func: Any) -> c_bool:
     return _wasmtime_funcref_table_get(table, index, func)
 
 _wasmtime_funcref_table_set = dll.wasmtime_funcref_table_set
 _wasmtime_funcref_table_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_funcref_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t)]
-def wasmtime_funcref_table_set(table: pointer, index: wasm_table_size_t, value: pointer) -> pointer:
+def wasmtime_funcref_table_set(table: Any, index: Any, value: Any) -> pointer:
     return _wasmtime_funcref_table_set(table, index, value)
 
 _wasmtime_funcref_table_grow = dll.wasmtime_funcref_table_grow
 _wasmtime_funcref_table_grow.restype = POINTER(wasmtime_error_t)
 _wasmtime_funcref_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t), POINTER(wasm_table_size_t)]
-def wasmtime_funcref_table_grow(table: pointer, delta: wasm_table_size_t, init: pointer, prev_size: pointer) -> pointer:
+def wasmtime_funcref_table_grow(table: Any, delta: Any, init: Any, prev_size: Any) -> pointer:
     return _wasmtime_funcref_table_grow(table, delta, init, prev_size)

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -19,31 +19,31 @@ _wasm_byte_vec_new_empty = dll.wasm_byte_vec_new_empty
 _wasm_byte_vec_new_empty.restype = None
 _wasm_byte_vec_new_empty.argtypes = [POINTER(wasm_byte_vec_t)]
 def wasm_byte_vec_new_empty(out: Any) -> None:
-    return _wasm_byte_vec_new_empty(out)
+    return _wasm_byte_vec_new_empty(out)  # type: ignore
 
 _wasm_byte_vec_new_uninitialized = dll.wasm_byte_vec_new_uninitialized
 _wasm_byte_vec_new_uninitialized.restype = None
 _wasm_byte_vec_new_uninitialized.argtypes = [POINTER(wasm_byte_vec_t), c_size_t]
 def wasm_byte_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_byte_vec_new_uninitialized(out, arg1)
+    return _wasm_byte_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_byte_vec_new = dll.wasm_byte_vec_new
 _wasm_byte_vec_new.restype = None
 _wasm_byte_vec_new.argtypes = [POINTER(wasm_byte_vec_t), c_size_t, POINTER(wasm_byte_t)]
 def wasm_byte_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_byte_vec_new(out, arg1, arg2)
+    return _wasm_byte_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_byte_vec_copy = dll.wasm_byte_vec_copy
 _wasm_byte_vec_copy.restype = None
 _wasm_byte_vec_copy.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
 def wasm_byte_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_byte_vec_copy(out, arg1)
+    return _wasm_byte_vec_copy(out, arg1)  # type: ignore
 
 _wasm_byte_vec_delete = dll.wasm_byte_vec_delete
 _wasm_byte_vec_delete.restype = None
 _wasm_byte_vec_delete.argtypes = [POINTER(wasm_byte_vec_t)]
 def wasm_byte_vec_delete(arg0: Any) -> None:
-    return _wasm_byte_vec_delete(arg0)
+    return _wasm_byte_vec_delete(arg0)  # type: ignore
 
 wasm_name_t = wasm_byte_vec_t
 
@@ -54,13 +54,13 @@ _wasm_config_delete = dll.wasm_config_delete
 _wasm_config_delete.restype = None
 _wasm_config_delete.argtypes = [POINTER(wasm_config_t)]
 def wasm_config_delete(arg0: Any) -> None:
-    return _wasm_config_delete(arg0)
+    return _wasm_config_delete(arg0)  # type: ignore
 
 _wasm_config_new = dll.wasm_config_new
 _wasm_config_new.restype = POINTER(wasm_config_t)
 _wasm_config_new.argtypes = []
 def wasm_config_new() -> pointer:
-    return _wasm_config_new()
+    return _wasm_config_new()  # type: ignore
 
 class wasm_engine_t(Structure):
     pass
@@ -69,19 +69,19 @@ _wasm_engine_delete = dll.wasm_engine_delete
 _wasm_engine_delete.restype = None
 _wasm_engine_delete.argtypes = [POINTER(wasm_engine_t)]
 def wasm_engine_delete(arg0: Any) -> None:
-    return _wasm_engine_delete(arg0)
+    return _wasm_engine_delete(arg0)  # type: ignore
 
 _wasm_engine_new = dll.wasm_engine_new
 _wasm_engine_new.restype = POINTER(wasm_engine_t)
 _wasm_engine_new.argtypes = []
 def wasm_engine_new() -> pointer:
-    return _wasm_engine_new()
+    return _wasm_engine_new()  # type: ignore
 
 _wasm_engine_new_with_config = dll.wasm_engine_new_with_config
 _wasm_engine_new_with_config.restype = POINTER(wasm_engine_t)
 _wasm_engine_new_with_config.argtypes = [POINTER(wasm_config_t)]
 def wasm_engine_new_with_config(arg0: Any) -> pointer:
-    return _wasm_engine_new_with_config(arg0)
+    return _wasm_engine_new_with_config(arg0)  # type: ignore
 
 class wasm_store_t(Structure):
     pass
@@ -90,13 +90,13 @@ _wasm_store_delete = dll.wasm_store_delete
 _wasm_store_delete.restype = None
 _wasm_store_delete.argtypes = [POINTER(wasm_store_t)]
 def wasm_store_delete(arg0: Any) -> None:
-    return _wasm_store_delete(arg0)
+    return _wasm_store_delete(arg0)  # type: ignore
 
 _wasm_store_new = dll.wasm_store_new
 _wasm_store_new.restype = POINTER(wasm_store_t)
 _wasm_store_new.argtypes = [POINTER(wasm_engine_t)]
 def wasm_store_new(arg0: Any) -> pointer:
-    return _wasm_store_new(arg0)
+    return _wasm_store_new(arg0)  # type: ignore
 
 wasm_mutability_t = c_uint8
 
@@ -113,7 +113,7 @@ _wasm_valtype_delete = dll.wasm_valtype_delete
 _wasm_valtype_delete.restype = None
 _wasm_valtype_delete.argtypes = [POINTER(wasm_valtype_t)]
 def wasm_valtype_delete(arg0: Any) -> None:
-    return _wasm_valtype_delete(arg0)
+    return _wasm_valtype_delete(arg0)  # type: ignore
 
 class wasm_valtype_vec_t(Structure):
     _fields_ = [
@@ -125,37 +125,37 @@ _wasm_valtype_vec_new_empty = dll.wasm_valtype_vec_new_empty
 _wasm_valtype_vec_new_empty.restype = None
 _wasm_valtype_vec_new_empty.argtypes = [POINTER(wasm_valtype_vec_t)]
 def wasm_valtype_vec_new_empty(out: Any) -> None:
-    return _wasm_valtype_vec_new_empty(out)
+    return _wasm_valtype_vec_new_empty(out)  # type: ignore
 
 _wasm_valtype_vec_new_uninitialized = dll.wasm_valtype_vec_new_uninitialized
 _wasm_valtype_vec_new_uninitialized.restype = None
 _wasm_valtype_vec_new_uninitialized.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t]
 def wasm_valtype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_valtype_vec_new_uninitialized(out, arg1)
+    return _wasm_valtype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_valtype_vec_new = dll.wasm_valtype_vec_new
 _wasm_valtype_vec_new.restype = None
 _wasm_valtype_vec_new.argtypes = [POINTER(wasm_valtype_vec_t), c_size_t, POINTER(POINTER(wasm_valtype_t))]
 def wasm_valtype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_valtype_vec_new(out, arg1, arg2)
+    return _wasm_valtype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_valtype_vec_copy = dll.wasm_valtype_vec_copy
 _wasm_valtype_vec_copy.restype = None
 _wasm_valtype_vec_copy.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
 def wasm_valtype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_valtype_vec_copy(out, arg1)
+    return _wasm_valtype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_valtype_vec_delete = dll.wasm_valtype_vec_delete
 _wasm_valtype_vec_delete.restype = None
 _wasm_valtype_vec_delete.argtypes = [POINTER(wasm_valtype_vec_t)]
 def wasm_valtype_vec_delete(arg0: Any) -> None:
-    return _wasm_valtype_vec_delete(arg0)
+    return _wasm_valtype_vec_delete(arg0)  # type: ignore
 
 _wasm_valtype_copy = dll.wasm_valtype_copy
 _wasm_valtype_copy.restype = POINTER(wasm_valtype_t)
 _wasm_valtype_copy.argtypes = [POINTER(wasm_valtype_t)]
 def wasm_valtype_copy(arg0: Any) -> pointer:
-    return _wasm_valtype_copy(arg0)
+    return _wasm_valtype_copy(arg0)  # type: ignore
 
 wasm_valkind_t = c_uint8
 
@@ -163,13 +163,13 @@ _wasm_valtype_new = dll.wasm_valtype_new
 _wasm_valtype_new.restype = POINTER(wasm_valtype_t)
 _wasm_valtype_new.argtypes = [wasm_valkind_t]
 def wasm_valtype_new(arg0: Any) -> pointer:
-    return _wasm_valtype_new(arg0)
+    return _wasm_valtype_new(arg0)  # type: ignore
 
 _wasm_valtype_kind = dll.wasm_valtype_kind
 _wasm_valtype_kind.restype = wasm_valkind_t
 _wasm_valtype_kind.argtypes = [POINTER(wasm_valtype_t)]
 def wasm_valtype_kind(arg0: Any) -> wasm_valkind_t:
-    return _wasm_valtype_kind(arg0)
+    return _wasm_valtype_kind(arg0)  # type: ignore
 
 class wasm_functype_t(Structure):
     pass
@@ -178,7 +178,7 @@ _wasm_functype_delete = dll.wasm_functype_delete
 _wasm_functype_delete.restype = None
 _wasm_functype_delete.argtypes = [POINTER(wasm_functype_t)]
 def wasm_functype_delete(arg0: Any) -> None:
-    return _wasm_functype_delete(arg0)
+    return _wasm_functype_delete(arg0)  # type: ignore
 
 class wasm_functype_vec_t(Structure):
     _fields_ = [
@@ -190,55 +190,55 @@ _wasm_functype_vec_new_empty = dll.wasm_functype_vec_new_empty
 _wasm_functype_vec_new_empty.restype = None
 _wasm_functype_vec_new_empty.argtypes = [POINTER(wasm_functype_vec_t)]
 def wasm_functype_vec_new_empty(out: Any) -> None:
-    return _wasm_functype_vec_new_empty(out)
+    return _wasm_functype_vec_new_empty(out)  # type: ignore
 
 _wasm_functype_vec_new_uninitialized = dll.wasm_functype_vec_new_uninitialized
 _wasm_functype_vec_new_uninitialized.restype = None
 _wasm_functype_vec_new_uninitialized.argtypes = [POINTER(wasm_functype_vec_t), c_size_t]
 def wasm_functype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_functype_vec_new_uninitialized(out, arg1)
+    return _wasm_functype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_functype_vec_new = dll.wasm_functype_vec_new
 _wasm_functype_vec_new.restype = None
 _wasm_functype_vec_new.argtypes = [POINTER(wasm_functype_vec_t), c_size_t, POINTER(POINTER(wasm_functype_t))]
 def wasm_functype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_functype_vec_new(out, arg1, arg2)
+    return _wasm_functype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_functype_vec_copy = dll.wasm_functype_vec_copy
 _wasm_functype_vec_copy.restype = None
 _wasm_functype_vec_copy.argtypes = [POINTER(wasm_functype_vec_t), POINTER(wasm_functype_vec_t)]
 def wasm_functype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_functype_vec_copy(out, arg1)
+    return _wasm_functype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_functype_vec_delete = dll.wasm_functype_vec_delete
 _wasm_functype_vec_delete.restype = None
 _wasm_functype_vec_delete.argtypes = [POINTER(wasm_functype_vec_t)]
 def wasm_functype_vec_delete(arg0: Any) -> None:
-    return _wasm_functype_vec_delete(arg0)
+    return _wasm_functype_vec_delete(arg0)  # type: ignore
 
 _wasm_functype_copy = dll.wasm_functype_copy
 _wasm_functype_copy.restype = POINTER(wasm_functype_t)
 _wasm_functype_copy.argtypes = [POINTER(wasm_functype_t)]
 def wasm_functype_copy(arg0: Any) -> pointer:
-    return _wasm_functype_copy(arg0)
+    return _wasm_functype_copy(arg0)  # type: ignore
 
 _wasm_functype_new = dll.wasm_functype_new
 _wasm_functype_new.restype = POINTER(wasm_functype_t)
 _wasm_functype_new.argtypes = [POINTER(wasm_valtype_vec_t), POINTER(wasm_valtype_vec_t)]
 def wasm_functype_new(params: Any, results: Any) -> pointer:
-    return _wasm_functype_new(params, results)
+    return _wasm_functype_new(params, results)  # type: ignore
 
 _wasm_functype_params = dll.wasm_functype_params
 _wasm_functype_params.restype = POINTER(wasm_valtype_vec_t)
 _wasm_functype_params.argtypes = [POINTER(wasm_functype_t)]
 def wasm_functype_params(arg0: Any) -> pointer:
-    return _wasm_functype_params(arg0)
+    return _wasm_functype_params(arg0)  # type: ignore
 
 _wasm_functype_results = dll.wasm_functype_results
 _wasm_functype_results.restype = POINTER(wasm_valtype_vec_t)
 _wasm_functype_results.argtypes = [POINTER(wasm_functype_t)]
 def wasm_functype_results(arg0: Any) -> pointer:
-    return _wasm_functype_results(arg0)
+    return _wasm_functype_results(arg0)  # type: ignore
 
 class wasm_globaltype_t(Structure):
     pass
@@ -247,7 +247,7 @@ _wasm_globaltype_delete = dll.wasm_globaltype_delete
 _wasm_globaltype_delete.restype = None
 _wasm_globaltype_delete.argtypes = [POINTER(wasm_globaltype_t)]
 def wasm_globaltype_delete(arg0: Any) -> None:
-    return _wasm_globaltype_delete(arg0)
+    return _wasm_globaltype_delete(arg0)  # type: ignore
 
 class wasm_globaltype_vec_t(Structure):
     _fields_ = [
@@ -259,55 +259,55 @@ _wasm_globaltype_vec_new_empty = dll.wasm_globaltype_vec_new_empty
 _wasm_globaltype_vec_new_empty.restype = None
 _wasm_globaltype_vec_new_empty.argtypes = [POINTER(wasm_globaltype_vec_t)]
 def wasm_globaltype_vec_new_empty(out: Any) -> None:
-    return _wasm_globaltype_vec_new_empty(out)
+    return _wasm_globaltype_vec_new_empty(out)  # type: ignore
 
 _wasm_globaltype_vec_new_uninitialized = dll.wasm_globaltype_vec_new_uninitialized
 _wasm_globaltype_vec_new_uninitialized.restype = None
 _wasm_globaltype_vec_new_uninitialized.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t]
 def wasm_globaltype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_globaltype_vec_new_uninitialized(out, arg1)
+    return _wasm_globaltype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_globaltype_vec_new = dll.wasm_globaltype_vec_new
 _wasm_globaltype_vec_new.restype = None
 _wasm_globaltype_vec_new.argtypes = [POINTER(wasm_globaltype_vec_t), c_size_t, POINTER(POINTER(wasm_globaltype_t))]
 def wasm_globaltype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_globaltype_vec_new(out, arg1, arg2)
+    return _wasm_globaltype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_globaltype_vec_copy = dll.wasm_globaltype_vec_copy
 _wasm_globaltype_vec_copy.restype = None
 _wasm_globaltype_vec_copy.argtypes = [POINTER(wasm_globaltype_vec_t), POINTER(wasm_globaltype_vec_t)]
 def wasm_globaltype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_globaltype_vec_copy(out, arg1)
+    return _wasm_globaltype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_globaltype_vec_delete = dll.wasm_globaltype_vec_delete
 _wasm_globaltype_vec_delete.restype = None
 _wasm_globaltype_vec_delete.argtypes = [POINTER(wasm_globaltype_vec_t)]
 def wasm_globaltype_vec_delete(arg0: Any) -> None:
-    return _wasm_globaltype_vec_delete(arg0)
+    return _wasm_globaltype_vec_delete(arg0)  # type: ignore
 
 _wasm_globaltype_copy = dll.wasm_globaltype_copy
 _wasm_globaltype_copy.restype = POINTER(wasm_globaltype_t)
 _wasm_globaltype_copy.argtypes = [POINTER(wasm_globaltype_t)]
 def wasm_globaltype_copy(arg0: Any) -> pointer:
-    return _wasm_globaltype_copy(arg0)
+    return _wasm_globaltype_copy(arg0)  # type: ignore
 
 _wasm_globaltype_new = dll.wasm_globaltype_new
 _wasm_globaltype_new.restype = POINTER(wasm_globaltype_t)
 _wasm_globaltype_new.argtypes = [POINTER(wasm_valtype_t), wasm_mutability_t]
 def wasm_globaltype_new(arg0: Any, arg1: Any) -> pointer:
-    return _wasm_globaltype_new(arg0, arg1)
+    return _wasm_globaltype_new(arg0, arg1)  # type: ignore
 
 _wasm_globaltype_content = dll.wasm_globaltype_content
 _wasm_globaltype_content.restype = POINTER(wasm_valtype_t)
 _wasm_globaltype_content.argtypes = [POINTER(wasm_globaltype_t)]
 def wasm_globaltype_content(arg0: Any) -> pointer:
-    return _wasm_globaltype_content(arg0)
+    return _wasm_globaltype_content(arg0)  # type: ignore
 
 _wasm_globaltype_mutability = dll.wasm_globaltype_mutability
 _wasm_globaltype_mutability.restype = wasm_mutability_t
 _wasm_globaltype_mutability.argtypes = [POINTER(wasm_globaltype_t)]
 def wasm_globaltype_mutability(arg0: Any) -> wasm_mutability_t:
-    return _wasm_globaltype_mutability(arg0)
+    return _wasm_globaltype_mutability(arg0)  # type: ignore
 
 class wasm_tabletype_t(Structure):
     pass
@@ -316,7 +316,7 @@ _wasm_tabletype_delete = dll.wasm_tabletype_delete
 _wasm_tabletype_delete.restype = None
 _wasm_tabletype_delete.argtypes = [POINTER(wasm_tabletype_t)]
 def wasm_tabletype_delete(arg0: Any) -> None:
-    return _wasm_tabletype_delete(arg0)
+    return _wasm_tabletype_delete(arg0)  # type: ignore
 
 class wasm_tabletype_vec_t(Structure):
     _fields_ = [
@@ -328,55 +328,55 @@ _wasm_tabletype_vec_new_empty = dll.wasm_tabletype_vec_new_empty
 _wasm_tabletype_vec_new_empty.restype = None
 _wasm_tabletype_vec_new_empty.argtypes = [POINTER(wasm_tabletype_vec_t)]
 def wasm_tabletype_vec_new_empty(out: Any) -> None:
-    return _wasm_tabletype_vec_new_empty(out)
+    return _wasm_tabletype_vec_new_empty(out)  # type: ignore
 
 _wasm_tabletype_vec_new_uninitialized = dll.wasm_tabletype_vec_new_uninitialized
 _wasm_tabletype_vec_new_uninitialized.restype = None
 _wasm_tabletype_vec_new_uninitialized.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t]
 def wasm_tabletype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_tabletype_vec_new_uninitialized(out, arg1)
+    return _wasm_tabletype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_tabletype_vec_new = dll.wasm_tabletype_vec_new
 _wasm_tabletype_vec_new.restype = None
 _wasm_tabletype_vec_new.argtypes = [POINTER(wasm_tabletype_vec_t), c_size_t, POINTER(POINTER(wasm_tabletype_t))]
 def wasm_tabletype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_tabletype_vec_new(out, arg1, arg2)
+    return _wasm_tabletype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_tabletype_vec_copy = dll.wasm_tabletype_vec_copy
 _wasm_tabletype_vec_copy.restype = None
 _wasm_tabletype_vec_copy.argtypes = [POINTER(wasm_tabletype_vec_t), POINTER(wasm_tabletype_vec_t)]
 def wasm_tabletype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_tabletype_vec_copy(out, arg1)
+    return _wasm_tabletype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_tabletype_vec_delete = dll.wasm_tabletype_vec_delete
 _wasm_tabletype_vec_delete.restype = None
 _wasm_tabletype_vec_delete.argtypes = [POINTER(wasm_tabletype_vec_t)]
 def wasm_tabletype_vec_delete(arg0: Any) -> None:
-    return _wasm_tabletype_vec_delete(arg0)
+    return _wasm_tabletype_vec_delete(arg0)  # type: ignore
 
 _wasm_tabletype_copy = dll.wasm_tabletype_copy
 _wasm_tabletype_copy.restype = POINTER(wasm_tabletype_t)
 _wasm_tabletype_copy.argtypes = [POINTER(wasm_tabletype_t)]
 def wasm_tabletype_copy(arg0: Any) -> pointer:
-    return _wasm_tabletype_copy(arg0)
+    return _wasm_tabletype_copy(arg0)  # type: ignore
 
 _wasm_tabletype_new = dll.wasm_tabletype_new
 _wasm_tabletype_new.restype = POINTER(wasm_tabletype_t)
 _wasm_tabletype_new.argtypes = [POINTER(wasm_valtype_t), POINTER(wasm_limits_t)]
 def wasm_tabletype_new(arg0: Any, arg1: Any) -> pointer:
-    return _wasm_tabletype_new(arg0, arg1)
+    return _wasm_tabletype_new(arg0, arg1)  # type: ignore
 
 _wasm_tabletype_element = dll.wasm_tabletype_element
 _wasm_tabletype_element.restype = POINTER(wasm_valtype_t)
 _wasm_tabletype_element.argtypes = [POINTER(wasm_tabletype_t)]
 def wasm_tabletype_element(arg0: Any) -> pointer:
-    return _wasm_tabletype_element(arg0)
+    return _wasm_tabletype_element(arg0)  # type: ignore
 
 _wasm_tabletype_limits = dll.wasm_tabletype_limits
 _wasm_tabletype_limits.restype = POINTER(wasm_limits_t)
 _wasm_tabletype_limits.argtypes = [POINTER(wasm_tabletype_t)]
 def wasm_tabletype_limits(arg0: Any) -> pointer:
-    return _wasm_tabletype_limits(arg0)
+    return _wasm_tabletype_limits(arg0)  # type: ignore
 
 class wasm_memorytype_t(Structure):
     pass
@@ -385,7 +385,7 @@ _wasm_memorytype_delete = dll.wasm_memorytype_delete
 _wasm_memorytype_delete.restype = None
 _wasm_memorytype_delete.argtypes = [POINTER(wasm_memorytype_t)]
 def wasm_memorytype_delete(arg0: Any) -> None:
-    return _wasm_memorytype_delete(arg0)
+    return _wasm_memorytype_delete(arg0)  # type: ignore
 
 class wasm_memorytype_vec_t(Structure):
     _fields_ = [
@@ -397,49 +397,49 @@ _wasm_memorytype_vec_new_empty = dll.wasm_memorytype_vec_new_empty
 _wasm_memorytype_vec_new_empty.restype = None
 _wasm_memorytype_vec_new_empty.argtypes = [POINTER(wasm_memorytype_vec_t)]
 def wasm_memorytype_vec_new_empty(out: Any) -> None:
-    return _wasm_memorytype_vec_new_empty(out)
+    return _wasm_memorytype_vec_new_empty(out)  # type: ignore
 
 _wasm_memorytype_vec_new_uninitialized = dll.wasm_memorytype_vec_new_uninitialized
 _wasm_memorytype_vec_new_uninitialized.restype = None
 _wasm_memorytype_vec_new_uninitialized.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t]
 def wasm_memorytype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_memorytype_vec_new_uninitialized(out, arg1)
+    return _wasm_memorytype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_memorytype_vec_new = dll.wasm_memorytype_vec_new
 _wasm_memorytype_vec_new.restype = None
 _wasm_memorytype_vec_new.argtypes = [POINTER(wasm_memorytype_vec_t), c_size_t, POINTER(POINTER(wasm_memorytype_t))]
 def wasm_memorytype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_memorytype_vec_new(out, arg1, arg2)
+    return _wasm_memorytype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_memorytype_vec_copy = dll.wasm_memorytype_vec_copy
 _wasm_memorytype_vec_copy.restype = None
 _wasm_memorytype_vec_copy.argtypes = [POINTER(wasm_memorytype_vec_t), POINTER(wasm_memorytype_vec_t)]
 def wasm_memorytype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_memorytype_vec_copy(out, arg1)
+    return _wasm_memorytype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_memorytype_vec_delete = dll.wasm_memorytype_vec_delete
 _wasm_memorytype_vec_delete.restype = None
 _wasm_memorytype_vec_delete.argtypes = [POINTER(wasm_memorytype_vec_t)]
 def wasm_memorytype_vec_delete(arg0: Any) -> None:
-    return _wasm_memorytype_vec_delete(arg0)
+    return _wasm_memorytype_vec_delete(arg0)  # type: ignore
 
 _wasm_memorytype_copy = dll.wasm_memorytype_copy
 _wasm_memorytype_copy.restype = POINTER(wasm_memorytype_t)
 _wasm_memorytype_copy.argtypes = [POINTER(wasm_memorytype_t)]
 def wasm_memorytype_copy(arg0: Any) -> pointer:
-    return _wasm_memorytype_copy(arg0)
+    return _wasm_memorytype_copy(arg0)  # type: ignore
 
 _wasm_memorytype_new = dll.wasm_memorytype_new
 _wasm_memorytype_new.restype = POINTER(wasm_memorytype_t)
 _wasm_memorytype_new.argtypes = [POINTER(wasm_limits_t)]
 def wasm_memorytype_new(arg0: Any) -> pointer:
-    return _wasm_memorytype_new(arg0)
+    return _wasm_memorytype_new(arg0)  # type: ignore
 
 _wasm_memorytype_limits = dll.wasm_memorytype_limits
 _wasm_memorytype_limits.restype = POINTER(wasm_limits_t)
 _wasm_memorytype_limits.argtypes = [POINTER(wasm_memorytype_t)]
 def wasm_memorytype_limits(arg0: Any) -> pointer:
-    return _wasm_memorytype_limits(arg0)
+    return _wasm_memorytype_limits(arg0)  # type: ignore
 
 class wasm_externtype_t(Structure):
     pass
@@ -448,7 +448,7 @@ _wasm_externtype_delete = dll.wasm_externtype_delete
 _wasm_externtype_delete.restype = None
 _wasm_externtype_delete.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_delete(arg0: Any) -> None:
-    return _wasm_externtype_delete(arg0)
+    return _wasm_externtype_delete(arg0)  # type: ignore
 
 class wasm_externtype_vec_t(Structure):
     _fields_ = [
@@ -460,37 +460,37 @@ _wasm_externtype_vec_new_empty = dll.wasm_externtype_vec_new_empty
 _wasm_externtype_vec_new_empty.restype = None
 _wasm_externtype_vec_new_empty.argtypes = [POINTER(wasm_externtype_vec_t)]
 def wasm_externtype_vec_new_empty(out: Any) -> None:
-    return _wasm_externtype_vec_new_empty(out)
+    return _wasm_externtype_vec_new_empty(out)  # type: ignore
 
 _wasm_externtype_vec_new_uninitialized = dll.wasm_externtype_vec_new_uninitialized
 _wasm_externtype_vec_new_uninitialized.restype = None
 _wasm_externtype_vec_new_uninitialized.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t]
 def wasm_externtype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_externtype_vec_new_uninitialized(out, arg1)
+    return _wasm_externtype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_externtype_vec_new = dll.wasm_externtype_vec_new
 _wasm_externtype_vec_new.restype = None
 _wasm_externtype_vec_new.argtypes = [POINTER(wasm_externtype_vec_t), c_size_t, POINTER(POINTER(wasm_externtype_t))]
 def wasm_externtype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_externtype_vec_new(out, arg1, arg2)
+    return _wasm_externtype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_externtype_vec_copy = dll.wasm_externtype_vec_copy
 _wasm_externtype_vec_copy.restype = None
 _wasm_externtype_vec_copy.argtypes = [POINTER(wasm_externtype_vec_t), POINTER(wasm_externtype_vec_t)]
 def wasm_externtype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_externtype_vec_copy(out, arg1)
+    return _wasm_externtype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_externtype_vec_delete = dll.wasm_externtype_vec_delete
 _wasm_externtype_vec_delete.restype = None
 _wasm_externtype_vec_delete.argtypes = [POINTER(wasm_externtype_vec_t)]
 def wasm_externtype_vec_delete(arg0: Any) -> None:
-    return _wasm_externtype_vec_delete(arg0)
+    return _wasm_externtype_vec_delete(arg0)  # type: ignore
 
 _wasm_externtype_copy = dll.wasm_externtype_copy
 _wasm_externtype_copy.restype = POINTER(wasm_externtype_t)
 _wasm_externtype_copy.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_copy(arg0: Any) -> pointer:
-    return _wasm_externtype_copy(arg0)
+    return _wasm_externtype_copy(arg0)  # type: ignore
 
 wasm_externkind_t = c_uint8
 
@@ -498,103 +498,103 @@ _wasm_externtype_kind = dll.wasm_externtype_kind
 _wasm_externtype_kind.restype = wasm_externkind_t
 _wasm_externtype_kind.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_kind(arg0: Any) -> wasm_externkind_t:
-    return _wasm_externtype_kind(arg0)
+    return _wasm_externtype_kind(arg0)  # type: ignore
 
 _wasm_functype_as_externtype = dll.wasm_functype_as_externtype
 _wasm_functype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_functype_as_externtype.argtypes = [POINTER(wasm_functype_t)]
 def wasm_functype_as_externtype(arg0: Any) -> pointer:
-    return _wasm_functype_as_externtype(arg0)
+    return _wasm_functype_as_externtype(arg0)  # type: ignore
 
 _wasm_globaltype_as_externtype = dll.wasm_globaltype_as_externtype
 _wasm_globaltype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_globaltype_as_externtype.argtypes = [POINTER(wasm_globaltype_t)]
 def wasm_globaltype_as_externtype(arg0: Any) -> pointer:
-    return _wasm_globaltype_as_externtype(arg0)
+    return _wasm_globaltype_as_externtype(arg0)  # type: ignore
 
 _wasm_tabletype_as_externtype = dll.wasm_tabletype_as_externtype
 _wasm_tabletype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_tabletype_as_externtype.argtypes = [POINTER(wasm_tabletype_t)]
 def wasm_tabletype_as_externtype(arg0: Any) -> pointer:
-    return _wasm_tabletype_as_externtype(arg0)
+    return _wasm_tabletype_as_externtype(arg0)  # type: ignore
 
 _wasm_memorytype_as_externtype = dll.wasm_memorytype_as_externtype
 _wasm_memorytype_as_externtype.restype = POINTER(wasm_externtype_t)
 _wasm_memorytype_as_externtype.argtypes = [POINTER(wasm_memorytype_t)]
 def wasm_memorytype_as_externtype(arg0: Any) -> pointer:
-    return _wasm_memorytype_as_externtype(arg0)
+    return _wasm_memorytype_as_externtype(arg0)  # type: ignore
 
 _wasm_externtype_as_functype = dll.wasm_externtype_as_functype
 _wasm_externtype_as_functype.restype = POINTER(wasm_functype_t)
 _wasm_externtype_as_functype.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_functype(arg0: Any) -> pointer:
-    return _wasm_externtype_as_functype(arg0)
+    return _wasm_externtype_as_functype(arg0)  # type: ignore
 
 _wasm_externtype_as_globaltype = dll.wasm_externtype_as_globaltype
 _wasm_externtype_as_globaltype.restype = POINTER(wasm_globaltype_t)
 _wasm_externtype_as_globaltype.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_globaltype(arg0: Any) -> pointer:
-    return _wasm_externtype_as_globaltype(arg0)
+    return _wasm_externtype_as_globaltype(arg0)  # type: ignore
 
 _wasm_externtype_as_tabletype = dll.wasm_externtype_as_tabletype
 _wasm_externtype_as_tabletype.restype = POINTER(wasm_tabletype_t)
 _wasm_externtype_as_tabletype.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_tabletype(arg0: Any) -> pointer:
-    return _wasm_externtype_as_tabletype(arg0)
+    return _wasm_externtype_as_tabletype(arg0)  # type: ignore
 
 _wasm_externtype_as_memorytype = dll.wasm_externtype_as_memorytype
 _wasm_externtype_as_memorytype.restype = POINTER(wasm_memorytype_t)
 _wasm_externtype_as_memorytype.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_memorytype(arg0: Any) -> pointer:
-    return _wasm_externtype_as_memorytype(arg0)
+    return _wasm_externtype_as_memorytype(arg0)  # type: ignore
 
 _wasm_functype_as_externtype_const = dll.wasm_functype_as_externtype_const
 _wasm_functype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_functype_as_externtype_const.argtypes = [POINTER(wasm_functype_t)]
 def wasm_functype_as_externtype_const(arg0: Any) -> pointer:
-    return _wasm_functype_as_externtype_const(arg0)
+    return _wasm_functype_as_externtype_const(arg0)  # type: ignore
 
 _wasm_globaltype_as_externtype_const = dll.wasm_globaltype_as_externtype_const
 _wasm_globaltype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_globaltype_as_externtype_const.argtypes = [POINTER(wasm_globaltype_t)]
 def wasm_globaltype_as_externtype_const(arg0: Any) -> pointer:
-    return _wasm_globaltype_as_externtype_const(arg0)
+    return _wasm_globaltype_as_externtype_const(arg0)  # type: ignore
 
 _wasm_tabletype_as_externtype_const = dll.wasm_tabletype_as_externtype_const
 _wasm_tabletype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_tabletype_as_externtype_const.argtypes = [POINTER(wasm_tabletype_t)]
 def wasm_tabletype_as_externtype_const(arg0: Any) -> pointer:
-    return _wasm_tabletype_as_externtype_const(arg0)
+    return _wasm_tabletype_as_externtype_const(arg0)  # type: ignore
 
 _wasm_memorytype_as_externtype_const = dll.wasm_memorytype_as_externtype_const
 _wasm_memorytype_as_externtype_const.restype = POINTER(wasm_externtype_t)
 _wasm_memorytype_as_externtype_const.argtypes = [POINTER(wasm_memorytype_t)]
 def wasm_memorytype_as_externtype_const(arg0: Any) -> pointer:
-    return _wasm_memorytype_as_externtype_const(arg0)
+    return _wasm_memorytype_as_externtype_const(arg0)  # type: ignore
 
 _wasm_externtype_as_functype_const = dll.wasm_externtype_as_functype_const
 _wasm_externtype_as_functype_const.restype = POINTER(wasm_functype_t)
 _wasm_externtype_as_functype_const.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_functype_const(arg0: Any) -> pointer:
-    return _wasm_externtype_as_functype_const(arg0)
+    return _wasm_externtype_as_functype_const(arg0)  # type: ignore
 
 _wasm_externtype_as_globaltype_const = dll.wasm_externtype_as_globaltype_const
 _wasm_externtype_as_globaltype_const.restype = POINTER(wasm_globaltype_t)
 _wasm_externtype_as_globaltype_const.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_globaltype_const(arg0: Any) -> pointer:
-    return _wasm_externtype_as_globaltype_const(arg0)
+    return _wasm_externtype_as_globaltype_const(arg0)  # type: ignore
 
 _wasm_externtype_as_tabletype_const = dll.wasm_externtype_as_tabletype_const
 _wasm_externtype_as_tabletype_const.restype = POINTER(wasm_tabletype_t)
 _wasm_externtype_as_tabletype_const.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_tabletype_const(arg0: Any) -> pointer:
-    return _wasm_externtype_as_tabletype_const(arg0)
+    return _wasm_externtype_as_tabletype_const(arg0)  # type: ignore
 
 _wasm_externtype_as_memorytype_const = dll.wasm_externtype_as_memorytype_const
 _wasm_externtype_as_memorytype_const.restype = POINTER(wasm_memorytype_t)
 _wasm_externtype_as_memorytype_const.argtypes = [POINTER(wasm_externtype_t)]
 def wasm_externtype_as_memorytype_const(arg0: Any) -> pointer:
-    return _wasm_externtype_as_memorytype_const(arg0)
+    return _wasm_externtype_as_memorytype_const(arg0)  # type: ignore
 
 class wasm_importtype_t(Structure):
     pass
@@ -603,7 +603,7 @@ _wasm_importtype_delete = dll.wasm_importtype_delete
 _wasm_importtype_delete.restype = None
 _wasm_importtype_delete.argtypes = [POINTER(wasm_importtype_t)]
 def wasm_importtype_delete(arg0: Any) -> None:
-    return _wasm_importtype_delete(arg0)
+    return _wasm_importtype_delete(arg0)  # type: ignore
 
 class wasm_importtype_vec_t(Structure):
     _fields_ = [
@@ -615,61 +615,61 @@ _wasm_importtype_vec_new_empty = dll.wasm_importtype_vec_new_empty
 _wasm_importtype_vec_new_empty.restype = None
 _wasm_importtype_vec_new_empty.argtypes = [POINTER(wasm_importtype_vec_t)]
 def wasm_importtype_vec_new_empty(out: Any) -> None:
-    return _wasm_importtype_vec_new_empty(out)
+    return _wasm_importtype_vec_new_empty(out)  # type: ignore
 
 _wasm_importtype_vec_new_uninitialized = dll.wasm_importtype_vec_new_uninitialized
 _wasm_importtype_vec_new_uninitialized.restype = None
 _wasm_importtype_vec_new_uninitialized.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t]
 def wasm_importtype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_importtype_vec_new_uninitialized(out, arg1)
+    return _wasm_importtype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_importtype_vec_new = dll.wasm_importtype_vec_new
 _wasm_importtype_vec_new.restype = None
 _wasm_importtype_vec_new.argtypes = [POINTER(wasm_importtype_vec_t), c_size_t, POINTER(POINTER(wasm_importtype_t))]
 def wasm_importtype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_importtype_vec_new(out, arg1, arg2)
+    return _wasm_importtype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_importtype_vec_copy = dll.wasm_importtype_vec_copy
 _wasm_importtype_vec_copy.restype = None
 _wasm_importtype_vec_copy.argtypes = [POINTER(wasm_importtype_vec_t), POINTER(wasm_importtype_vec_t)]
 def wasm_importtype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_importtype_vec_copy(out, arg1)
+    return _wasm_importtype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_importtype_vec_delete = dll.wasm_importtype_vec_delete
 _wasm_importtype_vec_delete.restype = None
 _wasm_importtype_vec_delete.argtypes = [POINTER(wasm_importtype_vec_t)]
 def wasm_importtype_vec_delete(arg0: Any) -> None:
-    return _wasm_importtype_vec_delete(arg0)
+    return _wasm_importtype_vec_delete(arg0)  # type: ignore
 
 _wasm_importtype_copy = dll.wasm_importtype_copy
 _wasm_importtype_copy.restype = POINTER(wasm_importtype_t)
 _wasm_importtype_copy.argtypes = [POINTER(wasm_importtype_t)]
 def wasm_importtype_copy(arg0: Any) -> pointer:
-    return _wasm_importtype_copy(arg0)
+    return _wasm_importtype_copy(arg0)  # type: ignore
 
 _wasm_importtype_new = dll.wasm_importtype_new
 _wasm_importtype_new.restype = POINTER(wasm_importtype_t)
 _wasm_importtype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
 def wasm_importtype_new(module: Any, name: Any, arg2: Any) -> pointer:
-    return _wasm_importtype_new(module, name, arg2)
+    return _wasm_importtype_new(module, name, arg2)  # type: ignore
 
 _wasm_importtype_module = dll.wasm_importtype_module
 _wasm_importtype_module.restype = POINTER(wasm_name_t)
 _wasm_importtype_module.argtypes = [POINTER(wasm_importtype_t)]
 def wasm_importtype_module(arg0: Any) -> pointer:
-    return _wasm_importtype_module(arg0)
+    return _wasm_importtype_module(arg0)  # type: ignore
 
 _wasm_importtype_name = dll.wasm_importtype_name
 _wasm_importtype_name.restype = POINTER(wasm_name_t)
 _wasm_importtype_name.argtypes = [POINTER(wasm_importtype_t)]
 def wasm_importtype_name(arg0: Any) -> pointer:
-    return _wasm_importtype_name(arg0)
+    return _wasm_importtype_name(arg0)  # type: ignore
 
 _wasm_importtype_type = dll.wasm_importtype_type
 _wasm_importtype_type.restype = POINTER(wasm_externtype_t)
 _wasm_importtype_type.argtypes = [POINTER(wasm_importtype_t)]
 def wasm_importtype_type(arg0: Any) -> pointer:
-    return _wasm_importtype_type(arg0)
+    return _wasm_importtype_type(arg0)  # type: ignore
 
 class wasm_exporttype_t(Structure):
     pass
@@ -678,7 +678,7 @@ _wasm_exporttype_delete = dll.wasm_exporttype_delete
 _wasm_exporttype_delete.restype = None
 _wasm_exporttype_delete.argtypes = [POINTER(wasm_exporttype_t)]
 def wasm_exporttype_delete(arg0: Any) -> None:
-    return _wasm_exporttype_delete(arg0)
+    return _wasm_exporttype_delete(arg0)  # type: ignore
 
 class wasm_exporttype_vec_t(Structure):
     _fields_ = [
@@ -690,55 +690,55 @@ _wasm_exporttype_vec_new_empty = dll.wasm_exporttype_vec_new_empty
 _wasm_exporttype_vec_new_empty.restype = None
 _wasm_exporttype_vec_new_empty.argtypes = [POINTER(wasm_exporttype_vec_t)]
 def wasm_exporttype_vec_new_empty(out: Any) -> None:
-    return _wasm_exporttype_vec_new_empty(out)
+    return _wasm_exporttype_vec_new_empty(out)  # type: ignore
 
 _wasm_exporttype_vec_new_uninitialized = dll.wasm_exporttype_vec_new_uninitialized
 _wasm_exporttype_vec_new_uninitialized.restype = None
 _wasm_exporttype_vec_new_uninitialized.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t]
 def wasm_exporttype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_exporttype_vec_new_uninitialized(out, arg1)
+    return _wasm_exporttype_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_exporttype_vec_new = dll.wasm_exporttype_vec_new
 _wasm_exporttype_vec_new.restype = None
 _wasm_exporttype_vec_new.argtypes = [POINTER(wasm_exporttype_vec_t), c_size_t, POINTER(POINTER(wasm_exporttype_t))]
 def wasm_exporttype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_exporttype_vec_new(out, arg1, arg2)
+    return _wasm_exporttype_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_exporttype_vec_copy = dll.wasm_exporttype_vec_copy
 _wasm_exporttype_vec_copy.restype = None
 _wasm_exporttype_vec_copy.argtypes = [POINTER(wasm_exporttype_vec_t), POINTER(wasm_exporttype_vec_t)]
 def wasm_exporttype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_exporttype_vec_copy(out, arg1)
+    return _wasm_exporttype_vec_copy(out, arg1)  # type: ignore
 
 _wasm_exporttype_vec_delete = dll.wasm_exporttype_vec_delete
 _wasm_exporttype_vec_delete.restype = None
 _wasm_exporttype_vec_delete.argtypes = [POINTER(wasm_exporttype_vec_t)]
 def wasm_exporttype_vec_delete(arg0: Any) -> None:
-    return _wasm_exporttype_vec_delete(arg0)
+    return _wasm_exporttype_vec_delete(arg0)  # type: ignore
 
 _wasm_exporttype_copy = dll.wasm_exporttype_copy
 _wasm_exporttype_copy.restype = POINTER(wasm_exporttype_t)
 _wasm_exporttype_copy.argtypes = [POINTER(wasm_exporttype_t)]
 def wasm_exporttype_copy(arg0: Any) -> pointer:
-    return _wasm_exporttype_copy(arg0)
+    return _wasm_exporttype_copy(arg0)  # type: ignore
 
 _wasm_exporttype_new = dll.wasm_exporttype_new
 _wasm_exporttype_new.restype = POINTER(wasm_exporttype_t)
 _wasm_exporttype_new.argtypes = [POINTER(wasm_name_t), POINTER(wasm_externtype_t)]
 def wasm_exporttype_new(arg0: Any, arg1: Any) -> pointer:
-    return _wasm_exporttype_new(arg0, arg1)
+    return _wasm_exporttype_new(arg0, arg1)  # type: ignore
 
 _wasm_exporttype_name = dll.wasm_exporttype_name
 _wasm_exporttype_name.restype = POINTER(wasm_name_t)
 _wasm_exporttype_name.argtypes = [POINTER(wasm_exporttype_t)]
 def wasm_exporttype_name(arg0: Any) -> pointer:
-    return _wasm_exporttype_name(arg0)
+    return _wasm_exporttype_name(arg0)  # type: ignore
 
 _wasm_exporttype_type = dll.wasm_exporttype_type
 _wasm_exporttype_type.restype = POINTER(wasm_externtype_t)
 _wasm_exporttype_type.argtypes = [POINTER(wasm_exporttype_t)]
 def wasm_exporttype_type(arg0: Any) -> pointer:
-    return _wasm_exporttype_type(arg0)
+    return _wasm_exporttype_type(arg0)  # type: ignore
 
 class wasm_ref_t(Structure):
     pass
@@ -747,13 +747,13 @@ _wasm_val_delete = dll.wasm_val_delete
 _wasm_val_delete.restype = None
 _wasm_val_delete.argtypes = [POINTER(wasm_val_t)]
 def wasm_val_delete(v: Any) -> None:
-    return _wasm_val_delete(v)
+    return _wasm_val_delete(v)  # type: ignore
 
 _wasm_val_copy = dll.wasm_val_copy
 _wasm_val_copy.restype = None
 _wasm_val_copy.argtypes = [POINTER(wasm_val_t), POINTER(wasm_val_t)]
 def wasm_val_copy(out: Any, arg1: Any) -> None:
-    return _wasm_val_copy(out, arg1)
+    return _wasm_val_copy(out, arg1)  # type: ignore
 
 class wasm_val_vec_t(Structure):
     _fields_ = [
@@ -765,67 +765,67 @@ _wasm_val_vec_new_empty = dll.wasm_val_vec_new_empty
 _wasm_val_vec_new_empty.restype = None
 _wasm_val_vec_new_empty.argtypes = [POINTER(wasm_val_vec_t)]
 def wasm_val_vec_new_empty(out: Any) -> None:
-    return _wasm_val_vec_new_empty(out)
+    return _wasm_val_vec_new_empty(out)  # type: ignore
 
 _wasm_val_vec_new_uninitialized = dll.wasm_val_vec_new_uninitialized
 _wasm_val_vec_new_uninitialized.restype = None
 _wasm_val_vec_new_uninitialized.argtypes = [POINTER(wasm_val_vec_t), c_size_t]
 def wasm_val_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_val_vec_new_uninitialized(out, arg1)
+    return _wasm_val_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_val_vec_new = dll.wasm_val_vec_new
 _wasm_val_vec_new.restype = None
 _wasm_val_vec_new.argtypes = [POINTER(wasm_val_vec_t), c_size_t, POINTER(wasm_val_t)]
 def wasm_val_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_val_vec_new(out, arg1, arg2)
+    return _wasm_val_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_val_vec_copy = dll.wasm_val_vec_copy
 _wasm_val_vec_copy.restype = None
 _wasm_val_vec_copy.argtypes = [POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t)]
 def wasm_val_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_val_vec_copy(out, arg1)
+    return _wasm_val_vec_copy(out, arg1)  # type: ignore
 
 _wasm_val_vec_delete = dll.wasm_val_vec_delete
 _wasm_val_vec_delete.restype = None
 _wasm_val_vec_delete.argtypes = [POINTER(wasm_val_vec_t)]
 def wasm_val_vec_delete(arg0: Any) -> None:
-    return _wasm_val_vec_delete(arg0)
+    return _wasm_val_vec_delete(arg0)  # type: ignore
 
 _wasm_ref_delete = dll.wasm_ref_delete
 _wasm_ref_delete.restype = None
 _wasm_ref_delete.argtypes = [POINTER(wasm_ref_t)]
 def wasm_ref_delete(arg0: Any) -> None:
-    return _wasm_ref_delete(arg0)
+    return _wasm_ref_delete(arg0)  # type: ignore
 
 _wasm_ref_copy = dll.wasm_ref_copy
 _wasm_ref_copy.restype = POINTER(wasm_ref_t)
 _wasm_ref_copy.argtypes = [POINTER(wasm_ref_t)]
 def wasm_ref_copy(arg0: Any) -> pointer:
-    return _wasm_ref_copy(arg0)
+    return _wasm_ref_copy(arg0)  # type: ignore
 
 _wasm_ref_same = dll.wasm_ref_same
 _wasm_ref_same.restype = c_bool
 _wasm_ref_same.argtypes = [POINTER(wasm_ref_t), POINTER(wasm_ref_t)]
 def wasm_ref_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_ref_same(arg0, arg1)
+    return _wasm_ref_same(arg0, arg1)  # type: ignore
 
 _wasm_ref_get_host_info = dll.wasm_ref_get_host_info
 _wasm_ref_get_host_info.restype = c_void_p
 _wasm_ref_get_host_info.argtypes = [POINTER(wasm_ref_t)]
 def wasm_ref_get_host_info(arg0: Any) -> pointer:
-    return _wasm_ref_get_host_info(arg0)
+    return _wasm_ref_get_host_info(arg0)  # type: ignore
 
 _wasm_ref_set_host_info = dll.wasm_ref_set_host_info
 _wasm_ref_set_host_info.restype = None
 _wasm_ref_set_host_info.argtypes = [POINTER(wasm_ref_t), c_void_p]
 def wasm_ref_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_ref_set_host_info(arg0, arg1)
+    return _wasm_ref_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_ref_set_host_info_with_finalizer = dll.wasm_ref_set_host_info_with_finalizer
 _wasm_ref_set_host_info_with_finalizer.restype = None
 _wasm_ref_set_host_info_with_finalizer.argtypes = [POINTER(wasm_ref_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_ref_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_ref_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_ref_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 class wasm_frame_t(Structure):
     pass
@@ -834,7 +834,7 @@ _wasm_frame_delete = dll.wasm_frame_delete
 _wasm_frame_delete.restype = None
 _wasm_frame_delete.argtypes = [POINTER(wasm_frame_t)]
 def wasm_frame_delete(arg0: Any) -> None:
-    return _wasm_frame_delete(arg0)
+    return _wasm_frame_delete(arg0)  # type: ignore
 
 class wasm_frame_vec_t(Structure):
     _fields_ = [
@@ -846,49 +846,49 @@ _wasm_frame_vec_new_empty = dll.wasm_frame_vec_new_empty
 _wasm_frame_vec_new_empty.restype = None
 _wasm_frame_vec_new_empty.argtypes = [POINTER(wasm_frame_vec_t)]
 def wasm_frame_vec_new_empty(out: Any) -> None:
-    return _wasm_frame_vec_new_empty(out)
+    return _wasm_frame_vec_new_empty(out)  # type: ignore
 
 _wasm_frame_vec_new_uninitialized = dll.wasm_frame_vec_new_uninitialized
 _wasm_frame_vec_new_uninitialized.restype = None
 _wasm_frame_vec_new_uninitialized.argtypes = [POINTER(wasm_frame_vec_t), c_size_t]
 def wasm_frame_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_frame_vec_new_uninitialized(out, arg1)
+    return _wasm_frame_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_frame_vec_new = dll.wasm_frame_vec_new
 _wasm_frame_vec_new.restype = None
 _wasm_frame_vec_new.argtypes = [POINTER(wasm_frame_vec_t), c_size_t, POINTER(POINTER(wasm_frame_t))]
 def wasm_frame_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_frame_vec_new(out, arg1, arg2)
+    return _wasm_frame_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_frame_vec_copy = dll.wasm_frame_vec_copy
 _wasm_frame_vec_copy.restype = None
 _wasm_frame_vec_copy.argtypes = [POINTER(wasm_frame_vec_t), POINTER(wasm_frame_vec_t)]
 def wasm_frame_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_frame_vec_copy(out, arg1)
+    return _wasm_frame_vec_copy(out, arg1)  # type: ignore
 
 _wasm_frame_vec_delete = dll.wasm_frame_vec_delete
 _wasm_frame_vec_delete.restype = None
 _wasm_frame_vec_delete.argtypes = [POINTER(wasm_frame_vec_t)]
 def wasm_frame_vec_delete(arg0: Any) -> None:
-    return _wasm_frame_vec_delete(arg0)
+    return _wasm_frame_vec_delete(arg0)  # type: ignore
 
 _wasm_frame_func_index = dll.wasm_frame_func_index
 _wasm_frame_func_index.restype = c_uint32
 _wasm_frame_func_index.argtypes = [POINTER(wasm_frame_t)]
 def wasm_frame_func_index(arg0: Any) -> int:
-    return _wasm_frame_func_index(arg0)
+    return _wasm_frame_func_index(arg0)  # type: ignore
 
 _wasm_frame_func_offset = dll.wasm_frame_func_offset
 _wasm_frame_func_offset.restype = c_size_t
 _wasm_frame_func_offset.argtypes = [POINTER(wasm_frame_t)]
 def wasm_frame_func_offset(arg0: Any) -> int:
-    return _wasm_frame_func_offset(arg0)
+    return _wasm_frame_func_offset(arg0)  # type: ignore
 
 _wasm_frame_module_offset = dll.wasm_frame_module_offset
 _wasm_frame_module_offset.restype = c_size_t
 _wasm_frame_module_offset.argtypes = [POINTER(wasm_frame_t)]
 def wasm_frame_module_offset(arg0: Any) -> int:
-    return _wasm_frame_module_offset(arg0)
+    return _wasm_frame_module_offset(arg0)  # type: ignore
 
 wasm_message_t = wasm_name_t
 
@@ -899,73 +899,73 @@ _wasm_trap_delete = dll.wasm_trap_delete
 _wasm_trap_delete.restype = None
 _wasm_trap_delete.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_delete(arg0: Any) -> None:
-    return _wasm_trap_delete(arg0)
+    return _wasm_trap_delete(arg0)  # type: ignore
 
 _wasm_trap_copy = dll.wasm_trap_copy
 _wasm_trap_copy.restype = POINTER(wasm_trap_t)
 _wasm_trap_copy.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_copy(arg0: Any) -> pointer:
-    return _wasm_trap_copy(arg0)
+    return _wasm_trap_copy(arg0)  # type: ignore
 
 _wasm_trap_same = dll.wasm_trap_same
 _wasm_trap_same.restype = c_bool
 _wasm_trap_same.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_trap_t)]
 def wasm_trap_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_trap_same(arg0, arg1)
+    return _wasm_trap_same(arg0, arg1)  # type: ignore
 
 _wasm_trap_get_host_info = dll.wasm_trap_get_host_info
 _wasm_trap_get_host_info.restype = c_void_p
 _wasm_trap_get_host_info.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_get_host_info(arg0: Any) -> pointer:
-    return _wasm_trap_get_host_info(arg0)
+    return _wasm_trap_get_host_info(arg0)  # type: ignore
 
 _wasm_trap_set_host_info = dll.wasm_trap_set_host_info
 _wasm_trap_set_host_info.restype = None
 _wasm_trap_set_host_info.argtypes = [POINTER(wasm_trap_t), c_void_p]
 def wasm_trap_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_trap_set_host_info(arg0, arg1)
+    return _wasm_trap_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_trap_set_host_info_with_finalizer = dll.wasm_trap_set_host_info_with_finalizer
 _wasm_trap_set_host_info_with_finalizer.restype = None
 _wasm_trap_set_host_info_with_finalizer.argtypes = [POINTER(wasm_trap_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_trap_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_trap_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_trap_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_trap_as_ref = dll.wasm_trap_as_ref
 _wasm_trap_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_trap_as_ref.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_as_ref(arg0: Any) -> pointer:
-    return _wasm_trap_as_ref(arg0)
+    return _wasm_trap_as_ref(arg0)  # type: ignore
 
 _wasm_trap_as_ref_const = dll.wasm_trap_as_ref_const
 _wasm_trap_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_trap_as_ref_const.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_trap_as_ref_const(arg0)
+    return _wasm_trap_as_ref_const(arg0)  # type: ignore
 
 _wasm_trap_new = dll.wasm_trap_new
 _wasm_trap_new.restype = POINTER(wasm_trap_t)
 _wasm_trap_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_message_t)]
 def wasm_trap_new(store: Any, arg1: Any) -> pointer:
-    return _wasm_trap_new(store, arg1)
+    return _wasm_trap_new(store, arg1)  # type: ignore
 
 _wasm_trap_message = dll.wasm_trap_message
 _wasm_trap_message.restype = None
 _wasm_trap_message.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_message_t)]
 def wasm_trap_message(arg0: Any, out: Any) -> None:
-    return _wasm_trap_message(arg0, out)
+    return _wasm_trap_message(arg0, out)  # type: ignore
 
 _wasm_trap_origin = dll.wasm_trap_origin
 _wasm_trap_origin.restype = POINTER(wasm_frame_t)
 _wasm_trap_origin.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_origin(arg0: Any) -> pointer:
-    return _wasm_trap_origin(arg0)
+    return _wasm_trap_origin(arg0)  # type: ignore
 
 _wasm_trap_trace = dll.wasm_trap_trace
 _wasm_trap_trace.restype = None
 _wasm_trap_trace.argtypes = [POINTER(wasm_trap_t), POINTER(wasm_frame_vec_t)]
 def wasm_trap_trace(arg0: Any, out: Any) -> None:
-    return _wasm_trap_trace(arg0, out)
+    return _wasm_trap_trace(arg0, out)  # type: ignore
 
 class wasm_foreign_t(Structure):
     pass
@@ -977,49 +977,49 @@ _wasm_module_delete = dll.wasm_module_delete
 _wasm_module_delete.restype = None
 _wasm_module_delete.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_delete(arg0: Any) -> None:
-    return _wasm_module_delete(arg0)
+    return _wasm_module_delete(arg0)  # type: ignore
 
 _wasm_module_copy = dll.wasm_module_copy
 _wasm_module_copy.restype = POINTER(wasm_module_t)
 _wasm_module_copy.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_copy(arg0: Any) -> pointer:
-    return _wasm_module_copy(arg0)
+    return _wasm_module_copy(arg0)  # type: ignore
 
 _wasm_module_same = dll.wasm_module_same
 _wasm_module_same.restype = c_bool
 _wasm_module_same.argtypes = [POINTER(wasm_module_t), POINTER(wasm_module_t)]
 def wasm_module_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_module_same(arg0, arg1)
+    return _wasm_module_same(arg0, arg1)  # type: ignore
 
 _wasm_module_get_host_info = dll.wasm_module_get_host_info
 _wasm_module_get_host_info.restype = c_void_p
 _wasm_module_get_host_info.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_get_host_info(arg0: Any) -> pointer:
-    return _wasm_module_get_host_info(arg0)
+    return _wasm_module_get_host_info(arg0)  # type: ignore
 
 _wasm_module_set_host_info = dll.wasm_module_set_host_info
 _wasm_module_set_host_info.restype = None
 _wasm_module_set_host_info.argtypes = [POINTER(wasm_module_t), c_void_p]
 def wasm_module_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_module_set_host_info(arg0, arg1)
+    return _wasm_module_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_module_set_host_info_with_finalizer = dll.wasm_module_set_host_info_with_finalizer
 _wasm_module_set_host_info_with_finalizer.restype = None
 _wasm_module_set_host_info_with_finalizer.argtypes = [POINTER(wasm_module_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_module_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_module_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_module_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_module_as_ref = dll.wasm_module_as_ref
 _wasm_module_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_module_as_ref.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_as_ref(arg0: Any) -> pointer:
-    return _wasm_module_as_ref(arg0)
+    return _wasm_module_as_ref(arg0)  # type: ignore
 
 _wasm_module_as_ref_const = dll.wasm_module_as_ref_const
 _wasm_module_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_module_as_ref_const.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_module_as_ref_const(arg0)
+    return _wasm_module_as_ref_const(arg0)  # type: ignore
 
 class wasm_shared_module_t(Structure):
     pass
@@ -1028,43 +1028,43 @@ _wasm_shared_module_delete = dll.wasm_shared_module_delete
 _wasm_shared_module_delete.restype = None
 _wasm_shared_module_delete.argtypes = [POINTER(wasm_shared_module_t)]
 def wasm_shared_module_delete(arg0: Any) -> None:
-    return _wasm_shared_module_delete(arg0)
+    return _wasm_shared_module_delete(arg0)  # type: ignore
 
 _wasm_module_share = dll.wasm_module_share
 _wasm_module_share.restype = POINTER(wasm_shared_module_t)
 _wasm_module_share.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_share(arg0: Any) -> pointer:
-    return _wasm_module_share(arg0)
+    return _wasm_module_share(arg0)  # type: ignore
 
 _wasm_module_obtain = dll.wasm_module_obtain
 _wasm_module_obtain.restype = POINTER(wasm_module_t)
 _wasm_module_obtain.argtypes = [POINTER(wasm_store_t), POINTER(wasm_shared_module_t)]
 def wasm_module_obtain(arg0: Any, arg1: Any) -> pointer:
-    return _wasm_module_obtain(arg0, arg1)
+    return _wasm_module_obtain(arg0, arg1)  # type: ignore
 
 _wasm_module_new = dll.wasm_module_new
 _wasm_module_new.restype = POINTER(wasm_module_t)
 _wasm_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
 def wasm_module_new(arg0: Any, binary: Any) -> pointer:
-    return _wasm_module_new(arg0, binary)
+    return _wasm_module_new(arg0, binary)  # type: ignore
 
 _wasm_module_validate = dll.wasm_module_validate
 _wasm_module_validate.restype = c_bool
 _wasm_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
 def wasm_module_validate(arg0: Any, binary: Any) -> c_bool:
-    return _wasm_module_validate(arg0, binary)
+    return _wasm_module_validate(arg0, binary)  # type: ignore
 
 _wasm_module_imports = dll.wasm_module_imports
 _wasm_module_imports.restype = None
 _wasm_module_imports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_importtype_vec_t)]
 def wasm_module_imports(arg0: Any, out: Any) -> None:
-    return _wasm_module_imports(arg0, out)
+    return _wasm_module_imports(arg0, out)  # type: ignore
 
 _wasm_module_exports = dll.wasm_module_exports
 _wasm_module_exports.restype = None
 _wasm_module_exports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_exporttype_vec_t)]
 def wasm_module_exports(arg0: Any, out: Any) -> None:
-    return _wasm_module_exports(arg0, out)
+    return _wasm_module_exports(arg0, out)  # type: ignore
 
 class wasm_func_t(Structure):
     pass
@@ -1073,49 +1073,49 @@ _wasm_func_delete = dll.wasm_func_delete
 _wasm_func_delete.restype = None
 _wasm_func_delete.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_delete(arg0: Any) -> None:
-    return _wasm_func_delete(arg0)
+    return _wasm_func_delete(arg0)  # type: ignore
 
 _wasm_func_copy = dll.wasm_func_copy
 _wasm_func_copy.restype = POINTER(wasm_func_t)
 _wasm_func_copy.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_copy(arg0: Any) -> pointer:
-    return _wasm_func_copy(arg0)
+    return _wasm_func_copy(arg0)  # type: ignore
 
 _wasm_func_same = dll.wasm_func_same
 _wasm_func_same.restype = c_bool
 _wasm_func_same.argtypes = [POINTER(wasm_func_t), POINTER(wasm_func_t)]
 def wasm_func_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_func_same(arg0, arg1)
+    return _wasm_func_same(arg0, arg1)  # type: ignore
 
 _wasm_func_get_host_info = dll.wasm_func_get_host_info
 _wasm_func_get_host_info.restype = c_void_p
 _wasm_func_get_host_info.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_get_host_info(arg0: Any) -> pointer:
-    return _wasm_func_get_host_info(arg0)
+    return _wasm_func_get_host_info(arg0)  # type: ignore
 
 _wasm_func_set_host_info = dll.wasm_func_set_host_info
 _wasm_func_set_host_info.restype = None
 _wasm_func_set_host_info.argtypes = [POINTER(wasm_func_t), c_void_p]
 def wasm_func_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_func_set_host_info(arg0, arg1)
+    return _wasm_func_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_func_set_host_info_with_finalizer = dll.wasm_func_set_host_info_with_finalizer
 _wasm_func_set_host_info_with_finalizer.restype = None
 _wasm_func_set_host_info_with_finalizer.argtypes = [POINTER(wasm_func_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_func_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_func_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_func_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_func_as_ref = dll.wasm_func_as_ref
 _wasm_func_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_func_as_ref.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_as_ref(arg0: Any) -> pointer:
-    return _wasm_func_as_ref(arg0)
+    return _wasm_func_as_ref(arg0)  # type: ignore
 
 _wasm_func_as_ref_const = dll.wasm_func_as_ref_const
 _wasm_func_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_func_as_ref_const.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_func_as_ref_const(arg0)
+    return _wasm_func_as_ref_const(arg0)  # type: ignore
 
 wasm_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasm_val_t), POINTER(wasm_val_t))
 
@@ -1125,37 +1125,37 @@ _wasm_func_new = dll.wasm_func_new
 _wasm_func_new.restype = POINTER(wasm_func_t)
 _wasm_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_t]
 def wasm_func_new(arg0: Any, arg1: Any, arg2: Any) -> pointer:
-    return _wasm_func_new(arg0, arg1, arg2)
+    return _wasm_func_new(arg0, arg1, arg2)  # type: ignore
 
 _wasm_func_new_with_env = dll.wasm_func_new_with_env
 _wasm_func_new_with_env.restype = POINTER(wasm_func_t)
 _wasm_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasm_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_func_new_with_env(arg0: Any, type: Any, arg2: Any, env: Any, finalizer: Any) -> pointer:
-    return _wasm_func_new_with_env(arg0, type, arg2, env, finalizer)
+    return _wasm_func_new_with_env(arg0, type, arg2, env, finalizer)  # type: ignore
 
 _wasm_func_type = dll.wasm_func_type
 _wasm_func_type.restype = POINTER(wasm_functype_t)
 _wasm_func_type.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_type(arg0: Any) -> pointer:
-    return _wasm_func_type(arg0)
+    return _wasm_func_type(arg0)  # type: ignore
 
 _wasm_func_param_arity = dll.wasm_func_param_arity
 _wasm_func_param_arity.restype = c_size_t
 _wasm_func_param_arity.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_param_arity(arg0: Any) -> int:
-    return _wasm_func_param_arity(arg0)
+    return _wasm_func_param_arity(arg0)  # type: ignore
 
 _wasm_func_result_arity = dll.wasm_func_result_arity
 _wasm_func_result_arity.restype = c_size_t
 _wasm_func_result_arity.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_result_arity(arg0: Any) -> int:
-    return _wasm_func_result_arity(arg0)
+    return _wasm_func_result_arity(arg0)  # type: ignore
 
 _wasm_func_call = dll.wasm_func_call
 _wasm_func_call.restype = POINTER(wasm_trap_t)
 _wasm_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), POINTER(wasm_val_t)]
 def wasm_func_call(arg0: Any, args: Any, results: Any) -> pointer:
-    return _wasm_func_call(arg0, args, results)
+    return _wasm_func_call(arg0, args, results)  # type: ignore
 
 class wasm_global_t(Structure):
     pass
@@ -1164,73 +1164,73 @@ _wasm_global_delete = dll.wasm_global_delete
 _wasm_global_delete.restype = None
 _wasm_global_delete.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_delete(arg0: Any) -> None:
-    return _wasm_global_delete(arg0)
+    return _wasm_global_delete(arg0)  # type: ignore
 
 _wasm_global_copy = dll.wasm_global_copy
 _wasm_global_copy.restype = POINTER(wasm_global_t)
 _wasm_global_copy.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_copy(arg0: Any) -> pointer:
-    return _wasm_global_copy(arg0)
+    return _wasm_global_copy(arg0)  # type: ignore
 
 _wasm_global_same = dll.wasm_global_same
 _wasm_global_same.restype = c_bool
 _wasm_global_same.argtypes = [POINTER(wasm_global_t), POINTER(wasm_global_t)]
 def wasm_global_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_global_same(arg0, arg1)
+    return _wasm_global_same(arg0, arg1)  # type: ignore
 
 _wasm_global_get_host_info = dll.wasm_global_get_host_info
 _wasm_global_get_host_info.restype = c_void_p
 _wasm_global_get_host_info.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_get_host_info(arg0: Any) -> pointer:
-    return _wasm_global_get_host_info(arg0)
+    return _wasm_global_get_host_info(arg0)  # type: ignore
 
 _wasm_global_set_host_info = dll.wasm_global_set_host_info
 _wasm_global_set_host_info.restype = None
 _wasm_global_set_host_info.argtypes = [POINTER(wasm_global_t), c_void_p]
 def wasm_global_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_global_set_host_info(arg0, arg1)
+    return _wasm_global_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_global_set_host_info_with_finalizer = dll.wasm_global_set_host_info_with_finalizer
 _wasm_global_set_host_info_with_finalizer.restype = None
 _wasm_global_set_host_info_with_finalizer.argtypes = [POINTER(wasm_global_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_global_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_global_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_global_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_global_as_ref = dll.wasm_global_as_ref
 _wasm_global_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_global_as_ref.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_as_ref(arg0: Any) -> pointer:
-    return _wasm_global_as_ref(arg0)
+    return _wasm_global_as_ref(arg0)  # type: ignore
 
 _wasm_global_as_ref_const = dll.wasm_global_as_ref_const
 _wasm_global_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_global_as_ref_const.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_global_as_ref_const(arg0)
+    return _wasm_global_as_ref_const(arg0)  # type: ignore
 
 _wasm_global_new = dll.wasm_global_new
 _wasm_global_new.restype = POINTER(wasm_global_t)
 _wasm_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t)]
 def wasm_global_new(arg0: Any, arg1: Any, arg2: Any) -> pointer:
-    return _wasm_global_new(arg0, arg1, arg2)
+    return _wasm_global_new(arg0, arg1, arg2)  # type: ignore
 
 _wasm_global_type = dll.wasm_global_type
 _wasm_global_type.restype = POINTER(wasm_globaltype_t)
 _wasm_global_type.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_type(arg0: Any) -> pointer:
-    return _wasm_global_type(arg0)
+    return _wasm_global_type(arg0)  # type: ignore
 
 _wasm_global_get = dll.wasm_global_get
 _wasm_global_get.restype = None
 _wasm_global_get.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
 def wasm_global_get(arg0: Any, out: Any) -> None:
-    return _wasm_global_get(arg0, out)
+    return _wasm_global_get(arg0, out)  # type: ignore
 
 _wasm_global_set = dll.wasm_global_set
 _wasm_global_set.restype = None
 _wasm_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
 def wasm_global_set(arg0: Any, arg1: Any) -> None:
-    return _wasm_global_set(arg0, arg1)
+    return _wasm_global_set(arg0, arg1)  # type: ignore
 
 class wasm_table_t(Structure):
     pass
@@ -1239,49 +1239,49 @@ _wasm_table_delete = dll.wasm_table_delete
 _wasm_table_delete.restype = None
 _wasm_table_delete.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_delete(arg0: Any) -> None:
-    return _wasm_table_delete(arg0)
+    return _wasm_table_delete(arg0)  # type: ignore
 
 _wasm_table_copy = dll.wasm_table_copy
 _wasm_table_copy.restype = POINTER(wasm_table_t)
 _wasm_table_copy.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_copy(arg0: Any) -> pointer:
-    return _wasm_table_copy(arg0)
+    return _wasm_table_copy(arg0)  # type: ignore
 
 _wasm_table_same = dll.wasm_table_same
 _wasm_table_same.restype = c_bool
 _wasm_table_same.argtypes = [POINTER(wasm_table_t), POINTER(wasm_table_t)]
 def wasm_table_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_table_same(arg0, arg1)
+    return _wasm_table_same(arg0, arg1)  # type: ignore
 
 _wasm_table_get_host_info = dll.wasm_table_get_host_info
 _wasm_table_get_host_info.restype = c_void_p
 _wasm_table_get_host_info.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_get_host_info(arg0: Any) -> pointer:
-    return _wasm_table_get_host_info(arg0)
+    return _wasm_table_get_host_info(arg0)  # type: ignore
 
 _wasm_table_set_host_info = dll.wasm_table_set_host_info
 _wasm_table_set_host_info.restype = None
 _wasm_table_set_host_info.argtypes = [POINTER(wasm_table_t), c_void_p]
 def wasm_table_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_table_set_host_info(arg0, arg1)
+    return _wasm_table_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_table_set_host_info_with_finalizer = dll.wasm_table_set_host_info_with_finalizer
 _wasm_table_set_host_info_with_finalizer.restype = None
 _wasm_table_set_host_info_with_finalizer.argtypes = [POINTER(wasm_table_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_table_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_table_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_table_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_table_as_ref = dll.wasm_table_as_ref
 _wasm_table_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_table_as_ref.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_as_ref(arg0: Any) -> pointer:
-    return _wasm_table_as_ref(arg0)
+    return _wasm_table_as_ref(arg0)  # type: ignore
 
 _wasm_table_as_ref_const = dll.wasm_table_as_ref_const
 _wasm_table_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_table_as_ref_const.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_table_as_ref_const(arg0)
+    return _wasm_table_as_ref_const(arg0)  # type: ignore
 
 wasm_table_size_t = c_uint32
 
@@ -1289,37 +1289,37 @@ _wasm_table_new = dll.wasm_table_new
 _wasm_table_new.restype = POINTER(wasm_table_t)
 _wasm_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_ref_t)]
 def wasm_table_new(arg0: Any, arg1: Any, init: Any) -> pointer:
-    return _wasm_table_new(arg0, arg1, init)
+    return _wasm_table_new(arg0, arg1, init)  # type: ignore
 
 _wasm_table_type = dll.wasm_table_type
 _wasm_table_type.restype = POINTER(wasm_tabletype_t)
 _wasm_table_type.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_type(arg0: Any) -> pointer:
-    return _wasm_table_type(arg0)
+    return _wasm_table_type(arg0)  # type: ignore
 
 _wasm_table_get = dll.wasm_table_get
 _wasm_table_get.restype = POINTER(wasm_ref_t)
 _wasm_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t]
 def wasm_table_get(arg0: Any, index: Any) -> pointer:
-    return _wasm_table_get(arg0, index)
+    return _wasm_table_get(arg0, index)  # type: ignore
 
 _wasm_table_set = dll.wasm_table_set
 _wasm_table_set.restype = c_bool
 _wasm_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
 def wasm_table_set(arg0: Any, index: Any, arg2: Any) -> c_bool:
-    return _wasm_table_set(arg0, index, arg2)
+    return _wasm_table_set(arg0, index, arg2)  # type: ignore
 
 _wasm_table_size = dll.wasm_table_size
 _wasm_table_size.restype = wasm_table_size_t
 _wasm_table_size.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_size(arg0: Any) -> int:
-    return _wasm_table_size(arg0)
+    return _wasm_table_size(arg0)  # type: ignore
 
 _wasm_table_grow = dll.wasm_table_grow
 _wasm_table_grow.restype = c_bool
 _wasm_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_ref_t)]
 def wasm_table_grow(arg0: Any, delta: Any, init: Any) -> c_bool:
-    return _wasm_table_grow(arg0, delta, init)
+    return _wasm_table_grow(arg0, delta, init)  # type: ignore
 
 class wasm_memory_t(Structure):
     pass
@@ -1328,49 +1328,49 @@ _wasm_memory_delete = dll.wasm_memory_delete
 _wasm_memory_delete.restype = None
 _wasm_memory_delete.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_delete(arg0: Any) -> None:
-    return _wasm_memory_delete(arg0)
+    return _wasm_memory_delete(arg0)  # type: ignore
 
 _wasm_memory_copy = dll.wasm_memory_copy
 _wasm_memory_copy.restype = POINTER(wasm_memory_t)
 _wasm_memory_copy.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_copy(arg0: Any) -> pointer:
-    return _wasm_memory_copy(arg0)
+    return _wasm_memory_copy(arg0)  # type: ignore
 
 _wasm_memory_same = dll.wasm_memory_same
 _wasm_memory_same.restype = c_bool
 _wasm_memory_same.argtypes = [POINTER(wasm_memory_t), POINTER(wasm_memory_t)]
 def wasm_memory_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_memory_same(arg0, arg1)
+    return _wasm_memory_same(arg0, arg1)  # type: ignore
 
 _wasm_memory_get_host_info = dll.wasm_memory_get_host_info
 _wasm_memory_get_host_info.restype = c_void_p
 _wasm_memory_get_host_info.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_get_host_info(arg0: Any) -> pointer:
-    return _wasm_memory_get_host_info(arg0)
+    return _wasm_memory_get_host_info(arg0)  # type: ignore
 
 _wasm_memory_set_host_info = dll.wasm_memory_set_host_info
 _wasm_memory_set_host_info.restype = None
 _wasm_memory_set_host_info.argtypes = [POINTER(wasm_memory_t), c_void_p]
 def wasm_memory_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_memory_set_host_info(arg0, arg1)
+    return _wasm_memory_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_memory_set_host_info_with_finalizer = dll.wasm_memory_set_host_info_with_finalizer
 _wasm_memory_set_host_info_with_finalizer.restype = None
 _wasm_memory_set_host_info_with_finalizer.argtypes = [POINTER(wasm_memory_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_memory_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_memory_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_memory_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_memory_as_ref = dll.wasm_memory_as_ref
 _wasm_memory_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_memory_as_ref.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_as_ref(arg0: Any) -> pointer:
-    return _wasm_memory_as_ref(arg0)
+    return _wasm_memory_as_ref(arg0)  # type: ignore
 
 _wasm_memory_as_ref_const = dll.wasm_memory_as_ref_const
 _wasm_memory_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_memory_as_ref_const.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_memory_as_ref_const(arg0)
+    return _wasm_memory_as_ref_const(arg0)  # type: ignore
 
 wasm_memory_pages_t = c_uint32
 
@@ -1378,37 +1378,37 @@ _wasm_memory_new = dll.wasm_memory_new
 _wasm_memory_new.restype = POINTER(wasm_memory_t)
 _wasm_memory_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_memorytype_t)]
 def wasm_memory_new(arg0: Any, arg1: Any) -> pointer:
-    return _wasm_memory_new(arg0, arg1)
+    return _wasm_memory_new(arg0, arg1)  # type: ignore
 
 _wasm_memory_type = dll.wasm_memory_type
 _wasm_memory_type.restype = POINTER(wasm_memorytype_t)
 _wasm_memory_type.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_type(arg0: Any) -> pointer:
-    return _wasm_memory_type(arg0)
+    return _wasm_memory_type(arg0)  # type: ignore
 
 _wasm_memory_data = dll.wasm_memory_data
 _wasm_memory_data.restype = POINTER(c_ubyte)
 _wasm_memory_data.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_data(arg0: Any) -> pointer:
-    return _wasm_memory_data(arg0)
+    return _wasm_memory_data(arg0)  # type: ignore
 
 _wasm_memory_data_size = dll.wasm_memory_data_size
 _wasm_memory_data_size.restype = c_size_t
 _wasm_memory_data_size.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_data_size(arg0: Any) -> int:
-    return _wasm_memory_data_size(arg0)
+    return _wasm_memory_data_size(arg0)  # type: ignore
 
 _wasm_memory_size = dll.wasm_memory_size
 _wasm_memory_size.restype = wasm_memory_pages_t
 _wasm_memory_size.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_size(arg0: Any) -> int:
-    return _wasm_memory_size(arg0)
+    return _wasm_memory_size(arg0)  # type: ignore
 
 _wasm_memory_grow = dll.wasm_memory_grow
 _wasm_memory_grow.restype = c_bool
 _wasm_memory_grow.argtypes = [POINTER(wasm_memory_t), wasm_memory_pages_t]
 def wasm_memory_grow(arg0: Any, delta: Any) -> c_bool:
-    return _wasm_memory_grow(arg0, delta)
+    return _wasm_memory_grow(arg0, delta)  # type: ignore
 
 class wasm_extern_t(Structure):
     pass
@@ -1417,49 +1417,49 @@ _wasm_extern_delete = dll.wasm_extern_delete
 _wasm_extern_delete.restype = None
 _wasm_extern_delete.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_delete(arg0: Any) -> None:
-    return _wasm_extern_delete(arg0)
+    return _wasm_extern_delete(arg0)  # type: ignore
 
 _wasm_extern_copy = dll.wasm_extern_copy
 _wasm_extern_copy.restype = POINTER(wasm_extern_t)
 _wasm_extern_copy.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_copy(arg0: Any) -> pointer:
-    return _wasm_extern_copy(arg0)
+    return _wasm_extern_copy(arg0)  # type: ignore
 
 _wasm_extern_same = dll.wasm_extern_same
 _wasm_extern_same.restype = c_bool
 _wasm_extern_same.argtypes = [POINTER(wasm_extern_t), POINTER(wasm_extern_t)]
 def wasm_extern_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_extern_same(arg0, arg1)
+    return _wasm_extern_same(arg0, arg1)  # type: ignore
 
 _wasm_extern_get_host_info = dll.wasm_extern_get_host_info
 _wasm_extern_get_host_info.restype = c_void_p
 _wasm_extern_get_host_info.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_get_host_info(arg0: Any) -> pointer:
-    return _wasm_extern_get_host_info(arg0)
+    return _wasm_extern_get_host_info(arg0)  # type: ignore
 
 _wasm_extern_set_host_info = dll.wasm_extern_set_host_info
 _wasm_extern_set_host_info.restype = None
 _wasm_extern_set_host_info.argtypes = [POINTER(wasm_extern_t), c_void_p]
 def wasm_extern_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_extern_set_host_info(arg0, arg1)
+    return _wasm_extern_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_extern_set_host_info_with_finalizer = dll.wasm_extern_set_host_info_with_finalizer
 _wasm_extern_set_host_info_with_finalizer.restype = None
 _wasm_extern_set_host_info_with_finalizer.argtypes = [POINTER(wasm_extern_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_extern_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_extern_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_extern_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_extern_as_ref = dll.wasm_extern_as_ref
 _wasm_extern_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_extern_as_ref.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_ref(arg0: Any) -> pointer:
-    return _wasm_extern_as_ref(arg0)
+    return _wasm_extern_as_ref(arg0)  # type: ignore
 
 _wasm_extern_as_ref_const = dll.wasm_extern_as_ref_const
 _wasm_extern_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_extern_as_ref_const.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_ref_const(arg0)
+    return _wasm_extern_as_ref_const(arg0)  # type: ignore
 
 class wasm_extern_vec_t(Structure):
     _fields_ = [
@@ -1471,115 +1471,115 @@ _wasm_extern_vec_new_empty = dll.wasm_extern_vec_new_empty
 _wasm_extern_vec_new_empty.restype = None
 _wasm_extern_vec_new_empty.argtypes = [POINTER(wasm_extern_vec_t)]
 def wasm_extern_vec_new_empty(out: Any) -> None:
-    return _wasm_extern_vec_new_empty(out)
+    return _wasm_extern_vec_new_empty(out)  # type: ignore
 
 _wasm_extern_vec_new_uninitialized = dll.wasm_extern_vec_new_uninitialized
 _wasm_extern_vec_new_uninitialized.restype = None
 _wasm_extern_vec_new_uninitialized.argtypes = [POINTER(wasm_extern_vec_t), c_size_t]
 def wasm_extern_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_extern_vec_new_uninitialized(out, arg1)
+    return _wasm_extern_vec_new_uninitialized(out, arg1)  # type: ignore
 
 _wasm_extern_vec_new = dll.wasm_extern_vec_new
 _wasm_extern_vec_new.restype = None
 _wasm_extern_vec_new.argtypes = [POINTER(wasm_extern_vec_t), c_size_t, POINTER(POINTER(wasm_extern_t))]
 def wasm_extern_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_extern_vec_new(out, arg1, arg2)
+    return _wasm_extern_vec_new(out, arg1, arg2)  # type: ignore
 
 _wasm_extern_vec_copy = dll.wasm_extern_vec_copy
 _wasm_extern_vec_copy.restype = None
 _wasm_extern_vec_copy.argtypes = [POINTER(wasm_extern_vec_t), POINTER(wasm_extern_vec_t)]
 def wasm_extern_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_extern_vec_copy(out, arg1)
+    return _wasm_extern_vec_copy(out, arg1)  # type: ignore
 
 _wasm_extern_vec_delete = dll.wasm_extern_vec_delete
 _wasm_extern_vec_delete.restype = None
 _wasm_extern_vec_delete.argtypes = [POINTER(wasm_extern_vec_t)]
 def wasm_extern_vec_delete(arg0: Any) -> None:
-    return _wasm_extern_vec_delete(arg0)
+    return _wasm_extern_vec_delete(arg0)  # type: ignore
 
 _wasm_extern_kind = dll.wasm_extern_kind
 _wasm_extern_kind.restype = wasm_externkind_t
 _wasm_extern_kind.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_kind(arg0: Any) -> wasm_externkind_t:
-    return _wasm_extern_kind(arg0)
+    return _wasm_extern_kind(arg0)  # type: ignore
 
 _wasm_extern_type = dll.wasm_extern_type
 _wasm_extern_type.restype = POINTER(wasm_externtype_t)
 _wasm_extern_type.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_type(arg0: Any) -> pointer:
-    return _wasm_extern_type(arg0)
+    return _wasm_extern_type(arg0)  # type: ignore
 
 _wasm_func_as_extern = dll.wasm_func_as_extern
 _wasm_func_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_func_as_extern.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_as_extern(arg0: Any) -> pointer:
-    return _wasm_func_as_extern(arg0)
+    return _wasm_func_as_extern(arg0)  # type: ignore
 
 _wasm_global_as_extern = dll.wasm_global_as_extern
 _wasm_global_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_global_as_extern.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_as_extern(arg0: Any) -> pointer:
-    return _wasm_global_as_extern(arg0)
+    return _wasm_global_as_extern(arg0)  # type: ignore
 
 _wasm_table_as_extern = dll.wasm_table_as_extern
 _wasm_table_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_table_as_extern.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_as_extern(arg0: Any) -> pointer:
-    return _wasm_table_as_extern(arg0)
+    return _wasm_table_as_extern(arg0)  # type: ignore
 
 _wasm_memory_as_extern = dll.wasm_memory_as_extern
 _wasm_memory_as_extern.restype = POINTER(wasm_extern_t)
 _wasm_memory_as_extern.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_as_extern(arg0: Any) -> pointer:
-    return _wasm_memory_as_extern(arg0)
+    return _wasm_memory_as_extern(arg0)  # type: ignore
 
 _wasm_extern_as_func = dll.wasm_extern_as_func
 _wasm_extern_as_func.restype = POINTER(wasm_func_t)
 _wasm_extern_as_func.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_func(arg0: Any) -> pointer:
-    return _wasm_extern_as_func(arg0)
+    return _wasm_extern_as_func(arg0)  # type: ignore
 
 _wasm_extern_as_global = dll.wasm_extern_as_global
 _wasm_extern_as_global.restype = POINTER(wasm_global_t)
 _wasm_extern_as_global.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_global(arg0: Any) -> pointer:
-    return _wasm_extern_as_global(arg0)
+    return _wasm_extern_as_global(arg0)  # type: ignore
 
 _wasm_extern_as_table = dll.wasm_extern_as_table
 _wasm_extern_as_table.restype = POINTER(wasm_table_t)
 _wasm_extern_as_table.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_table(arg0: Any) -> pointer:
-    return _wasm_extern_as_table(arg0)
+    return _wasm_extern_as_table(arg0)  # type: ignore
 
 _wasm_extern_as_memory = dll.wasm_extern_as_memory
 _wasm_extern_as_memory.restype = POINTER(wasm_memory_t)
 _wasm_extern_as_memory.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_memory(arg0: Any) -> pointer:
-    return _wasm_extern_as_memory(arg0)
+    return _wasm_extern_as_memory(arg0)  # type: ignore
 
 _wasm_extern_as_func_const = dll.wasm_extern_as_func_const
 _wasm_extern_as_func_const.restype = POINTER(wasm_func_t)
 _wasm_extern_as_func_const.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_func_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_func_const(arg0)
+    return _wasm_extern_as_func_const(arg0)  # type: ignore
 
 _wasm_extern_as_global_const = dll.wasm_extern_as_global_const
 _wasm_extern_as_global_const.restype = POINTER(wasm_global_t)
 _wasm_extern_as_global_const.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_global_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_global_const(arg0)
+    return _wasm_extern_as_global_const(arg0)  # type: ignore
 
 _wasm_extern_as_table_const = dll.wasm_extern_as_table_const
 _wasm_extern_as_table_const.restype = POINTER(wasm_table_t)
 _wasm_extern_as_table_const.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_table_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_table_const(arg0)
+    return _wasm_extern_as_table_const(arg0)  # type: ignore
 
 _wasm_extern_as_memory_const = dll.wasm_extern_as_memory_const
 _wasm_extern_as_memory_const.restype = POINTER(wasm_memory_t)
 _wasm_extern_as_memory_const.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_memory_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_memory_const(arg0)
+    return _wasm_extern_as_memory_const(arg0)  # type: ignore
 
 class wasm_instance_t(Structure):
     pass
@@ -1588,61 +1588,61 @@ _wasm_instance_delete = dll.wasm_instance_delete
 _wasm_instance_delete.restype = None
 _wasm_instance_delete.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_delete(arg0: Any) -> None:
-    return _wasm_instance_delete(arg0)
+    return _wasm_instance_delete(arg0)  # type: ignore
 
 _wasm_instance_copy = dll.wasm_instance_copy
 _wasm_instance_copy.restype = POINTER(wasm_instance_t)
 _wasm_instance_copy.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_copy(arg0: Any) -> pointer:
-    return _wasm_instance_copy(arg0)
+    return _wasm_instance_copy(arg0)  # type: ignore
 
 _wasm_instance_same = dll.wasm_instance_same
 _wasm_instance_same.restype = c_bool
 _wasm_instance_same.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_instance_t)]
 def wasm_instance_same(arg0: Any, arg1: Any) -> c_bool:
-    return _wasm_instance_same(arg0, arg1)
+    return _wasm_instance_same(arg0, arg1)  # type: ignore
 
 _wasm_instance_get_host_info = dll.wasm_instance_get_host_info
 _wasm_instance_get_host_info.restype = c_void_p
 _wasm_instance_get_host_info.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_get_host_info(arg0: Any) -> pointer:
-    return _wasm_instance_get_host_info(arg0)
+    return _wasm_instance_get_host_info(arg0)  # type: ignore
 
 _wasm_instance_set_host_info = dll.wasm_instance_set_host_info
 _wasm_instance_set_host_info.restype = None
 _wasm_instance_set_host_info.argtypes = [POINTER(wasm_instance_t), c_void_p]
 def wasm_instance_set_host_info(arg0: Any, arg1: Any) -> None:
-    return _wasm_instance_set_host_info(arg0, arg1)
+    return _wasm_instance_set_host_info(arg0, arg1)  # type: ignore
 
 _wasm_instance_set_host_info_with_finalizer = dll.wasm_instance_set_host_info_with_finalizer
 _wasm_instance_set_host_info_with_finalizer.restype = None
 _wasm_instance_set_host_info_with_finalizer.argtypes = [POINTER(wasm_instance_t), c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasm_instance_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_instance_set_host_info_with_finalizer(arg0, arg1, arg2)
+    return _wasm_instance_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
 
 _wasm_instance_as_ref = dll.wasm_instance_as_ref
 _wasm_instance_as_ref.restype = POINTER(wasm_ref_t)
 _wasm_instance_as_ref.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_as_ref(arg0: Any) -> pointer:
-    return _wasm_instance_as_ref(arg0)
+    return _wasm_instance_as_ref(arg0)  # type: ignore
 
 _wasm_instance_as_ref_const = dll.wasm_instance_as_ref_const
 _wasm_instance_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_instance_as_ref_const.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_as_ref_const(arg0: Any) -> pointer:
-    return _wasm_instance_as_ref_const(arg0)
+    return _wasm_instance_as_ref_const(arg0)  # type: ignore
 
 _wasm_instance_new = dll.wasm_instance_new
 _wasm_instance_new.restype = POINTER(wasm_instance_t)
 _wasm_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), POINTER(POINTER(wasm_trap_t))]
 def wasm_instance_new(arg0: Any, arg1: Any, imports: Any, arg3: Any) -> pointer:
-    return _wasm_instance_new(arg0, arg1, imports, arg3)
+    return _wasm_instance_new(arg0, arg1, imports, arg3)  # type: ignore
 
 _wasm_instance_exports = dll.wasm_instance_exports
 _wasm_instance_exports.restype = None
 _wasm_instance_exports.argtypes = [POINTER(wasm_instance_t), POINTER(wasm_extern_vec_t)]
 def wasm_instance_exports(arg0: Any, out: Any) -> None:
-    return _wasm_instance_exports(arg0, out)
+    return _wasm_instance_exports(arg0, out)  # type: ignore
 
 class wasi_config_t(Structure):
     pass
@@ -1651,79 +1651,79 @@ _wasi_config_delete = dll.wasi_config_delete
 _wasi_config_delete.restype = None
 _wasi_config_delete.argtypes = [POINTER(wasi_config_t)]
 def wasi_config_delete(arg0: Any) -> None:
-    return _wasi_config_delete(arg0)
+    return _wasi_config_delete(arg0)  # type: ignore
 
 _wasi_config_new = dll.wasi_config_new
 _wasi_config_new.restype = POINTER(wasi_config_t)
 _wasi_config_new.argtypes = []
 def wasi_config_new() -> pointer:
-    return _wasi_config_new()
+    return _wasi_config_new()  # type: ignore
 
 _wasi_config_set_argv = dll.wasi_config_set_argv
 _wasi_config_set_argv.restype = None
 _wasi_config_set_argv.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char))]
 def wasi_config_set_argv(config: Any, argc: Any, argv: Any) -> None:
-    return _wasi_config_set_argv(config, argc, argv)
+    return _wasi_config_set_argv(config, argc, argv)  # type: ignore
 
 _wasi_config_inherit_argv = dll.wasi_config_inherit_argv
 _wasi_config_inherit_argv.restype = None
 _wasi_config_inherit_argv.argtypes = [POINTER(wasi_config_t)]
 def wasi_config_inherit_argv(config: Any) -> None:
-    return _wasi_config_inherit_argv(config)
+    return _wasi_config_inherit_argv(config)  # type: ignore
 
 _wasi_config_set_env = dll.wasi_config_set_env
 _wasi_config_set_env.restype = None
 _wasi_config_set_env.argtypes = [POINTER(wasi_config_t), c_int, POINTER(POINTER(c_char)), POINTER(POINTER(c_char))]
 def wasi_config_set_env(config: Any, envc: Any, names: Any, values: Any) -> None:
-    return _wasi_config_set_env(config, envc, names, values)
+    return _wasi_config_set_env(config, envc, names, values)  # type: ignore
 
 _wasi_config_inherit_env = dll.wasi_config_inherit_env
 _wasi_config_inherit_env.restype = None
 _wasi_config_inherit_env.argtypes = [POINTER(wasi_config_t)]
 def wasi_config_inherit_env(config: Any) -> None:
-    return _wasi_config_inherit_env(config)
+    return _wasi_config_inherit_env(config)  # type: ignore
 
 _wasi_config_set_stdin_file = dll.wasi_config_set_stdin_file
 _wasi_config_set_stdin_file.restype = c_bool
 _wasi_config_set_stdin_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
 def wasi_config_set_stdin_file(config: Any, path: Any) -> c_bool:
-    return _wasi_config_set_stdin_file(config, path)
+    return _wasi_config_set_stdin_file(config, path)  # type: ignore
 
 _wasi_config_inherit_stdin = dll.wasi_config_inherit_stdin
 _wasi_config_inherit_stdin.restype = None
 _wasi_config_inherit_stdin.argtypes = [POINTER(wasi_config_t)]
 def wasi_config_inherit_stdin(config: Any) -> None:
-    return _wasi_config_inherit_stdin(config)
+    return _wasi_config_inherit_stdin(config)  # type: ignore
 
 _wasi_config_set_stdout_file = dll.wasi_config_set_stdout_file
 _wasi_config_set_stdout_file.restype = c_bool
 _wasi_config_set_stdout_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
 def wasi_config_set_stdout_file(config: Any, path: Any) -> c_bool:
-    return _wasi_config_set_stdout_file(config, path)
+    return _wasi_config_set_stdout_file(config, path)  # type: ignore
 
 _wasi_config_inherit_stdout = dll.wasi_config_inherit_stdout
 _wasi_config_inherit_stdout.restype = None
 _wasi_config_inherit_stdout.argtypes = [POINTER(wasi_config_t)]
 def wasi_config_inherit_stdout(config: Any) -> None:
-    return _wasi_config_inherit_stdout(config)
+    return _wasi_config_inherit_stdout(config)  # type: ignore
 
 _wasi_config_set_stderr_file = dll.wasi_config_set_stderr_file
 _wasi_config_set_stderr_file.restype = c_bool
 _wasi_config_set_stderr_file.argtypes = [POINTER(wasi_config_t), POINTER(c_char)]
 def wasi_config_set_stderr_file(config: Any, path: Any) -> c_bool:
-    return _wasi_config_set_stderr_file(config, path)
+    return _wasi_config_set_stderr_file(config, path)  # type: ignore
 
 _wasi_config_inherit_stderr = dll.wasi_config_inherit_stderr
 _wasi_config_inherit_stderr.restype = None
 _wasi_config_inherit_stderr.argtypes = [POINTER(wasi_config_t)]
 def wasi_config_inherit_stderr(config: Any) -> None:
-    return _wasi_config_inherit_stderr(config)
+    return _wasi_config_inherit_stderr(config)  # type: ignore
 
 _wasi_config_preopen_dir = dll.wasi_config_preopen_dir
 _wasi_config_preopen_dir.restype = c_bool
 _wasi_config_preopen_dir.argtypes = [POINTER(wasi_config_t), POINTER(c_char), POINTER(c_char)]
 def wasi_config_preopen_dir(config: Any, path: Any, guest_path: Any) -> c_bool:
-    return _wasi_config_preopen_dir(config, path, guest_path)
+    return _wasi_config_preopen_dir(config, path, guest_path)  # type: ignore
 
 class wasi_instance_t(Structure):
     pass
@@ -1732,19 +1732,19 @@ _wasi_instance_delete = dll.wasi_instance_delete
 _wasi_instance_delete.restype = None
 _wasi_instance_delete.argtypes = [POINTER(wasi_instance_t)]
 def wasi_instance_delete(arg0: Any) -> None:
-    return _wasi_instance_delete(arg0)
+    return _wasi_instance_delete(arg0)  # type: ignore
 
 _wasi_instance_new = dll.wasi_instance_new
 _wasi_instance_new.restype = POINTER(wasi_instance_t)
 _wasi_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(c_char), POINTER(wasi_config_t), POINTER(POINTER(wasm_trap_t))]
 def wasi_instance_new(store: Any, name: Any, config: Any, trap: Any) -> pointer:
-    return _wasi_instance_new(store, name, config, trap)
+    return _wasi_instance_new(store, name, config, trap)  # type: ignore
 
 _wasi_instance_bind_import = dll.wasi_instance_bind_import
 _wasi_instance_bind_import.restype = POINTER(wasm_extern_t)
 _wasi_instance_bind_import.argtypes = [POINTER(wasi_instance_t), POINTER(wasm_importtype_t)]
 def wasi_instance_bind_import(instance: Any, arg1: Any) -> pointer:
-    return _wasi_instance_bind_import(instance, arg1)
+    return _wasi_instance_bind_import(instance, arg1)  # type: ignore
 
 class wasmtime_error_t(Structure):
     pass
@@ -1753,13 +1753,13 @@ _wasmtime_error_delete = dll.wasmtime_error_delete
 _wasmtime_error_delete.restype = None
 _wasmtime_error_delete.argtypes = [POINTER(wasmtime_error_t)]
 def wasmtime_error_delete(arg0: Any) -> None:
-    return _wasmtime_error_delete(arg0)
+    return _wasmtime_error_delete(arg0)  # type: ignore
 
 _wasmtime_error_message = dll.wasmtime_error_message
 _wasmtime_error_message.restype = None
 _wasmtime_error_message.argtypes = [POINTER(wasmtime_error_t), POINTER(wasm_name_t)]
 def wasmtime_error_message(error: Any, message: Any) -> None:
-    return _wasmtime_error_message(error, message)
+    return _wasmtime_error_message(error, message)  # type: ignore
 
 wasmtime_strategy_t = c_uint8
 
@@ -1771,103 +1771,103 @@ _wasmtime_config_debug_info_set = dll.wasmtime_config_debug_info_set
 _wasmtime_config_debug_info_set.restype = None
 _wasmtime_config_debug_info_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_debug_info_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_debug_info_set(arg0, arg1)
+    return _wasmtime_config_debug_info_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_interruptable_set = dll.wasmtime_config_interruptable_set
 _wasmtime_config_interruptable_set.restype = None
 _wasmtime_config_interruptable_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_interruptable_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_interruptable_set(arg0, arg1)
+    return _wasmtime_config_interruptable_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_max_wasm_stack_set = dll.wasmtime_config_max_wasm_stack_set
 _wasmtime_config_max_wasm_stack_set.restype = None
 _wasmtime_config_max_wasm_stack_set.argtypes = [POINTER(wasm_config_t), c_size_t]
 def wasmtime_config_max_wasm_stack_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_max_wasm_stack_set(arg0, arg1)
+    return _wasmtime_config_max_wasm_stack_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_wasm_threads_set = dll.wasmtime_config_wasm_threads_set
 _wasmtime_config_wasm_threads_set.restype = None
 _wasmtime_config_wasm_threads_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_wasm_threads_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_wasm_threads_set(arg0, arg1)
+    return _wasmtime_config_wasm_threads_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_wasm_reference_types_set = dll.wasmtime_config_wasm_reference_types_set
 _wasmtime_config_wasm_reference_types_set.restype = None
 _wasmtime_config_wasm_reference_types_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_wasm_reference_types_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_wasm_reference_types_set(arg0, arg1)
+    return _wasmtime_config_wasm_reference_types_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_wasm_simd_set = dll.wasmtime_config_wasm_simd_set
 _wasmtime_config_wasm_simd_set.restype = None
 _wasmtime_config_wasm_simd_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_wasm_simd_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_wasm_simd_set(arg0, arg1)
+    return _wasmtime_config_wasm_simd_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_wasm_bulk_memory_set = dll.wasmtime_config_wasm_bulk_memory_set
 _wasmtime_config_wasm_bulk_memory_set.restype = None
 _wasmtime_config_wasm_bulk_memory_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_wasm_bulk_memory_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_wasm_bulk_memory_set(arg0, arg1)
+    return _wasmtime_config_wasm_bulk_memory_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_wasm_multi_value_set = dll.wasmtime_config_wasm_multi_value_set
 _wasmtime_config_wasm_multi_value_set.restype = None
 _wasmtime_config_wasm_multi_value_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_wasm_multi_value_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_wasm_multi_value_set(arg0, arg1)
+    return _wasmtime_config_wasm_multi_value_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_strategy_set = dll.wasmtime_config_strategy_set
 _wasmtime_config_strategy_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_config_strategy_set.argtypes = [POINTER(wasm_config_t), wasmtime_strategy_t]
 def wasmtime_config_strategy_set(arg0: Any, arg1: Any) -> pointer:
-    return _wasmtime_config_strategy_set(arg0, arg1)
+    return _wasmtime_config_strategy_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_cranelift_debug_verifier_set = dll.wasmtime_config_cranelift_debug_verifier_set
 _wasmtime_config_cranelift_debug_verifier_set.restype = None
 _wasmtime_config_cranelift_debug_verifier_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_cranelift_debug_verifier_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_cranelift_debug_verifier_set(arg0, arg1)
+    return _wasmtime_config_cranelift_debug_verifier_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_cranelift_opt_level_set = dll.wasmtime_config_cranelift_opt_level_set
 _wasmtime_config_cranelift_opt_level_set.restype = None
 _wasmtime_config_cranelift_opt_level_set.argtypes = [POINTER(wasm_config_t), wasmtime_opt_level_t]
 def wasmtime_config_cranelift_opt_level_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_cranelift_opt_level_set(arg0, arg1)
+    return _wasmtime_config_cranelift_opt_level_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_profiler_set = dll.wasmtime_config_profiler_set
 _wasmtime_config_profiler_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_config_profiler_set.argtypes = [POINTER(wasm_config_t), wasmtime_profiling_strategy_t]
 def wasmtime_config_profiler_set(arg0: Any, arg1: Any) -> pointer:
-    return _wasmtime_config_profiler_set(arg0, arg1)
+    return _wasmtime_config_profiler_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_static_memory_maximum_size_set = dll.wasmtime_config_static_memory_maximum_size_set
 _wasmtime_config_static_memory_maximum_size_set.restype = None
 _wasmtime_config_static_memory_maximum_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
 def wasmtime_config_static_memory_maximum_size_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_static_memory_maximum_size_set(arg0, arg1)
+    return _wasmtime_config_static_memory_maximum_size_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_static_memory_guard_size_set = dll.wasmtime_config_static_memory_guard_size_set
 _wasmtime_config_static_memory_guard_size_set.restype = None
 _wasmtime_config_static_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
 def wasmtime_config_static_memory_guard_size_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_static_memory_guard_size_set(arg0, arg1)
+    return _wasmtime_config_static_memory_guard_size_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_dynamic_memory_guard_size_set = dll.wasmtime_config_dynamic_memory_guard_size_set
 _wasmtime_config_dynamic_memory_guard_size_set.restype = None
 _wasmtime_config_dynamic_memory_guard_size_set.argtypes = [POINTER(wasm_config_t), c_uint64]
 def wasmtime_config_dynamic_memory_guard_size_set(arg0: Any, arg1: Any) -> None:
-    return _wasmtime_config_dynamic_memory_guard_size_set(arg0, arg1)
+    return _wasmtime_config_dynamic_memory_guard_size_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_cache_config_load = dll.wasmtime_config_cache_config_load
 _wasmtime_config_cache_config_load.restype = POINTER(wasmtime_error_t)
 _wasmtime_config_cache_config_load.argtypes = [POINTER(wasm_config_t), POINTER(c_char)]
 def wasmtime_config_cache_config_load(arg0: Any, arg1: Any) -> pointer:
-    return _wasmtime_config_cache_config_load(arg0, arg1)
+    return _wasmtime_config_cache_config_load(arg0, arg1)  # type: ignore
 
 _wasmtime_wat2wasm = dll.wasmtime_wat2wasm
 _wasmtime_wat2wasm.restype = POINTER(wasmtime_error_t)
 _wasmtime_wat2wasm.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
 def wasmtime_wat2wasm(wat: Any, ret: Any) -> pointer:
-    return _wasmtime_wat2wasm(wat, ret)
+    return _wasmtime_wat2wasm(wat, ret)  # type: ignore
 
 class wasmtime_linker_t(Structure):
     pass
@@ -1876,55 +1876,55 @@ _wasmtime_linker_delete = dll.wasmtime_linker_delete
 _wasmtime_linker_delete.restype = None
 _wasmtime_linker_delete.argtypes = [POINTER(wasmtime_linker_t)]
 def wasmtime_linker_delete(arg0: Any) -> None:
-    return _wasmtime_linker_delete(arg0)
+    return _wasmtime_linker_delete(arg0)  # type: ignore
 
 _wasmtime_linker_new = dll.wasmtime_linker_new
 _wasmtime_linker_new.restype = POINTER(wasmtime_linker_t)
 _wasmtime_linker_new.argtypes = [POINTER(wasm_store_t)]
 def wasmtime_linker_new(store: Any) -> pointer:
-    return _wasmtime_linker_new(store)
+    return _wasmtime_linker_new(store)  # type: ignore
 
 _wasmtime_linker_allow_shadowing = dll.wasmtime_linker_allow_shadowing
 _wasmtime_linker_allow_shadowing.restype = None
 _wasmtime_linker_allow_shadowing.argtypes = [POINTER(wasmtime_linker_t), c_bool]
 def wasmtime_linker_allow_shadowing(linker: Any, allow_shadowing: Any) -> None:
-    return _wasmtime_linker_allow_shadowing(linker, allow_shadowing)
+    return _wasmtime_linker_allow_shadowing(linker, allow_shadowing)  # type: ignore
 
 _wasmtime_linker_define = dll.wasmtime_linker_define
 _wasmtime_linker_define.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_define.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_extern_t)]
 def wasmtime_linker_define(linker: Any, module: Any, name: Any, item: Any) -> pointer:
-    return _wasmtime_linker_define(linker, module, name, item)
+    return _wasmtime_linker_define(linker, module, name, item)  # type: ignore
 
 _wasmtime_linker_define_wasi = dll.wasmtime_linker_define_wasi
 _wasmtime_linker_define_wasi.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_define_wasi.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasi_instance_t)]
 def wasmtime_linker_define_wasi(linker: Any, instance: Any) -> pointer:
-    return _wasmtime_linker_define_wasi(linker, instance)
+    return _wasmtime_linker_define_wasi(linker, instance)  # type: ignore
 
 _wasmtime_linker_define_instance = dll.wasmtime_linker_define_instance
 _wasmtime_linker_define_instance.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_define_instance.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_instance_t)]
 def wasmtime_linker_define_instance(linker: Any, name: Any, instance: Any) -> pointer:
-    return _wasmtime_linker_define_instance(linker, name, instance)
+    return _wasmtime_linker_define_instance(linker, name, instance)  # type: ignore
 
 _wasmtime_linker_instantiate = dll.wasmtime_linker_instantiate
 _wasmtime_linker_instantiate.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_instantiate.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
 def wasmtime_linker_instantiate(linker: Any, module: Any, instance: Any, trap: Any) -> pointer:
-    return _wasmtime_linker_instantiate(linker, module, instance, trap)
+    return _wasmtime_linker_instantiate(linker, module, instance, trap)  # type: ignore
 
 _wasmtime_linker_module = dll.wasmtime_linker_module
 _wasmtime_linker_module.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_module.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_module_t)]
 def wasmtime_linker_module(linker: Any, name: Any, module: Any) -> pointer:
-    return _wasmtime_linker_module(linker, name, module)
+    return _wasmtime_linker_module(linker, name, module)  # type: ignore
 
 _wasmtime_linker_get_default = dll.wasmtime_linker_get_default
 _wasmtime_linker_get_default.restype = POINTER(wasmtime_error_t)
 _wasmtime_linker_get_default.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(POINTER(wasm_func_t))]
 def wasmtime_linker_get_default(linker: Any, name: Any, func: Any) -> pointer:
-    return _wasmtime_linker_get_default(linker, name, func)
+    return _wasmtime_linker_get_default(linker, name, func)  # type: ignore
 
 class wasmtime_caller_t(Structure):
     pass
@@ -1937,19 +1937,19 @@ _wasmtime_func_new = dll.wasmtime_func_new
 _wasmtime_func_new.restype = POINTER(wasm_func_t)
 _wasmtime_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_t]
 def wasmtime_func_new(arg0: Any, arg1: Any, callback: Any) -> pointer:
-    return _wasmtime_func_new(arg0, arg1, callback)
+    return _wasmtime_func_new(arg0, arg1, callback)  # type: ignore
 
 _wasmtime_func_new_with_env = dll.wasmtime_func_new_with_env
 _wasmtime_func_new_with_env.restype = POINTER(wasm_func_t)
 _wasmtime_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
 def wasmtime_func_new_with_env(store: Any, type: Any, callback: Any, env: Any, finalizer: Any) -> pointer:
-    return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)
+    return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)  # type: ignore
 
 _wasmtime_caller_export_get = dll.wasmtime_caller_export_get
 _wasmtime_caller_export_get.restype = POINTER(wasm_extern_t)
 _wasmtime_caller_export_get.argtypes = [POINTER(wasmtime_caller_t), POINTER(wasm_name_t)]
 def wasmtime_caller_export_get(caller: Any, name: Any) -> pointer:
-    return _wasmtime_caller_export_get(caller, name)
+    return _wasmtime_caller_export_get(caller, name)  # type: ignore
 
 class wasmtime_interrupt_handle_t(Structure):
     pass
@@ -1958,88 +1958,88 @@ _wasmtime_interrupt_handle_delete = dll.wasmtime_interrupt_handle_delete
 _wasmtime_interrupt_handle_delete.restype = None
 _wasmtime_interrupt_handle_delete.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
 def wasmtime_interrupt_handle_delete(arg0: Any) -> None:
-    return _wasmtime_interrupt_handle_delete(arg0)
+    return _wasmtime_interrupt_handle_delete(arg0)  # type: ignore
 
 _wasmtime_interrupt_handle_new = dll.wasmtime_interrupt_handle_new
 _wasmtime_interrupt_handle_new.restype = POINTER(wasmtime_interrupt_handle_t)
 _wasmtime_interrupt_handle_new.argtypes = [POINTER(wasm_store_t)]
 def wasmtime_interrupt_handle_new(store: Any) -> pointer:
-    return _wasmtime_interrupt_handle_new(store)
+    return _wasmtime_interrupt_handle_new(store)  # type: ignore
 
 _wasmtime_interrupt_handle_interrupt = dll.wasmtime_interrupt_handle_interrupt
 _wasmtime_interrupt_handle_interrupt.restype = None
 _wasmtime_interrupt_handle_interrupt.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
 def wasmtime_interrupt_handle_interrupt(handle: Any) -> None:
-    return _wasmtime_interrupt_handle_interrupt(handle)
+    return _wasmtime_interrupt_handle_interrupt(handle)  # type: ignore
 
 _wasmtime_frame_func_name = dll.wasmtime_frame_func_name
 _wasmtime_frame_func_name.restype = POINTER(wasm_name_t)
 _wasmtime_frame_func_name.argtypes = [POINTER(wasm_frame_t)]
 def wasmtime_frame_func_name(arg0: Any) -> pointer:
-    return _wasmtime_frame_func_name(arg0)
+    return _wasmtime_frame_func_name(arg0)  # type: ignore
 
 _wasmtime_frame_module_name = dll.wasmtime_frame_module_name
 _wasmtime_frame_module_name.restype = POINTER(wasm_name_t)
 _wasmtime_frame_module_name.argtypes = [POINTER(wasm_frame_t)]
 def wasmtime_frame_module_name(arg0: Any) -> pointer:
-    return _wasmtime_frame_module_name(arg0)
+    return _wasmtime_frame_module_name(arg0)  # type: ignore
 
 _wasmtime_func_call = dll.wasmtime_func_call
 _wasmtime_func_call.restype = POINTER(wasmtime_error_t)
 _wasmtime_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t), c_size_t, POINTER(wasm_val_t), c_size_t, POINTER(POINTER(wasm_trap_t))]
 def wasmtime_func_call(func: Any, args: Any, num_args: Any, results: Any, num_results: Any, trap: Any) -> pointer:
-    return _wasmtime_func_call(func, args, num_args, results, num_results, trap)
+    return _wasmtime_func_call(func, args, num_args, results, num_results, trap)  # type: ignore
 
 _wasmtime_global_new = dll.wasmtime_global_new
 _wasmtime_global_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t), POINTER(POINTER(wasm_global_t))]
 def wasmtime_global_new(store: Any, type: Any, val: Any, ret: Any) -> pointer:
-    return _wasmtime_global_new(store, type, val, ret)
+    return _wasmtime_global_new(store, type, val, ret)  # type: ignore
 
 _wasmtime_global_set = dll.wasmtime_global_set
 _wasmtime_global_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
 def wasmtime_global_set(arg0: Any, val: Any) -> pointer:
-    return _wasmtime_global_set(arg0, val)
+    return _wasmtime_global_set(arg0, val)  # type: ignore
 
 _wasmtime_instance_new = dll.wasmtime_instance_new
 _wasmtime_instance_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_extern_t)), c_size_t, POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
 def wasmtime_instance_new(store: Any, module: Any, imports: Any, num_imports: Any, instance: Any, trap: Any) -> pointer:
-    return _wasmtime_instance_new(store, module, imports, num_imports, instance, trap)
+    return _wasmtime_instance_new(store, module, imports, num_imports, instance, trap)  # type: ignore
 
 _wasmtime_module_new = dll.wasmtime_module_new
 _wasmtime_module_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_module_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t), POINTER(POINTER(wasm_module_t))]
 def wasmtime_module_new(store: Any, binary: Any, ret: Any) -> pointer:
-    return _wasmtime_module_new(store, binary, ret)
+    return _wasmtime_module_new(store, binary, ret)  # type: ignore
 
 _wasmtime_module_validate = dll.wasmtime_module_validate
 _wasmtime_module_validate.restype = POINTER(wasmtime_error_t)
 _wasmtime_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
 def wasmtime_module_validate(store: Any, binary: Any) -> pointer:
-    return _wasmtime_module_validate(store, binary)
+    return _wasmtime_module_validate(store, binary)  # type: ignore
 
 _wasmtime_funcref_table_new = dll.wasmtime_funcref_table_new
 _wasmtime_funcref_table_new.restype = POINTER(wasmtime_error_t)
 _wasmtime_funcref_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_func_t), POINTER(POINTER(wasm_table_t))]
 def wasmtime_funcref_table_new(store: Any, element_ty: Any, init: Any, table: Any) -> pointer:
-    return _wasmtime_funcref_table_new(store, element_ty, init, table)
+    return _wasmtime_funcref_table_new(store, element_ty, init, table)  # type: ignore
 
 _wasmtime_funcref_table_get = dll.wasmtime_funcref_table_get
 _wasmtime_funcref_table_get.restype = c_bool
 _wasmtime_funcref_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(POINTER(wasm_func_t))]
 def wasmtime_funcref_table_get(table: Any, index: Any, func: Any) -> c_bool:
-    return _wasmtime_funcref_table_get(table, index, func)
+    return _wasmtime_funcref_table_get(table, index, func)  # type: ignore
 
 _wasmtime_funcref_table_set = dll.wasmtime_funcref_table_set
 _wasmtime_funcref_table_set.restype = POINTER(wasmtime_error_t)
 _wasmtime_funcref_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t)]
 def wasmtime_funcref_table_set(table: Any, index: Any, value: Any) -> pointer:
-    return _wasmtime_funcref_table_set(table, index, value)
+    return _wasmtime_funcref_table_set(table, index, value)  # type: ignore
 
 _wasmtime_funcref_table_grow = dll.wasmtime_funcref_table_grow
 _wasmtime_funcref_table_grow.restype = POINTER(wasmtime_error_t)
 _wasmtime_funcref_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t), POINTER(wasm_table_size_t)]
 def wasmtime_funcref_table_grow(table: Any, delta: Any, init: Any, prev_size: Any) -> pointer:
-    return _wasmtime_funcref_table_grow(table, delta, init, prev_size)
+    return _wasmtime_funcref_table_grow(table, delta, init, prev_size)  # type: ignore

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -1,11 +1,6 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
 from wasmtime import WasmtimeError
-
-dll.wasm_config_new.restype = P_wasm_config_t
-dll.wasmtime_config_strategy_set.restype = P_wasmtime_error_t
-dll.wasmtime_config_profiler_set.restype = P_wasmtime_error_t
-dll.wasmtime_config_cache_config_load.restype = P_wasmtime_error_t
 
 
 def setter_property(fset):
@@ -25,7 +20,7 @@ class Config:
     """
 
     def __init__(self):
-        self.__ptr__ = dll.wasm_config_new()
+        self.__ptr__ = ffi.wasm_config_new()
 
     @setter_property
     def debug_info(self, enable):
@@ -36,7 +31,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_debug_info_set(self.__ptr__, enable)
+        ffi.wasmtime_config_debug_info_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_threads(self, enable):
@@ -48,7 +43,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_reference_types(self, enable):
@@ -60,7 +55,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_simd(self, enable):
@@ -72,7 +67,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_bulk_memory(self, enable):
@@ -84,7 +79,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
 
     @setter_property
     def wasm_multi_value(self, enable):
@@ -96,7 +91,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
 
     @setter_property
     def strategy(self, strategy):
@@ -111,11 +106,11 @@ class Config:
         """
 
         if strategy == "auto":
-            error = dll.wasmtime_config_strategy_set(self.__ptr__, 0)
+            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 0)
         elif strategy == "cranelift":
-            error = dll.wasmtime_config_strategy_set(self.__ptr__, 1)
+            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 1)
         elif strategy == "lightbeam":
-            error = dll.wasmtime_config_strategy_set(self.__ptr__, 2)
+            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 2)
         else:
             raise WasmtimeError("unknown strategy: " + str(strategy))
         if error:
@@ -125,25 +120,25 @@ class Config:
     def cranelift_debug_verifier(self, enable):
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        dll.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
+        ffi.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
 
     @setter_property
     def cranelift_opt_level(self, opt_level):
         if opt_level == "none":
-            dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
         elif opt_level == "speed":
-            dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 1)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 1)
         elif opt_level == "speed_and_size":
-            dll.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 2)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 2)
         else:
             raise WasmtimeError("unknown opt level: " + str(opt_level))
 
     @setter_property
     def profiler(self, profiler):
         if profiler == "none":
-            error = dll.wasmtime_config_profiler_set(self.__ptr__, 0)
+            error = ffi.wasmtime_config_profiler_set(self.__ptr__, 0)
         elif profiler == "jitdump":
-            error = dll.wasmtime_config_profiler_set(self.__ptr__, 1)
+            error = ffi.wasmtime_config_profiler_set(self.__ptr__, 1)
         else:
             raise WasmtimeError("unknown profiler: " + str(profiler))
         if error:
@@ -165,9 +160,9 @@ class Config:
         if isinstance(enabled, bool):
             if not enabled:
                 raise WasmtimeError("caching cannot be explicitly disabled")
-            error = dll.wasmtime_config_cache_config_load(self.__ptr__, 0)
+            error = ffi.wasmtime_config_cache_config_load(self.__ptr__, None)
         elif isinstance(enabled, str):
-            error = dll.wasmtime_config_cache_config_load(self.__ptr__,
+            error = ffi.wasmtime_config_cache_config_load(self.__ptr__,
                                                           c_char_p(enabled.encode('utf-8')))
         else:
             raise TypeError("expected string or bool")
@@ -185,8 +180,8 @@ class Config:
             val = 1
         else:
             val = 0
-        dll.wasmtime_config_interruptable_set(self.__ptr__, val)
+        ffi.wasmtime_config_interruptable_set(self.__ptr__, val)
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasm_config_delete(self.__ptr__)
+            ffi.wasm_config_delete(self.__ptr__)

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -20,7 +20,7 @@ class Config:
     code is compiled or generated.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__ptr__ = ffi.wasm_config_new()
 
     @setter_property
@@ -183,6 +183,6 @@ class Config:
             val = 0
         ffi.wasmtime_config_interruptable_set(self.__ptr__, val)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasm_config_delete(self.__ptr__)

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -146,7 +146,7 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def cache(self, enabled: bool) -> None:
+    def cache(self, enabled: typing.Union[bool, str]) -> None:
         """
         Configures whether code caching is enabled for this `Config`.
 

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -24,7 +24,7 @@ class Config:
         self.__ptr__ = ffi.wasm_config_new()
 
     @setter_property
-    def debug_info(self, enable: bool):
+    def debug_info(self, enable: bool) -> None:
         """
         Configures whether DWARF debug information is emitted for the generated
         code. This can improve profiling and the debugging experience.
@@ -35,7 +35,7 @@ class Config:
         ffi.wasmtime_config_debug_info_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_threads(self, enable: bool):
+    def wasm_threads(self, enable: bool) -> None:
         """
         Configures whether the wasm [threads proposal] is enabled.
 
@@ -47,7 +47,7 @@ class Config:
         ffi.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_reference_types(self, enable: bool):
+    def wasm_reference_types(self, enable: bool) -> None:
         """
         Configures whether the wasm [reference types proposal] is enabled.
 
@@ -59,7 +59,7 @@ class Config:
         ffi.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_simd(self, enable: bool):
+    def wasm_simd(self, enable: bool) -> None:
         """
         Configures whether the wasm [SIMD proposal] is enabled.
 
@@ -71,7 +71,7 @@ class Config:
         ffi.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_bulk_memory(self, enable: bool):
+    def wasm_bulk_memory(self, enable: bool) -> None:
         """
         Configures whether the wasm [bulk memory proposal] is enabled.
 
@@ -83,7 +83,7 @@ class Config:
         ffi.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
 
     @setter_property
-    def wasm_multi_value(self, enable: bool):
+    def wasm_multi_value(self, enable: bool) -> None:
         """
         Configures whether the wasm [multi value proposal] is enabled.
 
@@ -95,7 +95,7 @@ class Config:
         ffi.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
 
     @setter_property
-    def strategy(self, strategy: str):
+    def strategy(self, strategy: str) -> None:
         """
         Configures the compilation strategy used for wasm code.
 
@@ -118,13 +118,13 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def cranelift_debug_verifier(self, enable: bool):
+    def cranelift_debug_verifier(self, enable: bool) -> None:
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
         ffi.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
 
     @setter_property
-    def cranelift_opt_level(self, opt_level: str):
+    def cranelift_opt_level(self, opt_level: str) -> None:
         if opt_level == "none":
             ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
         elif opt_level == "speed":
@@ -135,7 +135,7 @@ class Config:
             raise WasmtimeError("unknown opt level: " + str(opt_level))
 
     @setter_property
-    def profiler(self, profiler: str):
+    def profiler(self, profiler: str) -> None:
         if profiler == "none":
             error = ffi.wasmtime_config_profiler_set(self.__ptr__, 0)
         elif profiler == "jitdump":
@@ -146,7 +146,7 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def cache(self, enabled: bool):
+    def cache(self, enabled: bool) -> None:
         """
         Configures whether code caching is enabled for this `Config`.
 
@@ -171,7 +171,7 @@ class Config:
             raise WasmtimeError.__from_ptr__(error)
 
     @setter_property
-    def interruptable(self, enabled: bool):
+    def interruptable(self, enabled: bool) -> None:
         """
         Configures whether wasm execution can be interrupted via interrupt
         handles.

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -1,15 +1,11 @@
-from ._ffi import *
-from ctypes import *
+from . import _ffi as ffi
 from wasmtime import Config, WasmtimeError
-
-dll.wasm_engine_new.restype = P_wasm_engine_t
-dll.wasm_engine_new_with_config.restype = P_wasm_engine_t
 
 
 class Engine:
     def __init__(self, config=None):
         if config is None:
-            self.__ptr__ = dll.wasm_engine_new()
+            self.__ptr__ = ffi.wasm_engine_new()
         elif not isinstance(config, Config):
             raise TypeError("expected Config")
         elif not hasattr(config, '__ptr__'):
@@ -17,8 +13,8 @@ class Engine:
         else:
             ptr = config.__ptr__
             delattr(config, '__ptr__')
-            self.__ptr__ = dll.wasm_engine_new_with_config(ptr)
+            self.__ptr__ = ffi.wasm_engine_new_with_config(ptr)
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasm_engine_delete(self.__ptr__)
+            ffi.wasm_engine_delete(self.__ptr__)

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -15,6 +15,6 @@ class Engine:
             delattr(config, '__ptr__')
             self.__ptr__ = ffi.wasm_engine_new_with_config(ptr)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasm_engine_delete(self.__ptr__)

--- a/wasmtime/_error.py
+++ b/wasmtime/_error.py
@@ -17,5 +17,5 @@ class WasmtimeError(Exception):
         ffi.wasmtime_error_delete(ptr)
         return WasmtimeError(message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message

--- a/wasmtime/_error.py
+++ b/wasmtime/_error.py
@@ -2,7 +2,7 @@ from ctypes import byref, POINTER, pointer
 
 
 class WasmtimeError(Exception):
-    def __init__(self, message):
+    def __init__(self, message: str):
         self.message = message
 
     @classmethod

--- a/wasmtime/_error.py
+++ b/wasmtime/_error.py
@@ -1,4 +1,4 @@
-from ctypes import byref
+from ctypes import byref, POINTER
 
 
 class WasmtimeError(Exception):
@@ -7,14 +7,14 @@ class WasmtimeError(Exception):
 
     @classmethod
     def __from_ptr__(cls, ptr):
-        from ._ffi import P_wasmtime_error_t, wasm_byte_vec_t, dll  # Avoid circular import
-        if not isinstance(ptr, P_wasmtime_error_t):
+        from . import _ffi as ffi
+        if not isinstance(ptr, POINTER(ffi.wasmtime_error_t)):
             raise TypeError("wrong pointer type")
-        message_vec = wasm_byte_vec_t()
-        dll.wasmtime_error_message(ptr, byref(message_vec))
-        message = message_vec.to_str()
-        dll.wasm_byte_vec_delete(byref(message_vec))
-        dll.wasmtime_error_delete(ptr)
+        message_vec = ffi.wasm_byte_vec_t()
+        ffi.wasmtime_error_message(ptr, byref(message_vec))
+        message = ffi.to_str(message_vec)
+        ffi.wasm_byte_vec_delete(byref(message_vec))
+        ffi.wasmtime_error_delete(ptr)
         return WasmtimeError(message)
 
     def __str__(self):

--- a/wasmtime/_exportable.py
+++ b/wasmtime/_exportable.py
@@ -1,8 +1,9 @@
 import typing
 
-# from ._func import Func
-# from ._globals import Global
-# from ._memory import Memory
-# from ._table import Table
+if typing.TYPE_CHECKING:
+    from ._func import Func
+    from ._globals import Global
+    from ._memory import Memory
+    from ._table import Table
 
 AsExtern = typing.Union["Func", "Table", "Memory", "Global"]

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -45,8 +45,8 @@ def get_extern_ptr(item: AsExtern) -> "pointer[ffi.wasm_extern_t]":
 
 
 class Extern:
-    def __init__(self, ptr: pointer):
+    def __init__(self, ptr: "pointer[ffi.wasm_extern_t]"):
         self.ptr = ptr
 
-    def __del__(self):
+    def __del__(self) -> None:
         ffi.wasm_extern_delete(self.ptr)

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -29,7 +29,7 @@ def wrap_extern(ptr: pointer, owner: Optional[Any]) -> AsExtern:
     return Memory.__from_ptr__(val, owner)
 
 
-def get_extern_ptr(item: AsExtern) -> pointer:
+def get_extern_ptr(item: AsExtern) -> "pointer[ffi.wasm_extern_t]":
     from wasmtime import Func, Table, Global, Memory
 
     if isinstance(item, Func):

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -1,17 +1,11 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
-
-dll.wasm_extern_as_func.restype = P_wasm_func_t
-dll.wasm_extern_as_table.restype = P_wasm_table_t
-dll.wasm_extern_as_global.restype = P_wasm_global_t
-dll.wasm_extern_as_memory.restype = P_wasm_memory_t
-dll.wasm_extern_type.restype = P_wasm_externtype_t
 
 
 def wrap_extern(ptr, owner):
     from wasmtime import Func, Table, Global, Memory
 
-    if not isinstance(ptr, P_wasm_extern_t):
+    if not isinstance(ptr, POINTER(ffi.wasm_extern_t)):
         raise TypeError("wrong pointer type")
 
     # We must free this as an extern, so if there's no ambient owner then
@@ -19,16 +13,16 @@ def wrap_extern(ptr, owner):
     if owner is None:
         owner = Extern(ptr)
 
-    val = dll.wasm_extern_as_func(ptr)
+    val = ffi.wasm_extern_as_func(ptr)
     if val:
         return Func.__from_ptr__(val, owner)
-    val = dll.wasm_extern_as_table(ptr)
+    val = ffi.wasm_extern_as_table(ptr)
     if val:
         return Table.__from_ptr__(val, owner)
-    val = dll.wasm_extern_as_global(ptr)
+    val = ffi.wasm_extern_as_global(ptr)
     if val:
         return Global.__from_ptr__(val, owner)
-    val = dll.wasm_extern_as_memory(ptr)
+    val = ffi.wasm_extern_as_memory(ptr)
     assert(val)
     return Memory.__from_ptr__(val, owner)
 
@@ -53,4 +47,4 @@ class Extern:
         self.ptr = ptr
 
     def __del__(self):
-        dll.wasm_extern_delete(self.ptr)
+        ffi.wasm_extern_delete(self.ptr)

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -47,9 +47,17 @@ class wasm_val_union(Union):
         ("f64", c_double),
     ]
 
+    i32: int
+    i64: int
+    f32: float
+    f64: float
+
 
 class wasm_val_t(Structure):
     _fields_ = [("kind", c_uint8), ("of", wasm_val_union)]
+
+    kind: int
+    of: wasm_val_union
 
 
 from ._bindings import * # noqa

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -39,226 +39,6 @@ WASM_CONST = c_uint8(0)
 WASM_VAR = c_uint8(1)
 
 
-class wasm_valtype_t(Structure):
-    pass
-
-
-P_wasm_valtype_t = POINTER(wasm_valtype_t)
-
-
-class wasm_globaltype_t(Structure):
-    pass
-
-
-P_wasm_globaltype_t = POINTER(wasm_globaltype_t)
-
-
-class wasm_functype_t(Structure):
-    pass
-
-
-P_wasm_functype_t = POINTER(wasm_functype_t)
-
-
-class wasm_tabletype_t(Structure):
-    pass
-
-
-P_wasm_tabletype_t = POINTER(wasm_tabletype_t)
-
-
-class wasm_memorytype_t(Structure):
-    pass
-
-
-P_wasm_memorytype_t = POINTER(wasm_memorytype_t)
-
-
-class wasm_externtype_t(Structure):
-    pass
-
-
-P_wasm_externtype_t = POINTER(wasm_externtype_t)
-
-
-class wasm_engine_t(Structure):
-    pass
-
-
-P_wasm_engine_t = POINTER(wasm_engine_t)
-
-
-class wasm_store_t(Structure):
-    pass
-
-
-P_wasm_store_t = POINTER(wasm_store_t)
-
-
-class wasm_config_t(Structure):
-    pass
-
-
-P_wasm_config_t = POINTER(wasm_config_t)
-
-
-class wasm_importtype_t(Structure):
-    pass
-
-
-P_wasm_importtype_t = POINTER(wasm_importtype_t)
-
-
-class wasm_exporttype_t(Structure):
-    pass
-
-
-P_wasm_exporttype_t = POINTER(wasm_exporttype_t)
-
-
-class wasm_module_t(Structure):
-    pass
-
-
-P_wasm_module_t = POINTER(wasm_module_t)
-
-
-class wasm_global_t(Structure):
-    pass
-
-
-P_wasm_global_t = POINTER(wasm_global_t)
-
-
-class wasm_table_t(Structure):
-    pass
-
-
-P_wasm_table_t = POINTER(wasm_table_t)
-
-
-class wasm_memory_t(Structure):
-    pass
-
-
-P_wasm_memory_t = POINTER(wasm_memory_t)
-
-
-class wasm_func_t(Structure):
-    pass
-
-
-P_wasm_func_t = POINTER(wasm_func_t)
-
-
-class wasm_trap_t(Structure):
-    pass
-
-
-P_wasm_trap_t = POINTER(wasm_trap_t)
-
-
-class wasm_extern_t(Structure):
-    pass
-
-
-P_wasm_extern_t = POINTER(wasm_extern_t)
-
-
-class wasm_instance_t(Structure):
-    pass
-
-
-P_wasm_instance_t = POINTER(wasm_instance_t)
-
-
-class wasmtime_linker_t(Structure):
-    pass
-
-
-P_wasmtime_linker_t = POINTER(wasmtime_linker_t)
-
-
-class wasmtime_caller_t(Structure):
-    pass
-
-
-P_wasmtime_caller_t = POINTER(wasmtime_caller_t)
-
-
-class wasi_config_t(Structure):
-    pass
-
-
-P_wasi_config_t = POINTER(wasi_config_t)
-
-
-class wasi_instance_t(Structure):
-    pass
-
-
-P_wasi_instance_t = POINTER(wasi_instance_t)
-
-
-class wasm_frame_t(Structure):
-    pass
-
-
-P_wasm_frame_t = POINTER(wasm_frame_t)
-
-
-class wasmtime_error_t(Structure):
-    pass
-
-
-P_wasmtime_error_t = POINTER(wasmtime_error_t)
-
-
-class wasmtime_interrupt_handle_t(Structure):
-    pass
-
-
-P_wasmtime_interrupt_handle_t = POINTER(wasmtime_interrupt_handle_t)
-
-
-class wasm_valtype_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_valtype_t))]
-
-
-class wasm_limits_t(Structure):
-    _fields_ = [("min", c_uint32), ("max", c_uint32)]
-
-
-class wasm_byte_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(c_uint8))]
-
-    def to_bytes(self):
-        ty = c_uint8 * self.size
-        return bytearray(ty.from_address(addressof(self.data.contents)))
-
-    def to_str(self):
-        return self.to_bytes().decode("utf-8")
-
-
-wasm_name_t = wasm_byte_vec_t
-
-
-class wasm_exporttype_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_exporttype_t))]
-
-
-class wasm_importtype_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_importtype_t))]
-
-
-class wasm_extern_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_extern_t))]
-
-
-class wasm_frame_vec_t(Structure):
-    _fields_ = [("size", c_size_t), ("data", POINTER(P_wasm_frame_t))]
-
-
 class wasm_val_union(Union):
     _fields_ = [
         ("i32", c_int32),
@@ -270,6 +50,18 @@ class wasm_val_union(Union):
 
 class wasm_val_t(Structure):
     _fields_ = [("kind", c_uint8), ("of", wasm_val_union)]
+
+
+from ._bindings import * # noqa
+
+
+def to_bytes(vec):
+    ty = c_uint8 * vec.size
+    return bytearray(ty.from_address(addressof(vec.data.contents)))
+
+
+def to_str(vec):
+    return to_bytes(vec).decode("utf-8")
 
 
 def str_to_name(s, trailing_nul=False):

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -67,10 +67,10 @@ def to_str(vec: wasm_byte_vec_t) -> str:
 def str_to_name(s: str, trailing_nul: bool = False) -> wasm_byte_vec_t:
     if not isinstance(s, str):
         raise TypeError("expected a string")
-    s = s.encode('utf8')
-    buf = cast(create_string_buffer(s), POINTER(c_uint8))
+    s_bytes = s.encode('utf8')
+    buf = cast(create_string_buffer(s_bytes), POINTER(c_uint8))
     if trailing_nul:
         extra = 1
     else:
         extra = 0
-    return wasm_byte_vec_t(len(s) + extra, buf)
+    return wasm_byte_vec_t(len(s_bytes) + extra, buf)

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -4,11 +4,14 @@ import sys
 import traceback
 from . import _ffi as ffi
 from ._extern import wrap_extern
-import typing
+from typing import Callable, Optional, Tuple
+from ._exportable import AsExtern
 
 
 class Func:
-    def __init__(self, store: Store, ty: FuncType, func: typing.Callable, access_caller: bool = False):
+    __ptr__: "pointer[ffi.wasm_func_t]"
+
+    def __init__(self, store: Store, ty: FuncType, func: Callable, access_caller: bool = False):
         """
         Creates a new func in `store` with the given `ty` which calls the closure
         given
@@ -133,7 +136,7 @@ class Caller:
     def __init__(self, ptr: pointer):
         self.__ptr__ = ptr
 
-    def __getitem__(self, name) -> "Exportable":
+    def __getitem__(self, name) -> AsExtern:
         """
         Looks up an export with `name` on the calling module.
 
@@ -148,7 +151,7 @@ class Caller:
             raise KeyError("failed to find export {}".format(name))
         return ret
 
-    def get(self, name: str) -> typing.Optional["Exportable"]:
+    def get(self, name: str) -> Optional[AsExtern]:
         """
         Looks up an export with `name` on the calling module.
 
@@ -234,7 +237,7 @@ class Slab:
         self.list = []
         self.next = 0
 
-    def allocate(self, val: typing.Tuple) -> int:
+    def allocate(self, val: Tuple) -> int:
         idx = self.next
 
         if len(self.list) == idx:
@@ -246,7 +249,7 @@ class Slab:
         self.list[idx] = val
         return idx
 
-    def get(self, idx: int) -> typing.Tuple:
+    def get(self, idx: int) -> Tuple:
         return self.list[idx]
 
     def deallocate(self, idx: int) -> None:

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -239,7 +239,7 @@ class Slab(Generic[T]):
     list: List[Union[int, T]]
     next: int
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.list = []
         self.next = 0
 

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -178,12 +178,12 @@ def extract_val(val):
     return val
 
 
-@ffi.wasm_func_callback_with_env_t
+@ffi.wasm_func_callback_with_env_t  # type: ignore
 def trampoline(idx, params_ptr, results_ptr):
     return invoke(idx, params_ptr, results_ptr, [])
 
 
-@ffi.wasmtime_func_callback_with_env_t
+@ffi.wasmtime_func_callback_with_env_t  # type: ignore
 def trampoline_with_caller(caller, idx, params_ptr, results_ptr):
     caller = Caller(caller)
     try:

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -1,10 +1,10 @@
 from ctypes import POINTER, pointer, byref, CFUNCTYPE, c_void_p, cast
-from wasmtime import Store, FuncType, Val, Trap, WasmtimeError
+from wasmtime import Store, FuncType, Val, IntoVal, Trap, WasmtimeError
 import sys
 import traceback
 from . import _ffi as ffi
 from ._extern import wrap_extern
-from typing import Callable, Optional, Generic, TypeVar, List, Union, Tuple, cast as cast_type
+from typing import Callable, Optional, Generic, TypeVar, List, Union, Tuple, cast as cast_type, Any
 from ._exportable import AsExtern
 
 
@@ -44,7 +44,7 @@ class Func:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr: pointer, owner) -> "Func":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_func_t]", owner: Optional[Any]) -> "Func":
         ty: "Func" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_func_t)):
             raise TypeError("wrong pointer type")
@@ -136,7 +136,7 @@ class Caller:
     def __init__(self, ptr: pointer):
         self.__ptr__ = ptr
 
-    def __getitem__(self, name) -> AsExtern:
+    def __getitem__(self, name: str) -> AsExtern:
         """
         Looks up an export with `name` on the calling module.
 
@@ -175,7 +175,7 @@ class Caller:
             return None
 
 
-def extract_val(val: Val):
+def extract_val(val: Val) -> IntoVal:
     a = val.value
     if a is not None:
         return a

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 from . import _ffi as ffi
 from ._extern import wrap_extern
-from typing import Callable, Optional, Generic, TypeVar, List, Union, Tuple, cast as cast_type, Any
+from typing import Callable, Optional, Generic, TypeVar, List, Union, Tuple, cast as cast_type, Any, Sequence
 from ._exportable import AsExtern
 
 
@@ -74,7 +74,7 @@ class Func:
         """
         return ffi.wasm_func_result_arity(self.__ptr__)
 
-    def __call__(self, *params):
+    def __call__(self, *params: IntoVal) -> Union[IntoVal, Sequence[IntoVal], None]:
         """
         Calls this function with the given parameters
 
@@ -127,7 +127,7 @@ class Func:
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_func_as_extern(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_func_delete(self.__ptr__)
 
@@ -183,12 +183,12 @@ def extract_val(val: Val) -> IntoVal:
 
 
 @ffi.wasm_func_callback_with_env_t  # type: ignore
-def trampoline(idx, params_ptr, results_ptr):
+def trampoline(idx, params_ptr, results_ptr):  # type: ignore
     return invoke(idx, params_ptr, results_ptr, [])
 
 
 @ffi.wasmtime_func_callback_with_env_t  # type: ignore
-def trampoline_with_caller(caller, idx, params_ptr, results_ptr):
+def trampoline_with_caller(caller, idx, params_ptr, results_ptr):  # type: ignore
     caller = Caller(caller)
     try:
         return invoke(idx, params_ptr, results_ptr, [caller])
@@ -196,7 +196,7 @@ def trampoline_with_caller(caller, idx, params_ptr, results_ptr):
         delattr(caller, '__ptr__')
 
 
-def invoke(idx, params_ptr, results_ptr, params):
+def invoke(idx, params_ptr, results_ptr, params):  # type: ignore
     func, param_tys, result_tys, store = FUNCTIONS.get(idx or 0)
 
     try:
@@ -228,7 +228,7 @@ def invoke(idx, params_ptr, results_ptr, params):
 
 
 @CFUNCTYPE(None, c_void_p)
-def finalize(idx):
+def finalize(idx):  # type: ignore
     FUNCTIONS.deallocate(idx or 0)
 
 

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -41,7 +41,7 @@ class Global:
         return GlobalType.__from_ptr__(ptr, None)
 
     @property
-    def value(self):
+    def value(self) -> IntoVal:
         """
         Gets the current value of this global
 
@@ -49,10 +49,14 @@ class Global:
         """
         raw = ffi.wasm_val_t()
         ffi.wasm_global_get(self.__ptr__, byref(raw))
-        return Val(raw).value
+        val = Val(raw)
+        if val.value:
+            return val.value
+        else:
+            return val
 
     @value.setter
-    def value(self, val):
+    def value(self, val: IntoVal) -> None:
         """
         Sets the value of this global to a new value
         """
@@ -64,6 +68,6 @@ class Global:
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_global_as_extern(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_global_delete(self.__ptr__)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -1,11 +1,6 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
 from wasmtime import Store, GlobalType, Val, WasmtimeError
-
-dll.wasmtime_global_new.restype = P_wasmtime_error_t
-dll.wasm_global_type.restype = P_wasm_globaltype_t
-dll.wasm_global_as_extern.restype = P_wasm_extern_t
-dll.wasmtime_global_set.restype = P_wasmtime_error_t
 
 
 class Global:
@@ -15,8 +10,8 @@ class Global:
         if not isinstance(ty, GlobalType):
             raise TypeError("expected a GlobalType")
         val = Val.__convert__(ty.content, val)
-        ptr = P_wasm_global_t()
-        error = dll.wasmtime_global_new(
+        ptr = POINTER(ffi.wasm_global_t)()
+        error = ffi.wasmtime_global_new(
             store.__ptr__,
             ty.__ptr__,
             byref(val.__raw__),
@@ -29,7 +24,7 @@ class Global:
     @classmethod
     def __from_ptr__(cls, ptr, owner):
         ty = cls.__new__(cls)
-        if not isinstance(ptr, P_wasm_global_t):
+        if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
         ty.__owner__ = owner
@@ -41,7 +36,7 @@ class Global:
         Gets the type of this global as a `GlobalType`
         """
 
-        ptr = dll.wasm_global_type(self.__ptr__)
+        ptr = ffi.wasm_global_type(self.__ptr__)
         return GlobalType.__from_ptr__(ptr, None)
 
     @property
@@ -51,8 +46,8 @@ class Global:
 
         Returns a native python type
         """
-        raw = wasm_val_t()
-        dll.wasm_global_get(self.__ptr__, byref(raw))
+        raw = ffi.wasm_val_t()
+        ffi.wasm_global_get(self.__ptr__, byref(raw))
         return Val(raw).value
 
     @value.setter
@@ -61,13 +56,13 @@ class Global:
         Sets the value of this global to a new value
         """
         val = Val.__convert__(self.type.content, val)
-        error = dll.wasmtime_global_set(self.__ptr__, byref(val.__raw__))
+        error = ffi.wasmtime_global_set(self.__ptr__, byref(val.__raw__))
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def _as_extern(self):
-        return dll.wasm_global_as_extern(self.__ptr__)
+        return ffi.wasm_global_as_extern(self.__ptr__)
 
     def __del__(self):
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            dll.wasm_global_delete(self.__ptr__)
+            ffi.wasm_global_delete(self.__ptr__)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -1,10 +1,11 @@
 from . import _ffi as ffi
 from ctypes import *
-from wasmtime import Store, GlobalType, Val, WasmtimeError
+from wasmtime import Store, GlobalType, Val, WasmtimeError, IntoVal
+from typing import Optional, Any
 
 
 class Global:
-    def __init__(self, store: Store, ty: GlobalType, val):
+    def __init__(self, store: Store, ty: GlobalType, val: IntoVal):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
         if not isinstance(ty, GlobalType):
@@ -22,7 +23,7 @@ class Global:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr: pointer, owner) -> "Global":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_global_t]", owner: Optional[Any]) -> "Global":
         ty: "Global" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
             raise TypeError("wrong pointer type")

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -23,7 +23,7 @@ class Global:
 
     @classmethod
     def __from_ptr__(cls, ptr: pointer, owner) -> "Global":
-        ty = cls.__new__(cls)
+        ty: "Global" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -60,7 +60,7 @@ class Global:
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_global_as_extern(self.__ptr__)
 
     def __del__(self):

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -3,7 +3,7 @@ from ctypes import POINTER, pointer, byref
 from wasmtime import Module, Trap, WasmtimeError, Store
 from ._extern import wrap_extern, get_extern_ptr
 from ._exportable import AsExtern
-from typing import Sequence, Union, Optional
+from typing import Sequence, Union, Optional, Mapping
 
 
 class Instance:
@@ -52,7 +52,7 @@ class Instance:
 
     @classmethod
     def __from_ptr__(cls, ptr: pointer, module: Module) -> "Instance":
-        ty = cls.__new__(cls)
+        ty: "Instance" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_instance_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -83,6 +83,9 @@ class Instance:
 
 
 class InstanceExports:
+    _extern_list: Sequence[AsExtern]
+    _extern_map: Mapping[str, AsExtern]
+
     def __init__(self, extern_list, module: Module):
         self._extern_list = extern_list
         self._extern_map = {}

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -86,14 +86,14 @@ class InstanceExports:
     _extern_list: Sequence[AsExtern]
     _extern_map: Mapping[str, AsExtern]
 
-    def __init__(self, extern_list, module: Module):
+    def __init__(self, extern_list: Sequence[AsExtern], module: Module):
         self._extern_list = extern_list
         self._extern_map = {}
         exports = module.exports
         for i, extern in enumerate(extern_list):
             self._extern_map[exports[i].name] = extern
 
-    def __getitem__(self, idx: Union[int, str]):
+    def __getitem__(self, idx: Union[int, str]) -> AsExtern:
         ret = self.get(idx)
         if ret is None:
             msg = "failed to find export {}".format(idx)

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -3,7 +3,7 @@ from ctypes import POINTER, pointer, byref
 from wasmtime import Module, Trap, WasmtimeError, Store
 from ._extern import wrap_extern, get_extern_ptr
 from ._exportable import AsExtern
-from typing import Sequence, Union, Optional, Mapping
+from typing import Sequence, Union, Optional, Mapping, Iterable
 
 
 class Instance:
@@ -77,7 +77,7 @@ class Instance:
             self._exports = InstanceExports(extern_list, self._module)
         return self._exports
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasm_instance_delete(self.__ptr__)
 
@@ -102,10 +102,10 @@ class InstanceExports:
             raise IndexError(msg)
         return ret
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._extern_list)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable[AsExtern]:
         return iter(self._extern_list)
 
     def get(self, idx: Union[int, str]) -> Optional[AsExtern]:
@@ -120,5 +120,5 @@ class ExternTypeList:
     def __init__(self) -> None:
         self.vec = ffi.wasm_extern_vec_t(0, None)
 
-    def __del__(self):
+    def __del__(self) -> None:
         ffi.wasm_extern_vec_delete(byref(self.vec))

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -117,7 +117,7 @@ class InstanceExports:
 
 
 class ExternTypeList:
-    def __init__(self):
+    def __init__(self) -> None:
         self.vec = ffi.wasm_extern_vec_t(0, None)
 
     def __del__(self):

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -1,5 +1,5 @@
 from . import _ffi as ffi
-from ctypes import *
+from ctypes import POINTER, pointer, byref
 from wasmtime import Module, Trap, WasmtimeError, Store
 from ._extern import wrap_extern, get_extern_ptr
 from ._exportable import AsExtern
@@ -7,6 +7,10 @@ from typing import Sequence, Union, Optional
 
 
 class Instance:
+    __ptr__: "pointer[ffi.wasm_instance_t]"
+    _module: Module
+    _exports: Optional["InstanceExports"]
+
     def __init__(self, store: Store, module: Module, imports: Sequence[AsExtern]):
         """
         Creates a new instance by instantiating the `module` given with the

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -65,6 +65,6 @@ class Linker:
             raise Trap.__from_ptr__(trap)
         return Instance.__from_ptr__(instance, module)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasmtime_linker_delete(self.__ptr__)

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -1,22 +1,16 @@
-from ._ffi import *
 from ctypes import *
 from wasmtime import Store, Instance
 from wasmtime import Module, Trap, WasiInstance, WasmtimeError
+from . import _ffi as ffi
 from ._extern import get_extern_ptr
 from ._config import setter_property
-
-dll.wasmtime_linker_new.restype = P_wasmtime_linker_t
-dll.wasmtime_linker_define.restype = P_wasmtime_error_t
-dll.wasmtime_linker_define_instance.restype = P_wasmtime_error_t
-dll.wasmtime_linker_define_wasi.restype = P_wasmtime_error_t
-dll.wasmtime_linker_instantiate.restype = P_wasmtime_error_t
 
 
 class Linker:
     def __init__(self, store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        self.__ptr__ = dll.wasmtime_linker_new(store.__ptr__)
+        self.__ptr__ = ffi.wasmtime_linker_new(store.__ptr__)
         self.store = store
 
     @setter_property
@@ -27,13 +21,13 @@ class Linker:
         """
         if not isinstance(allow, bool):
             raise TypeError("expected a boolean")
-        dll.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
+        ffi.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
 
     def define(self, module, name, item):
         raw_item = get_extern_ptr(item)
-        module_raw = str_to_name(module)
-        name_raw = str_to_name(name)
-        error = dll.wasmtime_linker_define(
+        module_raw = ffi.str_to_name(module)
+        name_raw = ffi.str_to_name(name)
+        error = ffi.wasmtime_linker_define(
             self.__ptr__,
             byref(module_raw),
             byref(name_raw),
@@ -44,8 +38,8 @@ class Linker:
     def define_instance(self, name, instance):
         if not isinstance(instance, Instance):
             raise TypeError("expected an `Instance`")
-        name_raw = str_to_name(name)
-        error = dll.wasmtime_linker_define_instance(self.__ptr__, byref(name_raw),
+        name_raw = ffi.str_to_name(name)
+        error = ffi.wasmtime_linker_define_instance(self.__ptr__, byref(name_raw),
                                                     instance.__ptr__)
         if error:
             raise WasmtimeError.__from_ptr__(error)
@@ -53,16 +47,16 @@ class Linker:
     def define_wasi(self, instance):
         if not isinstance(instance, WasiInstance):
             raise TypeError("expected an `WasiInstance`")
-        error = dll.wasmtime_linker_define_wasi(self.__ptr__, instance.__ptr__)
+        error = ffi.wasmtime_linker_define_wasi(self.__ptr__, instance.__ptr__)
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def instantiate(self, module):
         if not isinstance(module, Module):
             raise TypeError("expected a `Module`")
-        trap = P_wasm_trap_t()
-        instance = P_wasm_instance_t()
-        error = dll.wasmtime_linker_instantiate(
+        trap = POINTER(ffi.wasm_trap_t)()
+        instance = POINTER(ffi.wasm_instance_t)()
+        error = ffi.wasmtime_linker_instantiate(
             self.__ptr__, module.__ptr__, byref(instance), byref(trap))
         if error:
             raise WasmtimeError.__from_ptr__(error)
@@ -72,4 +66,4 @@ class Linker:
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasmtime_linker_delete(self.__ptr__)
+            ffi.wasmtime_linker_delete(self.__ptr__)

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -15,7 +15,7 @@ class Linker:
         self.store = store
 
     @setter_property
-    def allow_shadowing(self, allow: bool):
+    def allow_shadowing(self, allow: bool) -> None:
         """
         Configures whether definitions are allowed to shadow one another within
         this linker

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -4,11 +4,7 @@ from wasmtime import Module, Trap, WasiInstance, WasmtimeError
 from . import _ffi as ffi
 from ._extern import get_extern_ptr
 from ._config import setter_property
-import typing
-
-if typing.TYPE_CHECKING:
-    from ._exportable import Exportable
-
+from ._exportable import AsExtern
 
 
 class Linker:
@@ -28,7 +24,7 @@ class Linker:
             raise TypeError("expected a boolean")
         ffi.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
 
-    def define(self, module: str, name: str, item: "Exportable") -> None:
+    def define(self, module: str, name: str, item: AsExtern) -> None:
         raw_item = get_extern_ptr(item)
         module_raw = ffi.str_to_name(module)
         name_raw = ffi.str_to_name(name)

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -1,6 +1,7 @@
 from . import _ffi as ffi
 from ctypes import *
 from wasmtime import Store, MemoryType, WasmtimeError
+from typing import Optional, Any
 
 
 class Memory:
@@ -20,7 +21,7 @@ class Memory:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr: pointer, owner) -> "Memory":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_memory_t]", owner: Optional[Any]) -> "Memory":
         ty: "Memory" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_memory_t)):
             raise TypeError("wrong pointer type")

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -61,7 +61,7 @@ class Memory:
         return ffi.wasm_memory_size(self.__ptr__)
 
     @property
-    def data_ptr(self) -> POINTER(c_ubyte):
+    def data_ptr(self) -> "pointer[c_ubyte]":
         """
         Returns the raw pointer in memory where this wasm memory lives.
 

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -21,7 +21,7 @@ class Memory:
 
     @classmethod
     def __from_ptr__(cls, ptr: pointer, owner) -> "Memory":
-        ty = cls.__new__(cls)
+        ty: "Memory" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_memory_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -78,7 +78,7 @@ class Memory:
 
         return ffi.wasm_memory_data_size(self.__ptr__)
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_memory_as_extern(self.__ptr__)
 
     def __del__(self):

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -82,6 +82,6 @@ class Memory:
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_memory_as_extern(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_memory_delete(self.__ptr__)

--- a/wasmtime/_module.py
+++ b/wasmtime/_module.py
@@ -6,7 +6,7 @@ import typing
 
 class Module:
     @classmethod
-    def from_file(cls, store: Store, path):
+    def from_file(cls, store: Store, path: str) -> "Module":
         """
         Compiles and creates a new `Module` by reading the file at `path` and
         then delegating to the `Module` constructor.

--- a/wasmtime/_module.py
+++ b/wasmtime/_module.py
@@ -97,7 +97,7 @@ class Module:
 
 
 class ImportTypeList:
-    def __init__(self):
+    def __init__(self) -> None:
         self.vec = ffi.wasm_importtype_vec_t(0, None)
 
     def __del__(self):
@@ -105,7 +105,7 @@ class ImportTypeList:
 
 
 class ExportTypeList:
-    def __init__(self):
+    def __init__(self) -> None:
         self.vec = ffi.wasm_exporttype_vec_t(0, None)
 
     def __del__(self):

--- a/wasmtime/_module.py
+++ b/wasmtime/_module.py
@@ -91,7 +91,7 @@ class Module:
             ret.append(ExportType.__from_ptr__(exports.vec.data[i], exports))
         return ret
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasm_module_delete(self.__ptr__)
 
@@ -100,7 +100,7 @@ class ImportTypeList:
     def __init__(self) -> None:
         self.vec = ffi.wasm_importtype_vec_t(0, None)
 
-    def __del__(self):
+    def __del__(self) -> None:
         ffi.wasm_importtype_vec_delete(byref(self.vec))
 
 
@@ -108,5 +108,5 @@ class ExportTypeList:
     def __init__(self) -> None:
         self.vec = ffi.wasm_exporttype_vec_t(0, None)
 
-    def __del__(self):
+    def __del__(self) -> None:
         ffi.wasm_exporttype_vec_delete(byref(self.vec))

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -28,7 +28,7 @@ class Store:
 
         return InterruptHandle(self)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasm_store_delete(self.__ptr__)
 
@@ -57,6 +57,6 @@ class InterruptHandle:
         """
         ffi.wasmtime_interrupt_handle_interrupt(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasmtime_interrupt_handle_delete(self.__ptr__)

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -1,9 +1,5 @@
-from ._ffi import *
-from ctypes import *
+from . import _ffi as ffi
 from wasmtime import Engine, WasmtimeError
-
-dll.wasm_store_new.restype = P_wasm_store_t
-dll.wasmtime_interrupt_handle_new.restype = P_wasmtime_interrupt_handle_t
 
 
 class Store:
@@ -12,7 +8,7 @@ class Store:
             engine = Engine()
         elif not isinstance(engine, Engine):
             raise TypeError("expected an Engine")
-        self.__ptr__ = dll.wasm_store_new(engine.__ptr__)
+        self.__ptr__ = ffi.wasm_store_new(engine.__ptr__)
         self.engine = engine
 
     def interrupt_handle(self):
@@ -31,7 +27,7 @@ class Store:
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasm_store_delete(self.__ptr__)
+            ffi.wasm_store_delete(self.__ptr__)
 
 
 class InterruptHandle:
@@ -46,7 +42,7 @@ class InterruptHandle:
     def __init__(self, store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        ptr = dll.wasmtime_interrupt_handle_new(store.__ptr__)
+        ptr = ffi.wasmtime_interrupt_handle_new(store.__ptr__)
         if not ptr:
             raise WasmtimeError("interrupts not enabled on Store")
         self.__ptr__ = ptr
@@ -56,8 +52,8 @@ class InterruptHandle:
         Schedules an interrupt to be sent to interrupt this handle's store's
         next (or current) execution of wasm code.
         """
-        dll.wasmtime_interrupt_handle_interrupt(self.__ptr__)
+        ffi.wasmtime_interrupt_handle_interrupt(self.__ptr__)
 
     def __del__(self):
         if hasattr(self, '__ptr__'):
-            dll.wasmtime_interrupt_handle_delete(self.__ptr__)
+            ffi.wasmtime_interrupt_handle_delete(self.__ptr__)

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -1,8 +1,10 @@
 from . import _ffi as ffi
+from ctypes import pointer
 from wasmtime import Engine, WasmtimeError
 
 
 class Store:
+    __ptr__: "pointer[ffi.wasm_store_t]"
 
     def __init__(self, engine: Engine = None):
         if engine is None:

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -116,6 +116,6 @@ class Table:
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_table_as_extern(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_table_delete(self.__ptr__)

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -39,7 +39,7 @@ class Table:
 
     @classmethod
     def __from_ptr__(cls, ptr: pointer, owner) -> "Table":
-        ty = cls.__new__(cls)
+        ty: "Table" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_table_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -113,7 +113,7 @@ class Table:
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
         return ffi.wasm_table_as_extern(self.__ptr__)
 
     def __del__(self):

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -1,7 +1,7 @@
 from . import _ffi as ffi
 from ctypes import *
 from wasmtime import TableType, Store, Func, WasmtimeError
-from typing import Optional
+from typing import Optional, Any
 
 
 def get_func_ptr(init: Optional[Func]) -> Optional["pointer[ffi.wasm_func_t]"]:
@@ -38,7 +38,7 @@ class Table:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr: pointer, owner) -> "Table":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_table_t]", owner: Optional[Any]) -> "Table":
         ty: "Table" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_table_t)):
             raise TypeError("wrong pointer type")

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -1,6 +1,6 @@
 from . import _ffi as ffi
-from ctypes import *
-from wasmtime import Store
+from ctypes import byref, POINTER, pointer
+from wasmtime import Store, WasmtimeError
 import typing
 
 
@@ -61,8 +61,10 @@ class Trap(Exception):
 
 
 class Frame:
+    __ptr__: "pointer[ffi.wasm_frame_t]"
+
     @classmethod
-    def __from_ptr__(cls, ptr: pointer, owner) -> "Frame":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_frame_t]", owner) -> "Frame":
         ty = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_frame_t)):
             raise TypeError("wrong pointer type")

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -52,10 +52,10 @@ class Trap(Exception):
             ret.append(Frame.__from_ptr__(frames.vec.data[i], frames))
         return ret
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasm_trap_delete(self.__ptr__)
 
@@ -127,7 +127,7 @@ class Frame:
 
         return ffi.wasm_frame_func_offset(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.__owner__ is None:
             ffi.wasm_frame_delete(self.__ptr__)
 
@@ -136,5 +136,5 @@ class FrameList:
     def __init__(self) -> None:
         self.vec = ffi.wasm_frame_vec_t(0, None)
 
-    def __del__(self):
+    def __del__(self) -> None:
         ffi.wasm_frame_vec_delete(byref(self.vec))

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -1,7 +1,7 @@
 from . import _ffi as ffi
 from ctypes import byref, POINTER, pointer
 from wasmtime import Store, WasmtimeError
-import typing
+from typing import Optional, Any, List
 
 
 class Trap(Exception):
@@ -44,7 +44,7 @@ class Trap(Exception):
         return ret
 
     @property
-    def frames(self) -> typing.List["Frame"]:
+    def frames(self) -> List["Frame"]:
         frames = FrameList()
         ffi.wasm_trap_trace(self.__ptr__, byref(frames.vec))
         ret = []
@@ -62,10 +62,11 @@ class Trap(Exception):
 
 class Frame:
     __ptr__: "pointer[ffi.wasm_frame_t]"
+    __owner__: Optional[Any]
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_frame_t]", owner) -> "Frame":
-        ty = cls.__new__(cls)
+        ty: "Frame" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_frame_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -81,7 +82,7 @@ class Frame:
         return ffi.wasm_frame_func_index(self.__ptr__)
 
     @property
-    def func_name(self) -> typing.Optional[str]:
+    def func_name(self) -> Optional[str]:
         """
         Returns the name of the function this frame corresponds to
 
@@ -95,7 +96,7 @@ class Frame:
             return None
 
     @property
-    def module_name(self) -> typing.Optional[str]:
+    def module_name(self) -> Optional[str]:
         """
         Returns the name of the module this frame corresponds to
 

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -65,7 +65,7 @@ class Frame:
     __owner__: Optional[Any]
 
     @classmethod
-    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_frame_t]", owner) -> "Frame":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_frame_t]", owner: Optional[Any]) -> "Frame":
         ty: "Frame" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_frame_t)):
             raise TypeError("wrong pointer type")

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -21,10 +21,10 @@ class Trap(Exception):
         self.__ptr__ = ptr
 
     @classmethod
-    def __from_ptr__(cls, ptr):
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_trap_t]") -> "Trap":
         if not isinstance(ptr, POINTER(ffi.wasm_trap_t)):
             raise TypeError("wrong pointer type")
-        trap = cls.__new__(cls)
+        trap: "Trap" = cls.__new__(cls)
         trap.__ptr__ = ptr
         return trap
 
@@ -133,7 +133,7 @@ class Frame:
 
 
 class FrameList:
-    def __init__(self):
+    def __init__(self) -> None:
         self.vec = ffi.wasm_frame_vec_t(0, None)
 
     def __del__(self):

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -82,7 +82,7 @@ class ValType:
             return 'funcref'
         return 'ValType(%d)' % kind.value
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not hasattr(self, '__owner__') or not hasattr(self, '__ptr__'):
             return
         # If this is owned by another object we don't free it since that object
@@ -162,10 +162,10 @@ class FuncType:
         ptr = ffi.wasm_functype_results(self.__ptr__)
         return ValType.__from_list__(ptr, self)
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
         return ffi.wasm_functype_as_externtype_const(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_functype_delete(self.__ptr__)
 
@@ -209,10 +209,10 @@ class GlobalType:
         val = ffi.wasm_globaltype_mutability(self.__ptr__)
         return val == ffi.WASM_VAR.value
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
         return ffi.wasm_globaltype_as_externtype_const(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_globaltype_delete(self.__ptr__)
 
@@ -278,10 +278,10 @@ class TableType:
         val = ffi.wasm_tabletype_limits(self.__ptr__)
         return Limits.__from_ffi__(val)
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
         return ffi.wasm_tabletype_as_externtype_const(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_tabletype_delete(self.__ptr__)
 
@@ -313,10 +313,10 @@ class MemoryType:
         val = ffi.wasm_memorytype_limits(self.__ptr__)
         return Limits.__from_ffi__(val)
 
-    def _as_extern(self):
+    def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
         return ffi.wasm_memorytype_as_externtype_const(self.__ptr__)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
             ffi.wasm_memorytype_delete(self.__ptr__)
 
@@ -374,7 +374,7 @@ class ImportType:
         ptr = ffi.wasm_importtype_type(self.__ptr__)
         return wrap_externtype(ptr, self.__owner__ or self)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.__owner__ is None:
             ffi.wasm_importtype_delete(self.__ptr__)
 
@@ -407,7 +407,7 @@ class ExportType:
         ptr = ffi.wasm_exporttype_type(self.__ptr__)
         return wrap_externtype(ptr, self.__owner__ or self)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.__owner__ is None:
             ffi.wasm_exporttype_delete(self.__ptr__)
 

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -9,36 +9,36 @@ class ValType:
     __owner__: Optional[Any]
 
     @classmethod
-    def i32(cls):
+    def i32(cls) -> "ValType":
         ptr = ffi.wasm_valtype_new(ffi.WASM_I32)
         return ValType.__from_ptr__(ptr, None)
 
     @classmethod
-    def i64(cls):
+    def i64(cls) -> "ValType":
         ptr = ffi.wasm_valtype_new(ffi.WASM_I64)
         return ValType.__from_ptr__(ptr, None)
 
     @classmethod
-    def f32(cls):
+    def f32(cls) -> "ValType":
         ptr = ffi.wasm_valtype_new(ffi.WASM_F32)
         return ValType.__from_ptr__(ptr, None)
 
     @classmethod
-    def f64(cls):
+    def f64(cls) -> "ValType":
         ptr = ffi.wasm_valtype_new(ffi.WASM_F64)
         return ValType.__from_ptr__(ptr, None)
 
     @classmethod
-    def anyref(cls):
+    def anyref(cls) -> "ValType":
         ptr = ffi.wasm_valtype_new(ffi.WASM_ANYREF)
         return ValType.__from_ptr__(ptr, None)
 
     @classmethod
-    def funcref(cls):
+    def funcref(cls) -> "ValType":
         ptr = ffi.wasm_valtype_new(ffi.WASM_FUNCREF)
         return ValType.__from_ptr__(ptr, None)
 
-    def __init__(self):
+    def __init__(self) -> None:
         raise WasmtimeError("cannot construct directly")
 
     @classmethod

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -5,7 +5,8 @@ from typing import Union, List, Optional, Any
 
 
 class ValType:
-    __ptr__: "pointer[ffi.wasm_val_t]"
+    __ptr__: "pointer[ffi.wasm_valtype_t]"
+    __owner__: Optional[Any]
 
     @classmethod
     def i32(cls):
@@ -42,7 +43,7 @@ class ValType:
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_valtype_t]", owner) -> "ValType":
-        ty = cls.__new__(cls)
+        ty: "ValType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_valtype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -136,7 +137,7 @@ class FuncType:
 
     @classmethod
     def __from_ptr__(cls, ptr, owner) -> "FuncType":
-        ty = cls.__new__(cls)
+        ty: "FuncType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_functype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -184,7 +185,7 @@ class GlobalType:
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_globaltype_t]", owner) -> "GlobalType":
-        ty = cls.__new__(cls)
+        ty: "GlobalType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_globaltype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -233,7 +234,7 @@ class Limits:
         return self.min == other.min and self.max == other.max
 
     @classmethod
-    def __from_ffi__(cls, val: 'pointer[ffi.wasm_limits_t]'):
+    def __from_ffi__(cls, val: 'pointer[ffi.wasm_limits_t]') -> "Limits":
         min = val.contents.min
         max = val.contents.max
         if max == 0xffffffff:
@@ -254,7 +255,7 @@ class TableType:
 
     @classmethod
     def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_tabletype_t]', owner) -> "TableType":
-        ty = cls.__new__(cls)
+        ty: "TableType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_tabletype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -297,7 +298,7 @@ class MemoryType:
 
     @classmethod
     def __from_ptr__(cls, ptr, owner) -> "MemoryType":
-        ty = cls.__new__(cls)
+        ty: "MemoryType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_memorytype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -320,7 +321,7 @@ class MemoryType:
             ffi.wasm_memorytype_delete(self.__ptr__)
 
 
-def wrap_externtype(ptr, owner):
+def wrap_externtype(ptr, owner) -> "AsExternType":
     if not isinstance(ptr, POINTER(ffi.wasm_externtype_t)):
         raise TypeError("wrong pointer type")
     val = ffi.wasm_externtype_as_functype_const(ptr)
@@ -343,7 +344,7 @@ class ImportType:
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_importtype_t]", owner) -> "ImportType":
-        ty = cls.__new__(cls)
+        ty: "ImportType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_importtype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr
@@ -366,7 +367,7 @@ class ImportType:
         return ffi.to_str(ffi.wasm_importtype_name(self.__ptr__).contents)
 
     @property
-    def type(self) -> "ExternalType":
+    def type(self) -> "AsExternType":
         """
         Returns the type that this import refers to
         """
@@ -399,7 +400,7 @@ class ExportType:
         return ffi.to_str(ffi.wasm_exporttype_name(self.__ptr__).contents)
 
     @property
-    def type(self) -> "ExternalType":
+    def type(self) -> "AsExternType":
         """
         Returns the type that this export refers to
         """
@@ -411,4 +412,4 @@ class ExportType:
             ffi.wasm_exporttype_delete(self.__ptr__)
 
 
-ExternalType = Union[FuncType, TableType, MemoryType, GlobalType]
+AsExternType = Union[FuncType, TableType, MemoryType, GlobalType]

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -42,7 +42,7 @@ class ValType:
         raise WasmtimeError("cannot construct directly")
 
     @classmethod
-    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_valtype_t]", owner) -> "ValType":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_valtype_t]", owner: Optional[Any]) -> "ValType":
         ty: "ValType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_valtype_t)):
             raise TypeError("wrong pointer type")
@@ -50,7 +50,7 @@ class ValType:
         ty.__owner__ = owner
         return ty
 
-    def __eq__(self, other: object):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, ValType):
             return False
         assert(self.__ptr__ is not None)
@@ -59,7 +59,7 @@ class ValType:
         kind2 = ffi.wasm_valtype_kind(other.__ptr__)
         return kind1 == kind2
 
-    def __ne__(self, other: object):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
     def __repr__(self) -> str:
@@ -91,7 +91,7 @@ class ValType:
             ffi.wasm_valtype_delete(self.__ptr__)
 
     @classmethod
-    def __from_list__(cls, items: "pointer[ffi.wasm_valtype_vec_t]", owner) -> List["ValType"]:
+    def __from_list__(cls, items: "pointer[ffi.wasm_valtype_vec_t]", owner: Optional[Any]) -> List["ValType"]:
         types = []
         for i in range(0, items.contents.size):
             types.append(ValType.__from_ptr__(items.contents.data[i], owner))
@@ -136,7 +136,7 @@ class FuncType:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr, owner) -> "FuncType":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_functype_t]", owner: Optional[Any]) -> "FuncType":
         ty: "FuncType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_functype_t)):
             raise TypeError("wrong pointer type")
@@ -184,7 +184,7 @@ class GlobalType:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_globaltype_t]", owner) -> "GlobalType":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_globaltype_t]", owner: Optional[Any]) -> "GlobalType":
         ty: "GlobalType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_globaltype_t)):
             raise TypeError("wrong pointer type")
@@ -228,7 +228,7 @@ class Limits:
             max = 0xffffffff
         return ffi.wasm_limits_t(self.min, max)
 
-    def __eq__(self, other: object):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Limits):
             return False
         return self.min == other.min and self.max == other.max
@@ -254,7 +254,7 @@ class TableType:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_tabletype_t]', owner) -> "TableType":
+    def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_tabletype_t]', owner: Optional[Any]) -> "TableType":
         ty: "TableType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_tabletype_t)):
             raise TypeError("wrong pointer type")
@@ -297,7 +297,7 @@ class MemoryType:
         self.__owner__ = None
 
     @classmethod
-    def __from_ptr__(cls, ptr, owner) -> "MemoryType":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_memorytype_t]", owner: Optional[Any]) -> "MemoryType":
         ty: "MemoryType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_memorytype_t)):
             raise TypeError("wrong pointer type")
@@ -321,7 +321,7 @@ class MemoryType:
             ffi.wasm_memorytype_delete(self.__ptr__)
 
 
-def wrap_externtype(ptr, owner) -> "AsExternType":
+def wrap_externtype(ptr: "pointer[ffi.wasm_externtype_t]", owner: Optional[Any]) -> "AsExternType":
     if not isinstance(ptr, POINTER(ffi.wasm_externtype_t)):
         raise TypeError("wrong pointer type")
     val = ffi.wasm_externtype_as_functype_const(ptr)
@@ -343,7 +343,7 @@ class ImportType:
     __owner__: Optional[Any]
 
     @classmethod
-    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_importtype_t]", owner) -> "ImportType":
+    def __from_ptr__(cls, ptr: "pointer[ffi.wasm_importtype_t]", owner: Optional[Any]) -> "ImportType":
         ty: "ImportType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_importtype_t)):
             raise TypeError("wrong pointer type")
@@ -384,8 +384,8 @@ class ExportType:
     __owner__: Optional[Any]
 
     @classmethod
-    def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_exporttype_t]', owner):
-        ty = cls.__new__(cls)
+    def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_exporttype_t]', owner: Optional[Any]) -> "ExportType":
+        ty: "ExportType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_exporttype_t)):
             raise TypeError("wrong pointer type")
         ty.__ptr__ = ptr

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -59,15 +59,17 @@ class Val:
             if ty != val.type:
                 raise TypeError("wrong type of `Val` provided")
             return val
-        if ty == ValType.i32():
-            return Val.i32(val)
-        if ty == ValType.i64():
-            return Val.i64(val)
-        if ty == ValType.f32():
-            return Val.f32(val)
-        if ty == ValType.f64():
-            return Val.f64(val)
-        raise WasmtimeError("don't know how to convert %r to %s" % (val, ty))
+        elif isinstance(val, int):
+            if ty == ValType.i32():
+                return Val.i32(val)
+            if ty == ValType.i64():
+                return Val.i64(val)
+        elif isinstance(val, float):
+            if ty == ValType.f32():
+                return Val.f32(val)
+            if ty == ValType.f64():
+                return Val.f64(val)
+        raise TypeError("don't know how to convert %r to %s" % (val, ty))
 
     @property
     def value(self) -> typing.Optional[typing.Union[int, float]]:

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -54,7 +54,7 @@ class Val:
         self.__raw__ = raw
 
     @classmethod
-    def __convert__(cls, ty: ValType, val: typing.Union["Val", int, float]) -> "Val":
+    def __convert__(cls, ty: ValType, val: "IntoVal") -> "Val":
         if isinstance(val, Val):
             if ty != val.type:
                 raise TypeError("wrong type of `Val` provided")
@@ -131,3 +131,6 @@ class Val:
         """
         ptr = dll.wasm_valtype_new(self.__raw__.kind)
         return ValType.__from_ptr__(ptr, None)
+
+
+IntoVal = typing.Union[Val, int, float]

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -12,18 +12,18 @@ class WasiConfig:
         self.__ptr__ = ffi.wasi_config_new()
 
     @setter_property
-    def set_argv(self, argv: List[str]):
+    def set_argv(self, argv: List[str]) -> None:
         """
         Explicitly configure the `argv` for this WASI configuration
         """
         ptrs = to_char_array(argv)
         ffi.wasi_config_set_argv(self.__ptr__, c_int(len(argv)), ptrs)
 
-    def inherit_argv(self):
+    def inherit_argv(self) -> None:
         ffi.wasi_config_inherit_argv(self.__ptr__)
 
     @setter_property
-    def env(self, pairs: Iterable[Iterable]):
+    def env(self, pairs: Iterable[Iterable]) -> None:
         """
         Configure environment variables to be returned for this WASI
         configuration.
@@ -41,31 +41,31 @@ class WasiConfig:
         ffi.wasi_config_set_env(self.__ptr__, c_int(
             len(names)), name_ptrs, value_ptrs)
 
-    def inherit_env(self):
+    def inherit_env(self) -> None:
         ffi.wasi_config_inherit_env(self.__ptr__)
 
     @setter_property
-    def stdin_file(self, path):
+    def stdin_file(self, path: str) -> None:
         ffi.wasi_config_set_stdin_file(
             self.__ptr__, c_char_p(path.encode('utf-8')))
 
-    def inherit_stdin(self):
+    def inherit_stdin(self) -> None:
         ffi.wasi_config_inherit_stdin(self.__ptr__)
 
     @setter_property
-    def stdout_file(self, path):
+    def stdout_file(self, path: str) -> None:
         ffi.wasi_config_set_stdout_file(
             self.__ptr__, c_char_p(path.encode('utf-8')))
 
-    def inherit_stdout(self):
+    def inherit_stdout(self) -> None:
         ffi.wasi_config_inherit_stdout(self.__ptr__)
 
     @setter_property
-    def stderr_file(self, path):
+    def stderr_file(self, path: str) -> None:
         ffi.wasi_config_set_stderr_file(
             self.__ptr__, c_char_p(path.encode('utf-8')))
 
-    def inherit_stderr(self):
+    def inherit_stderr(self) -> None:
         ffi.wasi_config_inherit_stderr(self.__ptr__)
 
     def preopen_dir(self, path: str, guest_path: str) -> None:

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -12,7 +12,7 @@ class WasiConfig:
         self.__ptr__ = ffi.wasi_config_new()
 
     @setter_property
-    def set_argv(self, argv: List[str]) -> None:
+    def argv(self, argv: List[str]) -> None:
         """
         Explicitly configure the `argv` for this WASI configuration
         """

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -73,7 +73,7 @@ class WasiConfig:
         guest_path_ptr = c_char_p(guest_path.encode('utf-8'))
         ffi.wasi_config_preopen_dir(self.__ptr__, path_ptr, guest_path_ptr)
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasi_config_delete(self.__ptr__)
 
@@ -86,6 +86,8 @@ def to_char_array(strings: List[str]) -> "pointer[pointer[c_char]]":
 
 
 class WasiInstance:
+    __ptr__: "pointer[ffi.wasi_instance_t]"
+
     def __init__(self, store: Store, name: str, config: WasiConfig):
         if not isinstance(store, Store):
             raise TypeError("expected a `Store`")
@@ -116,6 +118,6 @@ class WasiInstance:
         else:
             return None
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, '__ptr__'):
             ffi.wasi_instance_delete(self.__ptr__)

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -8,7 +8,7 @@ from ._exportable import AsExtern
 
 
 class WasiConfig:
-    def __init__(self):
+    def __init__(self) -> None:
         self.__ptr__ = ffi.wasi_config_new()
 
     @setter_property

--- a/wasmtime/_wat2wasm.py
+++ b/wasmtime/_wat2wasm.py
@@ -1,8 +1,6 @@
-from ._ffi import *
+from . import _ffi as ffi
 from ctypes import *
 from wasmtime import WasmtimeError
-
-dll.wasmtime_wat2wasm.restype = P_wasmtime_error_t
 
 
 def wat2wasm(wat):
@@ -26,12 +24,12 @@ def wat2wasm(wat):
     if isinstance(wat, str):
         wat = wat.encode('utf8')
     wat_buffer = cast(create_string_buffer(wat), POINTER(c_uint8))
-    wat = wasm_byte_vec_t(len(wat), wat_buffer)
-    wasm = wasm_byte_vec_t()
-    error = dll.wasmtime_wat2wasm(byref(wat), byref(wasm))
+    wat = ffi.wasm_byte_vec_t(len(wat), wat_buffer)
+    wasm = ffi.wasm_byte_vec_t()
+    error = ffi.wasmtime_wat2wasm(byref(wat), byref(wasm))
     if error:
         raise WasmtimeError.__from_ptr__(error)
     else:
-        ret = wasm.to_bytes()
-        dll.wasm_byte_vec_delete(byref(wasm))
+        ret = ffi.to_bytes(wasm)
+        ffi.wasm_byte_vec_delete(byref(wasm))
         return ret

--- a/wasmtime/_wat2wasm.py
+++ b/wasmtime/_wat2wasm.py
@@ -25,9 +25,9 @@ def wat2wasm(wat: typing.Union[str, bytes]) -> bytearray:
     if isinstance(wat, str):
         wat = wat.encode('utf8')
     wat_buffer = cast(create_string_buffer(wat), POINTER(c_uint8))
-    wat = ffi.wasm_byte_vec_t(len(wat), wat_buffer)
+    wat_bytes = ffi.wasm_byte_vec_t(len(wat), wat_buffer)
     wasm = ffi.wasm_byte_vec_t()
-    error = ffi.wasmtime_wat2wasm(byref(wat), byref(wasm))
+    error = ffi.wasmtime_wat2wasm(byref(wat_bytes), byref(wasm))
     if error:
         raise WasmtimeError.__from_ptr__(error)
     else:

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -28,7 +28,7 @@ linker.allow_shadowing = True
 
 
 class _WasmtimeMetaFinder(MetaPathFinder):
-    def find_spec(self, fullname, path, target=None):
+    def find_spec(self, fullname, path, target=None):  # type: ignore
         if path is None or path == "":
             path = [os.getcwd()]  # top level import --
             path.extend(sys.path)
@@ -54,10 +54,10 @@ class _WasmtimeLoader(Loader):
     def __init__(self, filename: str):
         self.filename = filename
 
-    def create_module(self, spec):
+    def create_module(self, spec):  # type: ignore
         return None  # use default module creation semantics
 
-    def exec_module(self, module):
+    def exec_module(self, module):  # type: ignore
         wasm_module = Module.from_file(store, self.filename)
 
         for wasm_import in wasm_module.imports:

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -12,11 +12,9 @@ from wasmtime import Func, Table, Global, Memory
 import sys
 import os.path
 import importlib
-from typing import Optional, Sequence, Union
 
 from importlib.abc import Loader, MetaPathFinder
 from importlib.util import spec_from_file_location
-from importlib.machinery import ModuleSpec
 
 store = Store()
 linker = Linker(store)
@@ -30,7 +28,7 @@ linker.allow_shadowing = True
 
 
 class _WasmtimeMetaFinder(MetaPathFinder):
-    def find_spec(self, fullname: str, path: Optional[Sequence[Union[bytes, str]]], target=None) -> Optional[ModuleSpec]:
+    def find_spec(self, fullname, path, target=None):
         if path is None or path == "":
             path = [os.getcwd()]  # top level import --
             path.extend(sys.path)
@@ -53,13 +51,13 @@ class _WasmtimeMetaFinder(MetaPathFinder):
 
 
 class _WasmtimeLoader(Loader):
-    def __init__(self, filename):
+    def __init__(self, filename: str):
         self.filename = filename
 
     def create_module(self, spec):
         return None  # use default module creation semantics
 
-    def exec_module(self, module) -> None:
+    def exec_module(self, module):
         wasm_module = Module.from_file(store, self.filename)
 
         for wasm_import in wasm_module.imports:

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -12,13 +12,11 @@ from wasmtime import Func, Table, Global, Memory
 import sys
 import os.path
 import importlib
-import typing
+from typing import Optional, Sequence, Union
 
 from importlib.abc import Loader, MetaPathFinder
 from importlib.util import spec_from_file_location
-
-if typing.TYPE_CHECKING:
-    from importlib.machinery import ModuleSpec
+from importlib.machinery import ModuleSpec
 
 store = Store()
 linker = Linker(store)
@@ -32,7 +30,7 @@ linker.allow_shadowing = True
 
 
 class _WasmtimeMetaFinder(MetaPathFinder):
-    def find_spec(self, fullname: str, path: str, target=None) -> typing.Optional["ModuleSpec"]:
+    def find_spec(self, fullname: str, path: Optional[Sequence[Union[bytes, str]]], target=None) -> Optional[ModuleSpec]:
         if path is None or path == "":
             path = [os.getcwd()]  # top level import --
             path.extend(sys.path)
@@ -41,13 +39,13 @@ class _WasmtimeMetaFinder(MetaPathFinder):
         else:
             name = fullname
         for entry in path:
-            py = os.path.join(entry, name + ".py")
+            py = os.path.join(str(entry), name + ".py")
             if os.path.exists(py):
                 continue
-            wasm = os.path.join(entry, name + ".wasm")
+            wasm = os.path.join(str(entry), name + ".wasm")
             if os.path.exists(wasm):
                 return spec_from_file_location(fullname, wasm, loader=_WasmtimeLoader(wasm))
-            wat = os.path.join(entry, name + ".wat")
+            wat = os.path.join(str(entry), name + ".wat")
             if os.path.exists(wat):
                 return spec_from_file_location(fullname, wat, loader=_WasmtimeLoader(wat))
 


### PR DESCRIPTION
This commit builds on #25 to add type annotations throughout this package. The `pytest-mypy` package is used to automate checking all this on CI, which both verifies that type annotations are correct and that they're present everywhere.

Closes #24 