### PR TITLE
Rename `Val.__raw__` to `Val._raw`

### DIFF
--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -21,7 +21,7 @@ class Config:
     """
 
     def __init__(self) -> None:
-        self.__ptr__ = ffi.wasm_config_new()
+        self._ptr = ffi.wasm_config_new()
 
     @setter_property
     def debug_info(self, enable: bool) -> None:
@@ -32,7 +32,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_debug_info_set(self.__ptr__, enable)
+        ffi.wasmtime_config_debug_info_set(self._ptr, enable)
 
     @setter_property
     def wasm_threads(self, enable: bool) -> None:
@@ -44,7 +44,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_threads_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_threads_set(self._ptr, enable)
 
     @setter_property
     def wasm_reference_types(self, enable: bool) -> None:
@@ -56,7 +56,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_reference_types_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_reference_types_set(self._ptr, enable)
 
     @setter_property
     def wasm_simd(self, enable: bool) -> None:
@@ -68,7 +68,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_simd_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_simd_set(self._ptr, enable)
 
     @setter_property
     def wasm_bulk_memory(self, enable: bool) -> None:
@@ -80,7 +80,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_bulk_memory_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_bulk_memory_set(self._ptr, enable)
 
     @setter_property
     def wasm_multi_value(self, enable: bool) -> None:
@@ -92,7 +92,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_multi_value_set(self.__ptr__, enable)
+        ffi.wasmtime_config_wasm_multi_value_set(self._ptr, enable)
 
     @setter_property
     def strategy(self, strategy: str) -> None:
@@ -107,11 +107,11 @@ class Config:
         """
 
         if strategy == "auto":
-            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 0)
+            error = ffi.wasmtime_config_strategy_set(self._ptr, 0)
         elif strategy == "cranelift":
-            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 1)
+            error = ffi.wasmtime_config_strategy_set(self._ptr, 1)
         elif strategy == "lightbeam":
-            error = ffi.wasmtime_config_strategy_set(self.__ptr__, 2)
+            error = ffi.wasmtime_config_strategy_set(self._ptr, 2)
         else:
             raise WasmtimeError("unknown strategy: " + str(strategy))
         if error:
@@ -121,25 +121,25 @@ class Config:
     def cranelift_debug_verifier(self, enable: bool) -> None:
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_cranelift_debug_verifier_set(self.__ptr__, enable)
+        ffi.wasmtime_config_cranelift_debug_verifier_set(self._ptr, enable)
 
     @setter_property
     def cranelift_opt_level(self, opt_level: str) -> None:
         if opt_level == "none":
-            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 0)
+            ffi.wasmtime_config_cranelift_opt_level_set(self._ptr, 0)
         elif opt_level == "speed":
-            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 1)
+            ffi.wasmtime_config_cranelift_opt_level_set(self._ptr, 1)
         elif opt_level == "speed_and_size":
-            ffi.wasmtime_config_cranelift_opt_level_set(self.__ptr__, 2)
+            ffi.wasmtime_config_cranelift_opt_level_set(self._ptr, 2)
         else:
             raise WasmtimeError("unknown opt level: " + str(opt_level))
 
     @setter_property
     def profiler(self, profiler: str) -> None:
         if profiler == "none":
-            error = ffi.wasmtime_config_profiler_set(self.__ptr__, 0)
+            error = ffi.wasmtime_config_profiler_set(self._ptr, 0)
         elif profiler == "jitdump":
-            error = ffi.wasmtime_config_profiler_set(self.__ptr__, 1)
+            error = ffi.wasmtime_config_profiler_set(self._ptr, 1)
         else:
             raise WasmtimeError("unknown profiler: " + str(profiler))
         if error:
@@ -161,9 +161,9 @@ class Config:
         if isinstance(enabled, bool):
             if not enabled:
                 raise WasmtimeError("caching cannot be explicitly disabled")
-            error = ffi.wasmtime_config_cache_config_load(self.__ptr__, None)
+            error = ffi.wasmtime_config_cache_config_load(self._ptr, None)
         elif isinstance(enabled, str):
