### PR TITLE
Fix wasmtime.loader to import module using wasi_snapshot_preview1

### DIFF
--- a/examples/loader.py
+++ b/examples/loader.py
@@ -5,6 +5,7 @@ import wasmtime.loader  # noqa: F401
 
 import loader_load_python  # type: ignore
 import loader_load_wasm  # type: ignore
+import loader_load_wasi  # type: ignore # noqa: F401
 
 # This imports our `loader_add.wat` file next to this module
 import loader_add  # type: ignore

--- a/examples/loader_load_wasi.wat
+++ b/examples/loader_load_wasi.wat
@@ -1,0 +1,3 @@
+(module
+    (import "wasi_snapshot_preview1" "random_get" (func (param i32 i32) (result i32)))
+)

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -16,10 +16,12 @@ import importlib
 from importlib.abc import Loader, MetaPathFinder
 from importlib.util import spec_from_file_location
 
+predefined_modules = []
 store = Store()
 linker = Linker(store)
 # TODO: how to configure wasi?
 wasi = WasiInstance(store, "wasi_snapshot_preview1", WasiConfig())
+predefined_modules.append("wasi_snapshot_preview1")
 linker.define_wasi(wasi)
 linker.allow_shadowing = True
 
@@ -62,6 +64,9 @@ class _WasmtimeLoader(Loader):
 
         for wasm_import in wasm_module.imports:
             module_name = wasm_import.module
+            # skip modules predefined in library
+            if module_name in predefined_modules:
+                break
             field_name = wasm_import.name
             imported_module = importlib.import_module(module_name)
             item = imported_module.__dict__[field_name]


### PR DESCRIPTION
Hi @alexcrichton.

I found that `wasmtime.loader` can't import the module importing `wasi_snapshot_preview1`

```python
# load_test.py
import wasmtime.loader
import hello_wasi # module using wasi_snapshot_preview1
```

```bash
$ python load_test.py
...
load_test.py:2: in <module>
    import hello_wasi
wasmtime/loader.py:71: in exec_module
    imported_module = importlib.import_module(module_name)
../.pyenv/versions/3.8.2/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
E   ModuleNotFoundError: No module named 'wasi_snapshot_preview1'
```

Currently, the loader can import any python modules, but loader must skip predefined modules in this library.

How about this fix?