-            error = ffi.wasmtime_config_cache_config_load(self.__ptr__,
+            error = ffi.wasmtime_config_cache_config_load(self._ptr,
                                                           c_char_p(enabled.encode('utf-8')))
         else:
             raise TypeError("expected string or bool")
@@ -181,8 +181,8 @@ class Config:
             val = 1
         else:
             val = 0
-        ffi.wasmtime_config_interruptable_set(self.__ptr__, val)
+        ffi.wasmtime_config_interruptable_set(self._ptr, val)
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasm_config_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasm_config_delete(self._ptr)

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -5,16 +5,16 @@ from wasmtime import Config, WasmtimeError
 class Engine:
     def __init__(self, config: Config = None):
         if config is None:
-            self.__ptr__ = ffi.wasm_engine_new()
+            self._ptr = ffi.wasm_engine_new()
         elif not isinstance(config, Config):
             raise TypeError("expected Config")
-        elif not hasattr(config, '__ptr__'):
+        elif not hasattr(config, '_ptr'):
             raise WasmtimeError("Config already used")
         else:
-            ptr = config.__ptr__
-            delattr(config, '__ptr__')
-            self.__ptr__ = ffi.wasm_engine_new_with_config(ptr)
+            ptr = config._ptr
+            delattr(config, '_ptr')
+            self._ptr = ffi.wasm_engine_new_with_config(ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasm_engine_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasm_engine_delete(self._ptr)

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -41,7 +41,7 @@ class Func:
             FUNCTIONS.deallocate(idx)
             raise WasmtimeError("failed to create func")
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_func_t]", owner: Optional[Any]) -> "Func":
@@ -49,7 +49,7 @@ class Func:
         if not isinstance(ptr, POINTER(ffi.wasm_func_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -128,7 +128,7 @@ class Func:
         return ffi.wasm_func_as_extern(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_func_delete(self._ptr)
 
 

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -96,7 +96,7 @@ class Func:
             if i >= len(param_tys):
                 raise WasmtimeError("too many parameters provided")
             val = Val.__convert__(param_tys[i], param)
-            params_ptr[i] = val.__raw__
+            params_ptr[i] = val._raw
 
         result_tys = ty.results
         results_ptr = (ffi.wasm_val_t * len(result_tys))()
@@ -209,13 +209,13 @@ def invoke(idx, params_ptr, results_ptr, params):  # type: ignore
                     "callback produced results when it shouldn't")
         elif len(result_tys) == 1:
             val = Val.__convert__(result_tys[0], results)
-            results_ptr[0] = val.__raw__
+            results_ptr[0] = val._raw
         else:
             if len(results) != len(result_tys):
                 raise WasmtimeError("callback produced wrong number of results")
             for i, result in enumerate(results):
                 val = Val.__convert__(result_tys[i], result)
-                results_ptr[i] = val.__raw__
+                results_ptr[i] = val._raw
     except Exception:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         fmt = traceback.format_exception(exc_type, exc_value, exc_traceback)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -20,7 +20,7 @@ class Global:
         if error:
             raise WasmtimeError.__from_ptr__(error)
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_global_t]", owner: Optional[Any]) -> "Global":
@@ -28,7 +28,7 @@ class Global:
         if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -69,5 +69,5 @@ class Global:
         return ffi.wasm_global_as_extern(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_global_delete(self._ptr)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -15,7 +15,7 @@ class Global:
         error = ffi.wasmtime_global_new(
             store.__ptr__,
             ty.__ptr__,
-            byref(val.__raw__),
+            byref(val._raw),
             byref(ptr))
         if error:
             raise WasmtimeError.__from_ptr__(error)
@@ -61,7 +61,7 @@ class Global:
         Sets the value of this global to a new value
         """
         val = Val.__convert__(self.type.content, val)
-        error = ffi.wasmtime_global_set(self.__ptr__, byref(val.__raw__))
+        error = ffi.wasmtime_global_set(self.__ptr__, byref(val._raw))
         if error:
             raise WasmtimeError.__from_ptr__(error)
 

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -13,13 +13,13 @@ class Global:
         val = Val.__convert__(ty.content, val)
         ptr = POINTER(ffi.wasm_global_t)()
         error = ffi.wasmtime_global_new(
-            store.__ptr__,
-            ty.__ptr__,
+            store._ptr,
+            ty._ptr,
             byref(val._raw),
             byref(ptr))
         if error:
             raise WasmtimeError.__from_ptr__(error)
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -27,7 +27,7 @@ class Global:
         ty: "Global" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -37,7 +37,7 @@ class Global:
         Gets the type of this global as a `GlobalType`
         """
 
-        ptr = ffi.wasm_global_type(self.__ptr__)
+        ptr = ffi.wasm_global_type(self._ptr)
         return GlobalType.__from_ptr__(ptr, None)
 
     @property
@@ -48,7 +48,7 @@ class Global:
         Returns a native python type
         """
         raw = ffi.wasm_val_t()
-        ffi.wasm_global_get(self.__ptr__, byref(raw))
+        ffi.wasm_global_get(self._ptr, byref(raw))
         val = Val(raw)
         if val.value:
             return val.value
@@ -61,13 +61,13 @@ class Global:
         Sets the value of this global to a new value
         """
         val = Val.__convert__(self.type.content, val)
-        error = ffi.wasmtime_global_set(self.__ptr__, byref(val._raw))
+        error = ffi.wasmtime_global_set(self._ptr, byref(val._raw))
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
-        return ffi.wasm_global_as_extern(self.__ptr__)
+        return ffi.wasm_global_as_extern(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_global_delete(self.__ptr__)
+            ffi.wasm_global_delete(self._ptr)

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -7,7 +7,7 @@ from typing import Sequence, Union, Optional, Mapping, Iterable
 
 
 class Instance:
-    __ptr__: "pointer[ffi.wasm_instance_t]"
+    _ptr: "pointer[ffi.wasm_instance_t]"
     _module: Module
     _exports: Optional["InstanceExports"]
 
@@ -36,8 +36,8 @@ class Instance:
         instance = POINTER(ffi.wasm_instance_t)()
         trap = POINTER(ffi.wasm_trap_t)()
         error = ffi.wasmtime_instance_new(
-            store.__ptr__,
-            module.__ptr__,
+            store._ptr,
+            module._ptr,
             imports_ptr,
             len(imports),
             byref(instance),
@@ -46,7 +46,7 @@ class Instance:
             raise WasmtimeError.__from_ptr__(error)
         if trap:
             raise Trap.__from_ptr__(trap)
-        self.__ptr__ = instance
+        self._ptr = instance
         self._module = module
         self._exports = None
 
@@ -55,7 +55,7 @@ class Instance:
         ty: "Instance" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_instance_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty._module = module
         ty._exports = None
         return ty
@@ -70,7 +70,7 @@ class Instance:
         """
         if self._exports is None:
             externs = ExternTypeList()
-            ffi.wasm_instance_exports(self.__ptr__, byref(externs.vec))
+            ffi.wasm_instance_exports(self._ptr, byref(externs.vec))
             extern_list = []
             for i in range(0, externs.vec.size):
                 extern_list.append(wrap_extern(externs.vec.data[i], externs))
@@ -78,8 +78,8 @@ class Instance:
         return self._exports
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasm_instance_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasm_instance_delete(self._ptr)
 
 
 class InstanceExports:

--- a/wasmtime/_linker.py
+++ b/wasmtime/_linker.py
@@ -11,7 +11,7 @@ class Linker:
     def __init__(self, store: Store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        self.__ptr__ = ffi.wasmtime_linker_new(store.__ptr__)
+        self._ptr = ffi.wasmtime_linker_new(store._ptr)
         self.store = store
 
     @setter_property
@@ -22,14 +22,14 @@ class Linker:
         """
         if not isinstance(allow, bool):
             raise TypeError("expected a boolean")
-        ffi.wasmtime_linker_allow_shadowing(self.__ptr__, allow)
+        ffi.wasmtime_linker_allow_shadowing(self._ptr, allow)
 
     def define(self, module: str, name: str, item: AsExtern) -> None:
         raw_item = get_extern_ptr(item)
         module_raw = ffi.str_to_name(module)
         name_raw = ffi.str_to_name(name)
         error = ffi.wasmtime_linker_define(
-            self.__ptr__,
+            self._ptr,
             byref(module_raw),
             byref(name_raw),
             raw_item)
@@ -40,15 +40,15 @@ class Linker:
         if not isinstance(instance, Instance):
             raise TypeError("expected an `Instance`")
         name_raw = ffi.str_to_name(name)
-        error = ffi.wasmtime_linker_define_instance(self.__ptr__, byref(name_raw),
-                                                    instance.__ptr__)
+        error = ffi.wasmtime_linker_define_instance(self._ptr, byref(name_raw),
+                                                    instance._ptr)
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def define_wasi(self, instance: WasiInstance) -> None:
         if not isinstance(instance, WasiInstance):
             raise TypeError("expected an `WasiInstance`")
-        error = ffi.wasmtime_linker_define_wasi(self.__ptr__, instance.__ptr__)
+        error = ffi.wasmtime_linker_define_wasi(self._ptr, instance._ptr)
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
@@ -58,7 +58,7 @@ class Linker:
         trap = POINTER(ffi.wasm_trap_t)()
         instance = POINTER(ffi.wasm_instance_t)()
         error = ffi.wasmtime_linker_instantiate(
-            self.__ptr__, module.__ptr__, byref(instance), byref(trap))
+            self._ptr, module._ptr, byref(instance), byref(trap))
         if error:
             raise WasmtimeError.__from_ptr__(error)
         if trap:
@@ -66,5 +66,5 @@ class Linker:
         return Instance.__from_ptr__(instance, module)
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasmtime_linker_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasmtime_linker_delete(self._ptr)

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -18,7 +18,7 @@ class Memory:
         if not ptr:
             raise WasmtimeError("failed to create memory")
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_memory_t]", owner: Optional[Any]) -> "Memory":
@@ -26,7 +26,7 @@ class Memory:
         if not isinstance(ptr, POINTER(ffi.wasm_memory_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -83,5 +83,5 @@ class Memory:
         return ffi.wasm_memory_as_extern(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_memory_delete(self._ptr)

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -14,10 +14,10 @@ class Memory:
             raise TypeError("expected a Store")
         if not isinstance(ty, MemoryType):
             raise TypeError("expected a MemoryType")
-        ptr = ffi.wasm_memory_new(store.__ptr__, ty.__ptr__)
+        ptr = ffi.wasm_memory_new(store._ptr, ty._ptr)
         if not ptr:
             raise WasmtimeError("failed to create memory")
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -25,7 +25,7 @@ class Memory:
         ty: "Memory" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_memory_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -35,7 +35,7 @@ class Memory:
         Gets the type of this memory as a `MemoryType`
         """
 
-        ptr = ffi.wasm_memory_type(self.__ptr__)
+        ptr = ffi.wasm_memory_type(self._ptr)
         return MemoryType.__from_ptr__(ptr, None)
 
     def grow(self, delta: int) -> bool:
@@ -47,7 +47,7 @@ class Memory:
             raise TypeError("expected an integer")
         if delta < 0:
             raise WasmtimeError("cannot grow by negative amount")
-        ok = ffi.wasm_memory_grow(self.__ptr__, delta)
+        ok = ffi.wasm_memory_grow(self._ptr, delta)
         if ok:
             return True
         else:
@@ -59,7 +59,7 @@ class Memory:
         Returns the size, in WebAssembly pages, of this memory.
         """
 
-        return ffi.wasm_memory_size(self.__ptr__)
+        return ffi.wasm_memory_size(self._ptr)
 
     @property
     def data_ptr(self) -> "pointer[c_ubyte]":
@@ -69,7 +69,7 @@ class Memory:
         Remember that all accesses to wasm memory should be bounds-checked
         against the `data_len` method.
         """
-        return ffi.wasm_memory_data(self.__ptr__)
+        return ffi.wasm_memory_data(self._ptr)
 
     @property
     def data_len(self) -> int:
@@ -77,11 +77,11 @@ class Memory:
         Returns the raw byte length of this memory.
         """
 
-        return ffi.wasm_memory_data_size(self.__ptr__)
+        return ffi.wasm_memory_data_size(self._ptr)
 
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
-        return ffi.wasm_memory_as_extern(self.__ptr__)
+        return ffi.wasm_memory_as_extern(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_memory_delete(self.__ptr__)
+            ffi.wasm_memory_delete(self._ptr)

--- a/wasmtime/_module.py
+++ b/wasmtime/_module.py
@@ -37,10 +37,10 @@ class Module:
         c_ty = c_uint8 * len(wasm)
         binary = ffi.wasm_byte_vec_t(len(wasm), c_ty.from_buffer_copy(wasm))
         ptr = POINTER(ffi.wasm_module_t)()
-        error = ffi.wasmtime_module_new(store.__ptr__, byref(binary), byref(ptr))
+        error = ffi.wasmtime_module_new(store._ptr, byref(binary), byref(ptr))
         if error:
             raise WasmtimeError.__from_ptr__(error)
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.store = store
 
     @classmethod
@@ -61,7 +61,7 @@ class Module:
         # figure this out.
         c_ty = c_uint8 * len(wasm)
         binary = ffi.wasm_byte_vec_t(len(wasm), c_ty.from_buffer_copy(wasm))
-        error = ffi.wasmtime_module_validate(store.__ptr__, byref(binary))
+        error = ffi.wasmtime_module_validate(store._ptr, byref(binary))
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
@@ -72,7 +72,7 @@ class Module:
         """
 
         imports = ImportTypeList()
-        ffi.wasm_module_imports(self.__ptr__, byref(imports.vec))
+        ffi.wasm_module_imports(self._ptr, byref(imports.vec))
         ret = []
         for i in range(0, imports.vec.size):
             ret.append(ImportType.__from_ptr__(imports.vec.data[i], imports))
@@ -85,15 +85,15 @@ class Module:
         """
 
         exports = ExportTypeList()
-        ffi.wasm_module_exports(self.__ptr__, byref(exports.vec))
+        ffi.wasm_module_exports(self._ptr, byref(exports.vec))
         ret = []
         for i in range(0, exports.vec.size):
             ret.append(ExportType.__from_ptr__(exports.vec.data[i], exports))
         return ret
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasm_module_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasm_module_delete(self._ptr)
 
 
 class ImportTypeList:

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -4,14 +4,14 @@ from wasmtime import Engine, WasmtimeError
 
 
 class Store:
-    __ptr__: "pointer[ffi.wasm_store_t]"
+    _ptr: "pointer[ffi.wasm_store_t]"
 
     def __init__(self, engine: Engine = None):
         if engine is None:
             engine = Engine()
         elif not isinstance(engine, Engine):
             raise TypeError("expected an Engine")
-        self.__ptr__ = ffi.wasm_store_new(engine.__ptr__)
+        self._ptr = ffi.wasm_store_new(engine._ptr)
         self.engine = engine
 
     def interrupt_handle(self) -> "InterruptHandle":
@@ -29,8 +29,8 @@ class Store:
         return InterruptHandle(self)
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasm_store_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasm_store_delete(self._ptr)
 
 
 class InterruptHandle:
@@ -45,18 +45,18 @@ class InterruptHandle:
     def __init__(self, store: Store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        ptr = ffi.wasmtime_interrupt_handle_new(store.__ptr__)
+        ptr = ffi.wasmtime_interrupt_handle_new(store._ptr)
         if not ptr:
             raise WasmtimeError("interrupts not enabled on Store")
-        self.__ptr__ = ptr
+        self._ptr = ptr
 
     def interrupt(self) -> None:
         """
         Schedules an interrupt to be sent to interrupt this handle's store's
         next (or current) execution of wasm code.
         """
-        ffi.wasmtime_interrupt_handle_interrupt(self.__ptr__)
+        ffi.wasmtime_interrupt_handle_interrupt(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasmtime_interrupt_handle_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasmtime_interrupt_handle_delete(self._ptr)

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -8,13 +8,13 @@ def get_func_ptr(init: Optional[Func]) -> Optional["pointer[ffi.wasm_func_t]"]:
     if init is None:
         return None
     elif isinstance(init, Func):
-        return init.__ptr__
+        return init._ptr
     else:
         raise TypeError("expected a `Func` or `None`")
 
 
 class Table:
-    __ptr__: "pointer[ffi.wasm_table_t]"
+    _ptr: "pointer[ffi.wasm_table_t]"
 
     def __init__(self, store: Store, ty: TableType, init: Optional[Func]):
         """
@@ -31,10 +31,10 @@ class Table:
 
         init_ptr = get_func_ptr(init)
         ptr = POINTER(ffi.wasm_table_t)()
-        error = ffi.wasmtime_funcref_table_new(store.__ptr__, ty.__ptr__, init_ptr, byref(ptr))
+        error = ffi.wasmtime_funcref_table_new(store._ptr, ty._ptr, init_ptr, byref(ptr))
         if error:
             raise WasmtimeError.__from_ptr__(error)
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -42,7 +42,7 @@ class Table:
         ty: "Table" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_table_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -52,7 +52,7 @@ class Table:
         Gets the type of this table as a `TableType`
         """
 
-        ptr = ffi.wasm_table_type(self.__ptr__)
+        ptr = ffi.wasm_table_type(self._ptr)
         return TableType.__from_ptr__(ptr, None)
 
     @property
@@ -61,7 +61,7 @@ class Table:
         Gets the size, in elements, of this table
         """
 
-        return ffi.wasm_table_size(self.__ptr__)
+        return ffi.wasm_table_size(self._ptr)
 
     def grow(self, amt: int, init: Optional[Func]) -> int:
         """
@@ -74,7 +74,7 @@ class Table:
         init_ptr = get_func_ptr(init)
 
         prev = c_uint32(0)
-        error = ffi.wasmtime_funcref_table_grow(self.__ptr__, c_uint32(amt), init_ptr, byref(prev))
+        error = ffi.wasmtime_funcref_table_grow(self._ptr, c_uint32(amt), init_ptr, byref(prev))
         if error:
             raise WasmtimeError("failed to grow table")
         return prev.value
@@ -90,7 +90,7 @@ class Table:
         """
 
         ptr = POINTER(ffi.wasm_func_t)()
-        ok = ffi.wasmtime_funcref_table_get(self.__ptr__, idx, byref(ptr))
+        ok = ffi.wasmtime_funcref_table_get(self._ptr, idx, byref(ptr))
         if ok:
             if ptr:
                 return Func.__from_ptr__(ptr, None)
@@ -109,13 +109,13 @@ class Table:
         """
 
         val_ptr = get_func_ptr(val)
-        error = ffi.wasmtime_funcref_table_set(self.__ptr__, idx, val_ptr)
+        error = ffi.wasmtime_funcref_table_set(self._ptr, idx, val_ptr)
         if error:
             raise WasmtimeError.__from_ptr__(error)
 
     def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
-        return ffi.wasm_table_as_extern(self.__ptr__)
+        return ffi.wasm_table_as_extern(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_table_delete(self.__ptr__)
+            ffi.wasm_table_delete(self._ptr)

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -35,7 +35,7 @@ class Table:
         if error:
             raise WasmtimeError.__from_ptr__(error)
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_table_t]", owner: Optional[Any]) -> "Table":
@@ -43,7 +43,7 @@ class Table:
         if not isinstance(ptr, POINTER(ffi.wasm_table_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -117,5 +117,5 @@ class Table:
         return ffi.wasm_table_as_extern(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_table_delete(self._ptr)

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -15,10 +15,10 @@ class Trap(Exception):
         if not isinstance(message, str):
             raise TypeError("expected a string")
         message_raw = ffi.str_to_name(message, trailing_nul=True)
-        ptr = ffi.wasm_trap_new(store.__ptr__, byref(message_raw))
+        ptr = ffi.wasm_trap_new(store._ptr, byref(message_raw))
         if not ptr:
             raise WasmtimeError("failed to create trap")
-        self.__ptr__ = ptr
+        self._ptr = ptr
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_trap_t]") -> "Trap":
@@ -27,12 +27,12 @@ class Trap(Exception):
         exit_code = c_int(0)
         if ffi.wasmtime_trap_exit_status(ptr, byref(exit_code)):
             exit_trap: ExitTrap = ExitTrap.__new__(ExitTrap)
-            exit_trap.__ptr__ = ptr
+            exit_trap._ptr = ptr
             exit_trap.code = exit_code.value
             return exit_trap
         else:
             trap: Trap = cls.__new__(cls)
-            trap.__ptr__ = ptr
+            trap._ptr = ptr
             return trap
 
     @property
@@ -42,7 +42,7 @@ class Trap(Exception):
         """
 
         message = ffi.wasm_byte_vec_t()
-        ffi.wasm_trap_message(self.__ptr__, byref(message))
+        ffi.wasm_trap_message(self._ptr, byref(message))
         # subtract one to chop off the trailing nul byte
         message.size -= 1
         ret = ffi.to_str(message)
@@ -53,7 +53,7 @@ class Trap(Exception):
     @property
     def frames(self) -> List["Frame"]:
         frames = FrameList()
-        ffi.wasm_trap_trace(self.__ptr__, byref(frames.vec))
+        ffi.wasm_trap_trace(self._ptr, byref(frames.vec))
         ret = []
         for i in range(0, frames.vec.size):
             ret.append(Frame.__from_ptr__(frames.vec.data[i], frames))
@@ -63,8 +63,8 @@ class Trap(Exception):
         return self.message
 
     def __del__(self) -> None:
-        if hasattr(self, '__ptr__'):
-            ffi.wasm_trap_delete(self.__ptr__)
+        if hasattr(self, '_ptr'):
+            ffi.wasm_trap_delete(self._ptr)
 
 
 class ExitTrap(Trap):
@@ -85,7 +85,7 @@ class ExitTrap(Trap):
 
 
 class Frame:
-    __ptr__: "pointer[ffi.wasm_frame_t]"
+    _ptr: "pointer[ffi.wasm_frame_t]"
     __owner__: Optional[Any]
 
     @classmethod
@@ -93,7 +93,7 @@ class Frame:
         ty: "Frame" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_frame_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -103,7 +103,7 @@ class Frame:
         Returns the function index this frame corresponds to in its wasm module
         """
 
-        return ffi.wasm_frame_func_index(self.__ptr__)
+        return ffi.wasm_frame_func_index(self._ptr)
 
     @property
     def func_name(self) -> Optional[str]:
@@ -113,7 +113,7 @@ class Frame:
         May return `None` if no name can be inferred
         """
 
-        ptr = ffi.wasmtime_frame_func_name(self.__ptr__)
+        ptr = ffi.wasmtime_frame_func_name(self._ptr)
         if ptr:
             return ffi.to_str(ptr.contents)
         else:
@@ -127,7 +127,7 @@ class Frame:
         May return `None` if no name can be inferred
         """
 
-        ptr = ffi.wasmtime_frame_module_name(self.__ptr__)
+        ptr = ffi.wasmtime_frame_module_name(self._ptr)
         if ptr:
             return ffi.to_str(ptr.contents)
         else:
@@ -140,7 +140,7 @@ class Frame:
         wasm source module.
         """
 
-        return ffi.wasm_frame_module_offset(self.__ptr__)
+        return ffi.wasm_frame_module_offset(self._ptr)
 
     @property
     def func_offset(self) -> int:
@@ -149,11 +149,11 @@ class Frame:
         wasm function.
         """
 
-        return ffi.wasm_frame_func_offset(self.__ptr__)
+        return ffi.wasm_frame_func_offset(self._ptr)
 
     def __del__(self) -> None:
         if self.__owner__ is None:
-            ffi.wasm_frame_delete(self.__ptr__)
+            ffi.wasm_frame_delete(self._ptr)
 
 
 class FrameList:

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -86,7 +86,7 @@ class ExitTrap(Trap):
 
 class Frame:
     _ptr: "pointer[ffi.wasm_frame_t]"
-    __owner__: Optional[Any]
+    _owner: Optional[Any]
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_frame_t]", owner: Optional[Any]) -> "Frame":
@@ -94,7 +94,7 @@ class Frame:
         if not isinstance(ptr, POINTER(ffi.wasm_frame_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -152,7 +152,7 @@ class Frame:
         return ffi.wasm_frame_func_offset(self._ptr)
 
     def __del__(self) -> None:
-        if self.__owner__ is None:
+        if self._owner is None:
             ffi.wasm_frame_delete(self._ptr)
 
 

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -6,7 +6,7 @@ from typing import Union, List, Optional, Any
 
 class ValType:
     _ptr: "pointer[ffi.wasm_valtype_t]"
-    __owner__: Optional[Any]
+    _owner: Optional[Any]
 
     @classmethod
     def i32(cls) -> "ValType":
@@ -47,7 +47,7 @@ class ValType:
         if not isinstance(ptr, POINTER(ffi.wasm_valtype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     def __eq__(self, other: object) -> bool:
@@ -83,11 +83,11 @@ class ValType:
         return 'ValType(%d)' % kind.value
 
     def __del__(self) -> None:
-        if not hasattr(self, '__owner__') or not hasattr(self, '_ptr'):
+        if not hasattr(self, '_owner') or not hasattr(self, '_ptr'):
             return
         # If this is owned by another object we don't free it since that object
         # is responsible for freeing the backing memory.
-        if self.__owner__ is None:
+        if self._owner is None:
             ffi.wasm_valtype_delete(self._ptr)
 
     @classmethod
@@ -133,7 +133,7 @@ class FuncType:
         if not ptr:
             raise WasmtimeError("failed to allocate FuncType")
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_functype_t]", owner: Optional[Any]) -> "FuncType":
@@ -141,7 +141,7 @@ class FuncType:
         if not isinstance(ptr, POINTER(ffi.wasm_functype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -166,7 +166,7 @@ class FuncType:
         return ffi.wasm_functype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_functype_delete(self._ptr)
 
 
@@ -181,7 +181,7 @@ class GlobalType:
         if ptr == 0:
             raise WasmtimeError("failed to allocate GlobalType")
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_globaltype_t]", owner: Optional[Any]) -> "GlobalType":
@@ -189,7 +189,7 @@ class GlobalType:
         if not isinstance(ptr, POINTER(ffi.wasm_globaltype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -213,7 +213,7 @@ class GlobalType:
         return ffi.wasm_globaltype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_globaltype_delete(self._ptr)
 
 
@@ -251,7 +251,7 @@ class TableType:
         if not ptr:
             raise WasmtimeError("failed to allocate TableType")
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_tabletype_t]', owner: Optional[Any]) -> "TableType":
@@ -259,7 +259,7 @@ class TableType:
         if not isinstance(ptr, POINTER(ffi.wasm_tabletype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -282,7 +282,7 @@ class TableType:
         return ffi.wasm_tabletype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_tabletype_delete(self._ptr)
 
 
@@ -294,7 +294,7 @@ class MemoryType:
         if not ptr:
             raise WasmtimeError("failed to allocate MemoryType")
         self._ptr = ptr
-        self.__owner__ = None
+        self._owner = None
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_memorytype_t]", owner: Optional[Any]) -> "MemoryType":
@@ -302,7 +302,7 @@ class MemoryType:
         if not isinstance(ptr, POINTER(ffi.wasm_memorytype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -317,7 +317,7 @@ class MemoryType:
         return ffi.wasm_memorytype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
-        if hasattr(self, '__owner__') and self.__owner__ is None:
+        if hasattr(self, '_owner') and self._owner is None:
             ffi.wasm_memorytype_delete(self._ptr)
 
 
@@ -340,7 +340,7 @@ def wrap_externtype(ptr: "pointer[ffi.wasm_externtype_t]", owner: Optional[Any])
 
 class ImportType:
     _ptr: "pointer[ffi.wasm_importtype_t]"
-    __owner__: Optional[Any]
+    _owner: Optional[Any]
 
     @classmethod
     def __from_ptr__(cls, ptr: "pointer[ffi.wasm_importtype_t]", owner: Optional[Any]) -> "ImportType":
@@ -348,7 +348,7 @@ class ImportType:
         if not isinstance(ptr, POINTER(ffi.wasm_importtype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -372,16 +372,16 @@ class ImportType:
         Returns the type that this import refers to
         """
         ptr = ffi.wasm_importtype_type(self._ptr)
-        return wrap_externtype(ptr, self.__owner__ or self)
+        return wrap_externtype(ptr, self._owner or self)
 
     def __del__(self) -> None:
-        if self.__owner__ is None:
+        if self._owner is None:
             ffi.wasm_importtype_delete(self._ptr)
 
 
 class ExportType:
     _ptr: "pointer[ffi.wasm_exporttype_t]"
-    __owner__: Optional[Any]
+    _owner: Optional[Any]
 
     @classmethod
     def __from_ptr__(cls, ptr: 'pointer[ffi.wasm_exporttype_t]', owner: Optional[Any]) -> "ExportType":
@@ -389,7 +389,7 @@ class ExportType:
         if not isinstance(ptr, POINTER(ffi.wasm_exporttype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
-        ty.__owner__ = owner
+        ty._owner = owner
         return ty
 
     @property
@@ -405,10 +405,10 @@ class ExportType:
         Returns the type that this export refers to
         """
         ptr = ffi.wasm_exporttype_type(self._ptr)
-        return wrap_externtype(ptr, self.__owner__ or self)
+        return wrap_externtype(ptr, self._owner or self)
 
     def __del__(self) -> None:
-        if self.__owner__ is None:
+        if self._owner is None:
             ffi.wasm_exporttype_delete(self._ptr)
 
 

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -5,7 +5,7 @@ from typing import Union, List, Optional, Any
 
 
 class ValType:
-    __ptr__: "pointer[ffi.wasm_valtype_t]"
+    _ptr: "pointer[ffi.wasm_valtype_t]"
     __owner__: Optional[Any]
 
     @classmethod
@@ -46,17 +46,17 @@ class ValType:
         ty: "ValType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_valtype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ValType):
             return False
-        assert(self.__ptr__ is not None)
-        assert(other.__ptr__ is not None)
-        kind1 = ffi.wasm_valtype_kind(self.__ptr__)
-        kind2 = ffi.wasm_valtype_kind(other.__ptr__)
+        assert(self._ptr is not None)
+        assert(other._ptr is not None)
+        kind1 = ffi.wasm_valtype_kind(self._ptr)
+        kind2 = ffi.wasm_valtype_kind(other._ptr)
         return kind1 == kind2
 
     def __ne__(self, other: object) -> bool:
@@ -66,8 +66,8 @@ class ValType:
         return str(self)
 
     def __str__(self) -> str:
-        assert(self.__ptr__ is not None)
-        kind = ffi.wasm_valtype_kind(self.__ptr__)
+        assert(self._ptr is not None)
+        kind = ffi.wasm_valtype_kind(self._ptr)
         if kind == ffi.WASM_I32.value:
             return 'i32'
         if kind == ffi.WASM_I64.value:
@@ -83,12 +83,12 @@ class ValType:
         return 'ValType(%d)' % kind.value
 
     def __del__(self) -> None:
-        if not hasattr(self, '__owner__') or not hasattr(self, '__ptr__'):
+        if not hasattr(self, '__owner__') or not hasattr(self, '_ptr'):
             return
         # If this is owned by another object we don't free it since that object
         # is responsible for freeing the backing memory.
         if self.__owner__ is None:
-            ffi.wasm_valtype_delete(self.__ptr__)
+            ffi.wasm_valtype_delete(self._ptr)
 
     @classmethod
     def __from_list__(cls, items: "pointer[ffi.wasm_valtype_vec_t]", owner: Optional[Any]) -> List["ValType"]:
@@ -106,7 +106,7 @@ def take_owned_valtype(ty: ValType) -> "pointer[ffi.wasm_valtype_t]":
     #
     # Trying to expose this as an implementation detail by sneaking out
     # types and having some be "taken" feels pretty weird
-    return ffi.wasm_valtype_new(ffi.wasm_valtype_kind(ty.__ptr__))
+    return ffi.wasm_valtype_new(ffi.wasm_valtype_kind(ty._ptr))
 
 
 class FuncType:
@@ -132,7 +132,7 @@ class FuncType:
         ptr = ffi.wasm_functype_new(byref(params_ffi), byref(results_ffi))
         if not ptr:
             raise WasmtimeError("failed to allocate FuncType")
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -140,7 +140,7 @@ class FuncType:
         ty: "FuncType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_functype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -150,7 +150,7 @@ class FuncType:
         Returns the list of parameter types for this function type
         """
 
-        ptr = ffi.wasm_functype_params(self.__ptr__)
+        ptr = ffi.wasm_functype_params(self._ptr)
         return ValType.__from_list__(ptr, self)
 
     @property
@@ -159,15 +159,15 @@ class FuncType:
         Returns the list of result types for this function type
         """
 
-        ptr = ffi.wasm_functype_results(self.__ptr__)
+        ptr = ffi.wasm_functype_results(self._ptr)
         return ValType.__from_list__(ptr, self)
 
     def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
-        return ffi.wasm_functype_as_externtype_const(self.__ptr__)
+        return ffi.wasm_functype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_functype_delete(self.__ptr__)
+            ffi.wasm_functype_delete(self._ptr)
 
 
 class GlobalType:
@@ -180,7 +180,7 @@ class GlobalType:
         ptr = ffi.wasm_globaltype_new(type_ptr, mutability)
         if ptr == 0:
             raise WasmtimeError("failed to allocate GlobalType")
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -188,7 +188,7 @@ class GlobalType:
         ty: "GlobalType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_globaltype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -198,7 +198,7 @@ class GlobalType:
         Returns the type this global contains
         """
 
-        ptr = ffi.wasm_globaltype_content(self.__ptr__)
+        ptr = ffi.wasm_globaltype_content(self._ptr)
         return ValType.__from_ptr__(ptr, self)
 
     @property
@@ -206,15 +206,15 @@ class GlobalType:
         """
         Returns whether this global is mutable or not
         """
-        val = ffi.wasm_globaltype_mutability(self.__ptr__)
+        val = ffi.wasm_globaltype_mutability(self._ptr)
         return val == ffi.WASM_VAR.value
 
     def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
-        return ffi.wasm_globaltype_as_externtype_const(self.__ptr__)
+        return ffi.wasm_globaltype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_globaltype_delete(self.__ptr__)
+            ffi.wasm_globaltype_delete(self._ptr)
 
 
 class Limits:
@@ -250,7 +250,7 @@ class TableType:
         ptr = ffi.wasm_tabletype_new(type_ptr, byref(limits.__ffi__()))
         if not ptr:
             raise WasmtimeError("failed to allocate TableType")
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -258,7 +258,7 @@ class TableType:
         ty: "TableType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_tabletype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -267,7 +267,7 @@ class TableType:
         """
         Returns the type of this table's elements
         """
-        ptr = ffi.wasm_tabletype_element(self.__ptr__)
+        ptr = ffi.wasm_tabletype_element(self._ptr)
         return ValType.__from_ptr__(ptr, self)
 
     @property
@@ -275,15 +275,15 @@ class TableType:
         """
         Returns the limits on the size of thi stable
         """
-        val = ffi.wasm_tabletype_limits(self.__ptr__)
+        val = ffi.wasm_tabletype_limits(self._ptr)
         return Limits.__from_ffi__(val)
 
     def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
-        return ffi.wasm_tabletype_as_externtype_const(self.__ptr__)
+        return ffi.wasm_tabletype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_tabletype_delete(self.__ptr__)
+            ffi.wasm_tabletype_delete(self._ptr)
 
 
 class MemoryType:
@@ -293,7 +293,7 @@ class MemoryType:
         ptr = ffi.wasm_memorytype_new(byref(limits.__ffi__()))
         if not ptr:
             raise WasmtimeError("failed to allocate MemoryType")
-        self.__ptr__ = ptr
+        self._ptr = ptr
         self.__owner__ = None
 
     @classmethod
@@ -301,7 +301,7 @@ class MemoryType:
         ty: "MemoryType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_memorytype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -310,15 +310,15 @@ class MemoryType:
         """
         Returns the limits on the size of this table
         """
-        val = ffi.wasm_memorytype_limits(self.__ptr__)
+        val = ffi.wasm_memorytype_limits(self._ptr)
         return Limits.__from_ffi__(val)
 
     def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
-        return ffi.wasm_memorytype_as_externtype_const(self.__ptr__)
+        return ffi.wasm_memorytype_as_externtype_const(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '__owner__') and self.__owner__ is None:
-            ffi.wasm_memorytype_delete(self.__ptr__)
+            ffi.wasm_memorytype_delete(self._ptr)
 
 
 def wrap_externtype(ptr: "pointer[ffi.wasm_externtype_t]", owner: Optional[Any]) -> "AsExternType":
@@ -339,7 +339,7 @@ def wrap_externtype(ptr: "pointer[ffi.wasm_externtype_t]", owner: Optional[Any])
 
 
 class ImportType:
-    __ptr__: "pointer[ffi.wasm_importtype_t]"
+    _ptr: "pointer[ffi.wasm_importtype_t]"
     __owner__: Optional[Any]
 
     @classmethod
@@ -347,7 +347,7 @@ class ImportType:
         ty: "ImportType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_importtype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -357,30 +357,30 @@ class ImportType:
         Returns the module this import type refers to
         """
 
-        return ffi.to_str(ffi.wasm_importtype_module(self.__ptr__).contents)
+        return ffi.to_str(ffi.wasm_importtype_module(self._ptr).contents)
 
     @property
     def name(self) -> str:
         """
         Returns the name in the modulethis import type refers to
         """
-        return ffi.to_str(ffi.wasm_importtype_name(self.__ptr__).contents)
+        return ffi.to_str(ffi.wasm_importtype_name(self._ptr).contents)
 
     @property
     def type(self) -> "AsExternType":
         """
         Returns the type that this import refers to
         """
-        ptr = ffi.wasm_importtype_type(self.__ptr__)
+        ptr = ffi.wasm_importtype_type(self._ptr)
         return wrap_externtype(ptr, self.__owner__ or self)
 
     def __del__(self) -> None:
         if self.__owner__ is None:
-            ffi.wasm_importtype_delete(self.__ptr__)
+            ffi.wasm_importtype_delete(self._ptr)
 
 
 class ExportType:
-    __ptr__: "pointer[ffi.wasm_exporttype_t]"
+    _ptr: "pointer[ffi.wasm_exporttype_t]"
     __owner__: Optional[Any]
 
     @classmethod
@@ -388,7 +388,7 @@ class ExportType:
         ty: "ExportType" = cls.__new__(cls)
         if not isinstance(ptr, POINTER(ffi.wasm_exporttype_t)):
             raise TypeError("wrong pointer type")
-        ty.__ptr__ = ptr
+        ty._ptr = ptr
         ty.__owner__ = owner
         return ty
 
@@ -397,19 +397,19 @@ class ExportType:
         """
         Returns the name in the modulethis export type refers to
         """
-        return ffi.to_str(ffi.wasm_exporttype_name(self.__ptr__).contents)
+        return ffi.to_str(ffi.wasm_exporttype_name(self._ptr).contents)
 
     @property
     def type(self) -> "AsExternType":
         """
         Returns the type that this export refers to
         """
-        ptr = ffi.wasm_exporttype_type(self.__ptr__)
+        ptr = ffi.wasm_exporttype_type(self._ptr)
         return wrap_externtype(ptr, self.__owner__ or self)
 
     def __del__(self) -> None:
         if self.__owner__ is None:
-            ffi.wasm_exporttype_delete(self.__ptr__)
+            ffi.wasm_exporttype_delete(self._ptr)
 
 
 AsExternType = Union[FuncType, TableType, MemoryType, GlobalType]

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -51,7 +51,7 @@ class Val:
     def __init__(self, raw: wasm_val_t):
         if not isinstance(raw, wasm_val_t):
             raise TypeError("expected a raw value")
-        self.__raw__ = raw
+        self._raw = raw
 
     @classmethod
     def __convert__(cls, ty: ValType, val: "IntoVal") -> "Val":
@@ -78,22 +78,22 @@ class Val:
 
         Returns `None` if the value can't be represented in Python
         """
-        if self.__raw__.kind == WASM_I32.value:
-            return self.__raw__.of.i32
-        if self.__raw__.kind == WASM_I64.value:
-            return self.__raw__.of.i64
-        if self.__raw__.kind == WASM_F32.value:
-            return self.__raw__.of.f32
-        if self.__raw__.kind == WASM_F64.value:
-            return self.__raw__.of.f64
+        if self._raw.kind == WASM_I32.value:
+            return self._raw.of.i32
+        if self._raw.kind == WASM_I64.value:
+            return self._raw.of.i64
+        if self._raw.kind == WASM_F32.value:
+            return self._raw.of.f32
+        if self._raw.kind == WASM_F64.value:
+            return self._raw.of.f64
         return None
 
     def as_i32(self) -> typing.Optional[int]:
         """
         Get the 32-bit integer value of this value, or `None` if it's not an i32
         """
-        if self.__raw__.kind == WASM_I32.value:
-            return self.__raw__.of.i32
+        if self._raw.kind == WASM_I32.value:
+            return self._raw.of.i32
         else:
             return None
 
@@ -101,8 +101,8 @@ class Val:
         """
         Get the 64-bit integer value of this value, or `None` if it's not an i64
         """
-        if self.__raw__.kind == WASM_I64.value:
-            return self.__raw__.of.i64
+        if self._raw.kind == WASM_I64.value:
+            return self._raw.of.i64
         else:
             return None
 
@@ -110,8 +110,8 @@ class Val:
         """
         Get the 32-bit float value of this value, or `None` if it's not an f32
         """
-        if self.__raw__.kind == WASM_F32.value:
-            return self.__raw__.of.f32
+        if self._raw.kind == WASM_F32.value:
+            return self._raw.of.f32
         else:
             return None
 
@@ -119,8 +119,8 @@ class Val:
         """
         Get the 64-bit float value of this value, or `None` if it's not an f64
         """
-        if self.__raw__.kind == WASM_F64.value:
-            return self.__raw__.of.f64
+        if self._raw.kind == WASM_F64.value:
+            return self._raw.of.f64
         else:
             return None
 
@@ -129,7 +129,7 @@ class Val:
         """
         Returns the `ValType` corresponding to this `Val`
         """
-        ptr = dll.wasm_valtype_new(self.__raw__.kind)
+        ptr = dll.wasm_valtype_new(self._raw.kind)
         return ValType.__from_ptr__(ptr, None)
 
 


### PR DESCRIPTION
Stylistically we shouldn't use double under for non-builtin fields.