### PR TITLE
Update to Wasmtime's new C API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         exclude:
         # Looks like pypy on Windows is 32-bit, so don't test it since we
         # only work with 64-bit builds

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '0 0 * * *' # run at 00:00 UTC
 
+# Cancel any in-flight jobs for the same PR/branch so there's only one active
+# at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/download-wasmtime.py
+++ b/download-wasmtime.py
@@ -42,14 +42,16 @@ def main(platform, arch):
     except Exception:
         pass
     os.makedirs(os.path.dirname(dst))
-    os.makedirs(os.path.join('wasmtime', 'include'))
+    os.makedirs(os.path.join('wasmtime', 'include', 'wasmtime'))
 
     with urllib.request.urlopen(url) as f:
         contents = f.read()
 
     def final_loc(name):
-        if name.endswith('.h'):
-            return os.path.join('wasmtime', 'include', os.path.basename(name))
+        parts = name.split('include/')
+        print(parts)
+        if len(parts) > 1 and name.endswith('.h'):
+            return os.path.join('wasmtime', 'include', parts[1])
         elif name.endswith('.dll') or name.endswith('.so') or name.endswith('.dylib'):
             return dst
         else:

--- a/examples/gcd.py
+++ b/examples/gcd.py
@@ -5,6 +5,6 @@ from wasmtime import Store, Module, Instance
 store = Store()
 module = Module.from_file(store.engine, './examples/gcd.wat')
 instance = Instance(store, module, [])
-gcd = instance.exports["gcd"]
+gcd = instance.exports(store)["gcd"]
 
-print("gcd(6, 27) = %d" % gcd(6, 27))
+print("gcd(6, 27) = %d" % gcd(store, 6, 27))

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -19,4 +19,4 @@ hello = Func(store, FuncType([], []), say_hello)
 
 # And with all that we can instantiate our module and call the export!
 instance = Instance(store, module, [hello])
-instance.exports["run"]()
+instance.exports(store)["run"](store)

--- a/examples/linking.py
+++ b/examples/linking.py
@@ -1,25 +1,30 @@
 # Example of instantiating two modules which link to each other.
 
-from wasmtime import Store, Module, Linker, WasiConfig, WasiInstance
+from wasmtime import Engine, Store, Module, Linker, WasiConfig
 
-store = Store()
-
-# First set up our linker which is going to be linking modules together. We
-# want our linker to have wasi available, so we set that up here as well.
-linker = Linker(store)
-wasi = WasiInstance(store, "wasi_snapshot_preview1", WasiConfig())
-linker.define_wasi(wasi)
+engine = Engine()
 
 # Load and compile our two modules
-linking1 = Module.from_file(store.engine, "examples/linking1.wat")
-linking2 = Module.from_file(store.engine, "examples/linking2.wat")
+linking1 = Module.from_file(engine, "examples/linking1.wat")
+linking2 = Module.from_file(engine, "examples/linking2.wat")
+
+# Set up our linker which is going to be linking modules together. We
+# want our linker to have wasi available, so we set that up here as well.
+linker = Linker(engine)
+linker.define_wasi()
+
+# Create a `Store` to hold instances, and configure wasi state
+store = Store(engine)
+wasi = WasiConfig()
+wasi.inherit_stdout()
+store.set_wasi(wasi)
 
 # Instantiate our first module which only uses WASI, then register that
 # instance with the linker since the next linking will use it.
-linking2 = linker.instantiate(linking2)
-linker.define_instance("linking2", linking2)
+linking2 = linker.instantiate(store, linking2)
+linker.define_instance(store, "linking2", linking2)
 
 # And with that we can perform the final link and the execute the module.
-linking1 = linker.instantiate(linking1)
-run = linking1.exports["run"]
-run()
+linking1 = linker.instantiate(store, linking1)
+run = linking1.exports(store)["run"]
+run(store)

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -4,36 +4,37 @@
 # read and write memory through the `Memory` object, and how wasm functions
 # can trap when dealing with out-of-bounds addresses.
 
-from wasmtime import Store, Module, Instance, Trap, MemoryType, Memory, Limits
+from wasmtime import Store, Module, Instance, Trap, MemoryType, Memory, Limits, WasmtimeError
 
 # Create our `Store` context and then compile a module and create an
 # instance from the compiled module all in one go.
-wasmtime_store = Store()
-module = Module.from_file(wasmtime_store.engine, "examples/memory.wat")
-instance = Instance(wasmtime_store, module, [])
+store = Store()
+module = Module.from_file(store.engine, "examples/memory.wat")
+instance = Instance(store, module, [])
 
 # Load up our exports from the instance
-memory = instance.exports["memory"]
-size = instance.exports["size"]
-load = instance.exports["load"]
-store = instance.exports["store"]
+exports = instance.exports(store)
+memory = exports["memory"]
+size_fn = exports["size"]
+load_fn = exports["load"]
+store_fn = exports["store"]
 
 print("Checking memory...")
-assert(memory.size == 2)
-assert(memory.data_len == 0x20000)
+assert(memory.size(store) == 2)
+assert(memory.data_len(store) == 0x20000)
 
 # Note that usage of `data_ptr` is unsafe! This is a raw C pointer which is not
 # bounds checked at all. We checked our `data_len` above but you'll want to be
 # very careful when accessing data through `data_ptr()`
-assert(memory.data_ptr[0] == 0)
-assert(memory.data_ptr[0x1000] == 1)
-assert(memory.data_ptr[0x1003] == 4)
+assert(memory.data_ptr(store)[0] == 0)
+assert(memory.data_ptr(store)[0x1000] == 1)
+assert(memory.data_ptr(store)[0x1003] == 4)
 
-assert(size() == 2)
-assert(load(0) == 0)
-assert(load(0x1000) == 1)
-assert(load(0x1003) == 4)
-assert(load(0x1ffff) == 0)
+assert(size_fn(store) == 2)
+assert(load_fn(store, 0) == 0)
+assert(load_fn(store, 0x1000) == 1)
+assert(load_fn(store, 0x1003) == 4)
+assert(load_fn(store, 0x1ffff) == 0)
 
 
 def assert_traps(func):
@@ -42,40 +43,42 @@ def assert_traps(func):
         assert(False)
     except Trap:
         pass
+    except WasmtimeError:
+        pass
 
 
 # out of bounds trap
-assert_traps(lambda: load(0x20000))
+assert_traps(lambda: load_fn(store, 0x20000))
 
 print("Mutating memory...")
-memory.data_ptr[0x1003] = 5
-store(0x1002, 6)
+memory.data_ptr(store)[0x1003] = 5
+store_fn(store, 0x1002, 6)
 # out of bounds trap
-assert_traps(lambda: store(0x20000, 0))
+assert_traps(lambda: store_fn(store, 0x20000, 0))
 
-assert(memory.data_ptr[0x1002] == 6)
-assert(memory.data_ptr[0x1003] == 5)
-assert(load(0x1002) == 6)
-assert(load(0x1003) == 5)
+assert(memory.data_ptr(store)[0x1002] == 6)
+assert(memory.data_ptr(store)[0x1003] == 5)
+assert(load_fn(store, 0x1002) == 6)
+assert(load_fn(store, 0x1003) == 5)
 
 # Grow memory.
 print("Growing memory...")
-assert(memory.grow(1))
-assert(memory.size == 3)
-assert(memory.data_len == 0x30000)
+assert(memory.grow(store, 1))
+assert(memory.size(store) == 3)
+assert(memory.data_len(store) == 0x30000)
 
-assert(load(0x20000) == 0)
-store(0x20000, 0)
-assert_traps(lambda: load(0x30000))
-assert_traps(lambda: store(0x30000, 0))
+assert(load_fn(store, 0x20000) == 0)
+store_fn(store, 0x20000, 0)
+assert_traps(lambda: load_fn(store, 0x30000))
+assert_traps(lambda: store_fn(store, 0x30000, 0))
 
 # Memory can fail to grow
-assert(not memory.grow(1))
-assert(memory.grow(0))
+assert_traps(lambda: memory.grow(store, 1))
+assert(memory.grow(store, 0))
 
 print("Creating stand-alone memory...")
 memorytype = MemoryType(Limits(5, 5))
-memory2 = Memory(wasmtime_store, memorytype)
-assert(memory2.size == 5)
-assert(not memory2.grow(1))
-assert(memory2.grow(0))
+memory2 = Memory(store, memorytype)
+assert(memory2.size(store) == 5)
+assert_traps(lambda: memory2.grow(store, 1))
+assert(memory2.grow(store, 0))

--- a/examples/multi.py
+++ b/examples/multi.py
@@ -27,18 +27,18 @@ print("Instantiating module...")
 instance = Instance(store, module, [callback_func])
 
 print("Extracting export...")
-g = instance.exports["g"]
+g = instance.exports(store)["g"]
 
 print("Calling export \"g\"...")
-results = g(1, 3)
+results = g(store, 1, 3)
 print("> {} {}".format(results[0], results[1]))
 
 assert(results[0] == 4)
 assert(results[1] == 2)
 
 print("Calling export \"round_trip_many\"...")
-round_trip_many = instance.exports["round_trip_many"]
-results = round_trip_many(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+round_trip_many = instance.exports(store)["round_trip_many"]
+results = round_trip_many(store, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 print("Printing result...")
 print(">")

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Compilers',

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -8,40 +8,38 @@ class TestFunc(unittest.TestCase):
         store = Store()
         ty = FuncType([], [])
         func = Func(store, ty, lambda: None)
-        func()
-        self.assertEqual(func.param_arity, 0)
-        self.assertEqual(func.result_arity, 0)
-        self.assertTrue(isinstance(func.type, FuncType))
+        func(store)
+        self.assertTrue(isinstance(func.type(store), FuncType))
 
     def test_add(self):
         store = Store()
         ty = FuncType([ValType.i32(), ValType.i32()], [ValType.i32()])
         func = Func(store, ty, lambda a, b: a + b)
-        self.assertEqual(func(1, 2), 3)
+        self.assertEqual(func(store, 1, 2), 3)
 
     def test_calls(self):
         store = Store()
         ty = FuncType([ValType.i32()], [])
         func = Func(store, ty, lambda a: self.assertEqual(a, 1))
-        func(1)
+        func(store, 1)
 
         ty = FuncType([ValType.i64()], [])
         func = Func(store, ty, lambda a: self.assertEqual(a, 2))
-        func(Val.i64(2))
+        func(store, Val.i64(2))
 
         ty = FuncType([ValType.f32()], [])
         func = Func(store, ty, lambda a: self.assertEqual(a, 3.0))
-        func(3.0)
+        func(store, 3.0)
 
         ty = FuncType([ValType.f64()], [])
         func = Func(store, ty, lambda a: self.assertEqual(a, 4.0))
-        func(4.0)
+        func(store, 4.0)
 
     def test_multi_return(self):
         store = Store()
         ty = FuncType([], [ValType.i32(), ValType.i32()])
         func = Func(store, ty, lambda: [1, 2])
-        self.assertEqual(func(), [1, 2])
+        self.assertEqual(func(store), [1, 2])
 
     def test_errors(self):
         store = Store()
@@ -52,31 +50,42 @@ class TestFunc(unittest.TestCase):
             Func(store, 1, lambda: None)  # type: ignore
         func = Func(store, ty, lambda: None)
         with self.assertRaises(WasmtimeError):
-            func(2)
+            func(store, 2)
 
         ty = FuncType([ValType.i32()], [])
         func = Func(store, ty, lambda: None)
         with self.assertRaises(TypeError):
-            func(3.0)
+            func(store, 3.0)
         with self.assertRaises(TypeError):
-            func(Val.i64(3))
+            func(store, Val.i64(3))
         ty = FuncType([ValType.i32()], [])
 
         func = Func(store, ty, lambda x: x)
-        with self.assertRaises(Trap):
-            func(1)
+        with self.assertRaises(WasmtimeError, msg="produced results"):
+            func(store, 1)
 
     def test_produce_wrong(self):
         store = Store()
         ty = FuncType([], [ValType.i32(), ValType.i32()])
         func = Func(store, ty, lambda: 1)
-        with self.assertRaises(Trap):
-            func()
+        with self.assertRaises(TypeError, msg="has no len"):
+            func(store)
         func = Func(store, ty, lambda: [1, 2, 3])
-        with self.assertRaises(Trap):
-            func()
+        with self.assertRaises(WasmtimeError, msg="wrong number of results"):
+            func(store)
 
-    def test_typest(self):
+    def test_host_exception(self):
+        store = Store()
+        ty = FuncType([], [])
+
+        def do_raise():
+            raise Exception("hello")
+
+        func = Func(store, ty, do_raise)
+        with self.assertRaises(Exception, msg="hello"):
+            func(store)
+
+    def test_type(self):
         store = Store()
         i32 = ValType.i32()
         i64 = ValType.i64()
@@ -90,7 +99,7 @@ class TestFunc(unittest.TestCase):
             return ret
 
         func = Func(store, ty, rev)
-        self.assertEqual(func(1, 2, 3.0, 4.0), [4.0, 3.0, 2, 1])
+        self.assertEqual(func(store, 1, 2, 3.0, 4.0), [4.0, 3.0, 2, 1])
 
     def test_access_caller(self):
         # Test that we get *something*
@@ -101,7 +110,7 @@ class TestFunc(unittest.TestCase):
             self.assertEqual(caller.get('x'), None)
             self.assertEqual(caller.get('y'), None)
 
-        Func(store, FuncType([], []), runtest, access_caller=True)()
+        Func(store, FuncType([], []), runtest, access_caller=True)(store)
 
         hit = {}
 
@@ -114,10 +123,10 @@ class TestFunc(unittest.TestCase):
             mem = caller.get('foo')
             self.assertTrue(isinstance(mem, Memory))
 
-            self.assertEqual(mem.data_ptr[0], ord('f'))
-            self.assertEqual(mem.data_ptr[1], ord('o'))
-            self.assertEqual(mem.data_ptr[2], ord('o'))
-            self.assertEqual(mem.data_ptr[3], 0)
+            self.assertEqual(mem.data_ptr(caller)[0], ord('f'))
+            self.assertEqual(mem.data_ptr(caller)[1], ord('o'))
+            self.assertEqual(mem.data_ptr(caller)[2], ord('o'))
+            self.assertEqual(mem.data_ptr(caller)[3], 0)
 
         module = Module(store.engine, """
             (module
@@ -141,6 +150,6 @@ class TestFunc(unittest.TestCase):
             raise WasmtimeError('foo')
 
         func = Func(store, FuncType([], []), runtest3, access_caller=True)
-        with self.assertRaises(Trap):
+        with self.assertRaises(WasmtimeError, msg='foo'):
             Instance(store, module, [func])
         self.assertTrue(hit2['caller'].get('foo') is None)

--- a/tests/test_global.py
+++ b/tests/test_global.py
@@ -9,13 +9,13 @@ class TestGlobal(unittest.TestCase):
         ty = GlobalType(ValType.i32(), True)
         g = Global(store, ty, Val.i32(1))
         Global(store, ty, Val.i32(1))
-        self.assertEqual(g.type.content, ValType.i32())
-        self.assertTrue(g.type.mutable)
+        self.assertEqual(g.type(store).content, ValType.i32())
+        self.assertTrue(g.type(store).mutable)
 
-        self.assertEqual(g.value, 1)
-        g.value = Val.i32(2)
-        self.assertEqual(g.value, 2)
-        self.assertTrue(isinstance(g.type, GlobalType))
+        self.assertEqual(g.value(store), 1)
+        g.set_value(store, Val.i32(2))
+        self.assertEqual(g.value(store), 2)
+        self.assertTrue(isinstance(g.type(store), GlobalType))
 
     def test_errors(self):
         store = Store()
@@ -24,14 +24,14 @@ class TestGlobal(unittest.TestCase):
             Global(store, ty, store)
         with self.assertRaises(TypeError):
             Global(store, 1, Val.i32(1))  # type: ignore
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             Global(1, ty, Val.i32(1))  # type: ignore
 
         g = Global(store, ty, Val.i32(1))
         with self.assertRaises(TypeError):
-            g.value = g
+            g.set_value(store, g)
 
         ty = GlobalType(ValType.i32(), False)
         g = Global(store, ty, Val.i32(1))
         with self.assertRaises(WasmtimeError):
-            g.value = 1
+            g.set_value(store, 1)

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -6,7 +6,7 @@ from wasmtime import *
 class TestLinker(unittest.TestCase):
     def test_define(self):
         store = Store()
-        linker = Linker(store)
+        linker = Linker(store.engine)
         linker.allow_shadowing = False
 
         func = Func(store, FuncType([], []), lambda: None)
@@ -21,7 +21,7 @@ class TestLinker(unittest.TestCase):
         module = Module(store.engine, """
             (module (table (export "") 1 funcref))
         """)
-        table = Instance(store, module, []).exports[0]
+        table = Instance(store, module, []).exports(store)[0]
         linker.define("", "g", table)
 
         with self.assertRaises(WasmtimeError):
@@ -31,41 +31,39 @@ class TestLinker(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             linker.define("", "", 2)  # type: ignore
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             linker.define(2, "", func)  # type: ignore
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             linker.define("", 2, func)  # type: ignore
 
     def test_define_instance(self):
         store = Store()
-        linker = Linker(store)
+        linker = Linker(store.engine)
         with self.assertRaises(TypeError):
             linker.define_instance("x", 2)  # type: ignore
 
         module = Module(store.engine, "(module)")
-        linker.define_instance("a", Instance(store, module, []))
+        linker.define_instance(store, "a", Instance(store, module, []))
 
         module = Module(store.engine, "(module (func (export \"foo\")))")
         instance = Instance(store, module, [])
-        linker.define_instance("b", instance)
+        linker.define_instance(store, "b", instance)
         with self.assertRaises(WasmtimeError):
-            linker.define_instance("b", instance)
+            linker.define_instance(store, "b", instance)
         linker.allow_shadowing = True
-        linker.define_instance("b", instance)
+        linker.define_instance(store, "b", instance)
 
     def test_define_wasi(self):
-        store = Store()
-        linker = Linker(store)
-        instance = WasiInstance(store, "wasi_unstable", WasiConfig())
-        linker.define_wasi(instance)
+        linker = Linker(Engine())
+        linker.define_wasi()
 
     def test_instantiate(self):
         store = Store()
-        linker = Linker(store)
+        linker = Linker(store.engine)
 
         module = Module(store.engine, "(module (func (export \"foo\")))")
         instance = Instance(store, module, [])
-        linker.define_instance("x", instance)
+        linker.define_instance(store, "x", instance)
 
         func = Func(store, FuncType([], []), lambda: None)
         linker.define("y", "z", func)
@@ -76,7 +74,7 @@ class TestLinker(unittest.TestCase):
                 (import "y" "z" (func))
             )
         """)
-        linker.instantiate(module)
+        linker.instantiate(store, module)
 
         module = Module(store.engine, """
             (module
@@ -85,7 +83,7 @@ class TestLinker(unittest.TestCase):
             )
         """)
         with self.assertRaises(WasmtimeError):
-            linker.instantiate(module)
+            linker.instantiate(store, module)
 
         module = Module(store.engine, """
             (module
@@ -94,50 +92,50 @@ class TestLinker(unittest.TestCase):
             )
         """)
         with self.assertRaises(Trap):
-            linker.instantiate(module)
+            linker.instantiate(store, module)
 
         module = Module(store.engine, "(module)")
-        linker.instantiate(module)
+        linker.instantiate(store, module)
 
     def test_errors(self):
-        linker = Linker(Store())
+        linker = Linker(Engine())
         with self.assertRaises(TypeError):
             linker.allow_shadowing = 2
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             Linker(2)  # type: ignore
-        with self.assertRaises(TypeError):
-            linker.instantiate(3)  # type: ignore
+        with self.assertRaises(AttributeError):
+            linker.instantiate(Store(), 3)  # type: ignore
 
     def test_module(self):
         store = Store()
-        linker = Linker(store)
+        linker = Linker(store.engine)
         module = Module(store.engine, """
             (module
                 (func (export "f"))
             )
         """)
-        linker.define_module("foo", module)
+        linker.define_module(store, "foo", module)
         module = Module(store.engine, """
             (module
                 (import "foo" "f" (func))
             )
         """)
-        linker.instantiate(module)
+        linker.instantiate(store, module)
 
     def test_get_default(self):
         store = Store()
-        linker = Linker(store)
-        linker.get_default("foo")()
+        linker = Linker(store.engine)
+        linker.get_default(store, "foo")(store)
 
     def test_get_one_by_name(self):
         store = Store()
-        linker = Linker(store)
+        linker = Linker(store.engine)
         with self.assertRaises(WasmtimeError):
-            linker.get_one_by_name("foo", "bar")
+            linker.get(store, "foo", "bar")
         module = Module(store.engine, """
             (module
                 (func (export "f"))
             )
         """)
-        linker.define_module("foo", module)
-        assert(isinstance(linker.get_one_by_name("foo", "f"), Func))
+        linker.define_module(store, "foo", module)
+        assert(isinstance(linker.get(store, "foo", "f"), Func))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -8,32 +8,33 @@ class TestMemory(unittest.TestCase):
         store = Store()
         ty = MemoryType(Limits(1, None))
         memory = Memory(store, ty)
-        self.assertEqual(memory.type.limits, Limits(1, None))
-        self.assertEqual(memory.size, 1)
-        self.assertTrue(memory.grow(1))
-        self.assertEqual(memory.size, 2)
-        self.assertTrue(memory.grow(0))
-        self.assertEqual(memory.size, 2)
+        self.assertEqual(memory.type(store).limits, Limits(1, None))
+        self.assertEqual(memory.size(store), 1)
+        self.assertTrue(memory.grow(store, 1))
+        self.assertEqual(memory.size(store), 2)
+        self.assertTrue(memory.grow(store, 0))
+        self.assertEqual(memory.size(store), 2)
         with self.assertRaises(TypeError):
-            memory.grow('')  # type: ignore
+            memory.grow(store, '')  # type: ignore
         with self.assertRaises(WasmtimeError):
-            memory.grow(-1)
-        self.assertEqual(memory.data_ptr[0], 0)
-        self.assertEqual(memory.data_len, 65536 * 2)
-        self.assertTrue(isinstance(memory.type, MemoryType))
+            memory.grow(store, -1)
+        self.assertEqual(memory.data_ptr(store)[0], 0)
+        self.assertEqual(memory.data_len(store), 65536 * 2)
+        self.assertTrue(isinstance(memory.type(store), MemoryType))
 
     def test_grow(self):
         store = Store()
         ty = MemoryType(Limits(1, 2))
         memory = Memory(store, ty)
-        self.assertTrue(memory.grow(1))
-        self.assertTrue(memory.grow(0))
-        self.assertFalse(memory.grow(1))
+        assert(memory.grow(store, 1) == 1)
+        assert(memory.grow(store, 0) == 2)
+        with self.assertRaises(WasmtimeError):
+            memory.grow(store, 1)
 
     def test_errors(self):
         store = Store()
         ty = MemoryType(Limits(1, 2))
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             Memory(1, ty)  # type: ignore
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             Memory(store, 1)  # type: ignore

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -10,7 +10,7 @@ class TestModule(unittest.TestCase):
         Module(Engine(), bytearray(b'\0asm\x01\0\0\0'))
 
     def test_invalid(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             Module.validate(1, b'')  # type: ignore
         with self.assertRaises(TypeError):
             Module.validate(Store(), 2)  # type: ignore
@@ -24,10 +24,10 @@ class TestModule(unittest.TestCase):
             Module(Engine(), b'\x00')
 
     def test_validate(self):
-        store = Store()
-        Module.validate(store, b'\0asm\x01\0\0\0')
+        engine = Engine()
+        Module.validate(engine, b'\0asm\x01\0\0\0')
         with self.assertRaises(WasmtimeError):
-            self.assertFalse(Module.validate(store, b''))
+            Module.validate(engine, b'')
 
     def test_imports(self):
         store = Store()
@@ -148,9 +148,9 @@ class TestModule(unittest.TestCase):
         assert(isinstance(exports[3].type, TableType))
 
     def test_serialize(self):
-        store = Store()
-        module = Module(store.engine, '(module)')
+        engine = Engine()
+        module = Module(engine, '(module)')
         encoded = module.serialize()
-        module = Module.deserialize(store.engine, encoded)
+        module = Module.deserialize(engine, encoded)
         assert(len(module.imports) == 0)
         assert(len(module.exports) == 0)

--- a/tests/test_module_linking.py
+++ b/tests/test_module_linking.py
@@ -33,7 +33,7 @@ class TestModuleLinking(unittest.TestCase):
             (module (module (export "")))
         """)
         i = Instance(store, module, [])
-        assert(isinstance(i.exports[0], Module))
+        assert(isinstance(i.exports(store)[0], Module))
 
     def test_instance_import(self):
         store = self.store()
@@ -52,4 +52,4 @@ class TestModuleLinking(unittest.TestCase):
             )
         """)
         i = Instance(store, instance, [])
-        assert(isinstance(i.exports[0], Instance))
+        assert(isinstance(i.exports(store)[0], Instance))

--- a/tests/test_wasi.py
+++ b/tests/test_wasi.py
@@ -28,51 +28,17 @@ class TestWasi(unittest.TestCase):
             config.stderr_file = 'some-directory/without-a-rainbow'
         config.preopen_dir('wasmtime', 'other')
 
-    def test_instance(self):
-        config = WasiConfig()
-        instance = WasiInstance(Store(), "wasi_unstable", config)
-
-        # specify nonexistent version
-        with self.assertRaises(Trap):
-            WasiInstance(Store(), "nonexistent_wasi", WasiConfig())
-        # re-use config
-        with self.assertRaises(AttributeError):
-            WasiInstance(Store(), "nonexistent_wasi", config)
-
-        # Type errors
-        with self.assertRaises(TypeError):
-            WasiInstance(1, "nonexistent_wasi", config)  # type: ignore
-        with self.assertRaises(TypeError):
-            WasiInstance(Store(), 1, config)  # type: ignore
-        with self.assertRaises(TypeError):
-            WasiInstance(Store(), "nonexistent_wasi", 1)  # type: ignore
-        with self.assertRaises(TypeError):
-            instance.bind(3)  # type: ignore
-
-        module = Module(instance.store.engine, """
-            (module
-                (import "wasi_unstable" "random_get"
-                    (func (param i32 i32) (result i32)))
-            )
-        """)
-        imp = module.imports[0]
-        binding = instance.bind(imp)
-        assert(isinstance(binding, Func))
-        with self.assertRaises(Trap):
-            binding(1, 2)
-
     def test_preview1(self):
-        config = WasiConfig()
-        instance = WasiInstance(Store(), "wasi_snapshot_preview1", config)
+        linker = Linker(Engine())
+        linker.define_wasi()
 
-        module = Module(instance.store.engine, """
+        module = Module(linker.engine, """
             (module
                 (import "wasi_snapshot_preview1" "random_get"
                     (func (param i32 i32) (result i32)))
             )
         """)
-        imp = module.imports[0]
-        binding = instance.bind(imp)
-        assert(isinstance(binding, Func))
-        with self.assertRaises(Trap):
-            binding(1, 2)
+
+        store = Store(linker.engine)
+        store.set_wasi(WasiConfig())
+        linker.instantiate(store, module)

--- a/wasmtime/__init__.py
+++ b/wasmtime/__init__.py
@@ -28,7 +28,7 @@ from ._globals import Global
 from ._table import Table
 from ._memory import Memory
 from ._instance import Instance
-from ._wasi import WasiInstance, WasiConfig
+from ._wasi import WasiConfig
 from ._linker import Linker
 
 __all__ = [
@@ -57,7 +57,6 @@ __all__ = [
     'Module',
     'Instance',
     'WasiConfig',
-    'WasiInstance',
     'Linker',
     'WasmtimeError',
 ]

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -14,6 +14,8 @@ class wasm_byte_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(wasm_byte_t)),
     ]
+    size: int
+    data: pointer
 
 _wasm_byte_vec_new_empty = dll.wasm_byte_vec_new_empty
 _wasm_byte_vec_new_empty.restype = None
@@ -105,6 +107,8 @@ class wasm_limits_t(Structure):
         ("min", c_uint32),
         ("max", c_uint32),
     ]
+    min: int
+    max: int
 
 class wasm_valtype_t(Structure):
     pass
@@ -120,6 +124,8 @@ class wasm_valtype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_valtype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_valtype_vec_new_empty = dll.wasm_valtype_vec_new_empty
 _wasm_valtype_vec_new_empty.restype = None
@@ -185,6 +191,8 @@ class wasm_functype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_functype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_functype_vec_new_empty = dll.wasm_functype_vec_new_empty
 _wasm_functype_vec_new_empty.restype = None
@@ -254,6 +262,8 @@ class wasm_globaltype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_globaltype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_globaltype_vec_new_empty = dll.wasm_globaltype_vec_new_empty
 _wasm_globaltype_vec_new_empty.restype = None
@@ -323,6 +333,8 @@ class wasm_tabletype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_tabletype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_tabletype_vec_new_empty = dll.wasm_tabletype_vec_new_empty
 _wasm_tabletype_vec_new_empty.restype = None
@@ -392,6 +404,8 @@ class wasm_memorytype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_memorytype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_memorytype_vec_new_empty = dll.wasm_memorytype_vec_new_empty
 _wasm_memorytype_vec_new_empty.restype = None
@@ -455,6 +469,8 @@ class wasm_externtype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_externtype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_externtype_vec_new_empty = dll.wasm_externtype_vec_new_empty
 _wasm_externtype_vec_new_empty.restype = None
@@ -610,6 +626,8 @@ class wasm_importtype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_importtype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_importtype_vec_new_empty = dll.wasm_importtype_vec_new_empty
 _wasm_importtype_vec_new_empty.restype = None
@@ -685,6 +703,8 @@ class wasm_exporttype_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_exporttype_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_exporttype_vec_new_empty = dll.wasm_exporttype_vec_new_empty
 _wasm_exporttype_vec_new_empty.restype = None
@@ -757,6 +777,8 @@ class wasm_val_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(wasm_val_t)),
     ]
+    size: int
+    data: pointer
 
 _wasm_val_vec_new_empty = dll.wasm_val_vec_new_empty
 _wasm_val_vec_new_empty.restype = None
@@ -809,7 +831,7 @@ def wasm_ref_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_ref_get_host_info = dll.wasm_ref_get_host_info
 _wasm_ref_get_host_info.restype = c_void_p
 _wasm_ref_get_host_info.argtypes = [POINTER(wasm_ref_t)]
-def wasm_ref_get_host_info(arg0: Any) -> pointer:
+def wasm_ref_get_host_info(arg0: Any) -> int:
     return _wasm_ref_get_host_info(arg0)  # type: ignore
 
 _wasm_ref_set_host_info = dll.wasm_ref_set_host_info
@@ -838,6 +860,8 @@ class wasm_frame_vec_t(Structure):
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_frame_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_frame_vec_new_empty = dll.wasm_frame_vec_new_empty
 _wasm_frame_vec_new_empty.restype = None
@@ -868,6 +892,12 @@ _wasm_frame_vec_delete.restype = None
 _wasm_frame_vec_delete.argtypes = [POINTER(wasm_frame_vec_t)]
 def wasm_frame_vec_delete(arg0: Any) -> None:
     return _wasm_frame_vec_delete(arg0)  # type: ignore
+
+_wasm_frame_copy = dll.wasm_frame_copy
+_wasm_frame_copy.restype = POINTER(wasm_frame_t)
+_wasm_frame_copy.argtypes = [POINTER(wasm_frame_t)]
+def wasm_frame_copy(arg0: Any) -> pointer:
+    return _wasm_frame_copy(arg0)  # type: ignore
 
 _wasm_frame_func_index = dll.wasm_frame_func_index
 _wasm_frame_func_index.restype = c_uint32
@@ -913,7 +943,7 @@ def wasm_trap_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_trap_get_host_info = dll.wasm_trap_get_host_info
 _wasm_trap_get_host_info.restype = c_void_p
 _wasm_trap_get_host_info.argtypes = [POINTER(wasm_trap_t)]
-def wasm_trap_get_host_info(arg0: Any) -> pointer:
+def wasm_trap_get_host_info(arg0: Any) -> int:
     return _wasm_trap_get_host_info(arg0)  # type: ignore
 
 _wasm_trap_set_host_info = dll.wasm_trap_set_host_info
@@ -934,11 +964,23 @@ _wasm_trap_as_ref.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_as_ref(arg0: Any) -> pointer:
     return _wasm_trap_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_trap = dll.wasm_ref_as_trap
+_wasm_ref_as_trap.restype = POINTER(wasm_trap_t)
+_wasm_ref_as_trap.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_trap(arg0: Any) -> pointer:
+    return _wasm_ref_as_trap(arg0)  # type: ignore
+
 _wasm_trap_as_ref_const = dll.wasm_trap_as_ref_const
 _wasm_trap_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_trap_as_ref_const.argtypes = [POINTER(wasm_trap_t)]
 def wasm_trap_as_ref_const(arg0: Any) -> pointer:
     return _wasm_trap_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_trap_const = dll.wasm_ref_as_trap_const
+_wasm_ref_as_trap_const.restype = POINTER(wasm_trap_t)
+_wasm_ref_as_trap_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_trap_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_trap_const(arg0)  # type: ignore
 
 _wasm_trap_new = dll.wasm_trap_new
 _wasm_trap_new.restype = POINTER(wasm_trap_t)
@@ -967,6 +1009,72 @@ def wasm_trap_trace(arg0: Any, out: Any) -> None:
 class wasm_foreign_t(Structure):
     pass
 
+_wasm_foreign_delete = dll.wasm_foreign_delete
+_wasm_foreign_delete.restype = None
+_wasm_foreign_delete.argtypes = [POINTER(wasm_foreign_t)]
+def wasm_foreign_delete(arg0: Any) -> None:
+    return _wasm_foreign_delete(arg0)  # type: ignore
+
+_wasm_foreign_copy = dll.wasm_foreign_copy
+_wasm_foreign_copy.restype = POINTER(wasm_foreign_t)
+_wasm_foreign_copy.argtypes = [POINTER(wasm_foreign_t)]
+def wasm_foreign_copy(arg0: Any) -> pointer:
+    return _wasm_foreign_copy(arg0)  # type: ignore
+
+_wasm_foreign_same = dll.wasm_foreign_same
+_wasm_foreign_same.restype = c_bool
+_wasm_foreign_same.argtypes = [POINTER(wasm_foreign_t), POINTER(wasm_foreign_t)]
+def wasm_foreign_same(arg0: Any, arg1: Any) -> c_bool:
+    return _wasm_foreign_same(arg0, arg1)  # type: ignore
+
+_wasm_foreign_get_host_info = dll.wasm_foreign_get_host_info
+_wasm_foreign_get_host_info.restype = c_void_p
+_wasm_foreign_get_host_info.argtypes = [POINTER(wasm_foreign_t)]
+def wasm_foreign_get_host_info(arg0: Any) -> int:
+    return _wasm_foreign_get_host_info(arg0)  # type: ignore
+
+_wasm_foreign_set_host_info = dll.wasm_foreign_set_host_info
+_wasm_foreign_set_host_info.restype = None
+_wasm_foreign_set_host_info.argtypes = [POINTER(wasm_foreign_t), c_void_p]
+def wasm_foreign_set_host_info(arg0: Any, arg1: Any) -> None:
+    return _wasm_foreign_set_host_info(arg0, arg1)  # type: ignore
+
+_wasm_foreign_set_host_info_with_finalizer = dll.wasm_foreign_set_host_info_with_finalizer
+_wasm_foreign_set_host_info_with_finalizer.restype = None
+_wasm_foreign_set_host_info_with_finalizer.argtypes = [POINTER(wasm_foreign_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasm_foreign_set_host_info_with_finalizer(arg0: Any, arg1: Any, arg2: Any) -> None:
+    return _wasm_foreign_set_host_info_with_finalizer(arg0, arg1, arg2)  # type: ignore
+
+_wasm_foreign_as_ref = dll.wasm_foreign_as_ref
+_wasm_foreign_as_ref.restype = POINTER(wasm_ref_t)
+_wasm_foreign_as_ref.argtypes = [POINTER(wasm_foreign_t)]
+def wasm_foreign_as_ref(arg0: Any) -> pointer:
+    return _wasm_foreign_as_ref(arg0)  # type: ignore
+
+_wasm_ref_as_foreign = dll.wasm_ref_as_foreign
+_wasm_ref_as_foreign.restype = POINTER(wasm_foreign_t)
+_wasm_ref_as_foreign.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_foreign(arg0: Any) -> pointer:
+    return _wasm_ref_as_foreign(arg0)  # type: ignore
+
+_wasm_foreign_as_ref_const = dll.wasm_foreign_as_ref_const
+_wasm_foreign_as_ref_const.restype = POINTER(wasm_ref_t)
+_wasm_foreign_as_ref_const.argtypes = [POINTER(wasm_foreign_t)]
+def wasm_foreign_as_ref_const(arg0: Any) -> pointer:
+    return _wasm_foreign_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_foreign_const = dll.wasm_ref_as_foreign_const
+_wasm_ref_as_foreign_const.restype = POINTER(wasm_foreign_t)
+_wasm_ref_as_foreign_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_foreign_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_foreign_const(arg0)  # type: ignore
+
+_wasm_foreign_new = dll.wasm_foreign_new
+_wasm_foreign_new.restype = POINTER(wasm_foreign_t)
+_wasm_foreign_new.argtypes = [POINTER(wasm_store_t)]
+def wasm_foreign_new(arg0: Any) -> pointer:
+    return _wasm_foreign_new(arg0)  # type: ignore
+
 class wasm_module_t(Structure):
     pass
 
@@ -991,7 +1099,7 @@ def wasm_module_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_module_get_host_info = dll.wasm_module_get_host_info
 _wasm_module_get_host_info.restype = c_void_p
 _wasm_module_get_host_info.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_get_host_info(arg0: Any) -> pointer:
+def wasm_module_get_host_info(arg0: Any) -> int:
     return _wasm_module_get_host_info(arg0)  # type: ignore
 
 _wasm_module_set_host_info = dll.wasm_module_set_host_info
@@ -1012,11 +1120,23 @@ _wasm_module_as_ref.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_as_ref(arg0: Any) -> pointer:
     return _wasm_module_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_module = dll.wasm_ref_as_module
+_wasm_ref_as_module.restype = POINTER(wasm_module_t)
+_wasm_ref_as_module.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_module(arg0: Any) -> pointer:
+    return _wasm_ref_as_module(arg0)  # type: ignore
+
 _wasm_module_as_ref_const = dll.wasm_module_as_ref_const
 _wasm_module_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_module_as_ref_const.argtypes = [POINTER(wasm_module_t)]
 def wasm_module_as_ref_const(arg0: Any) -> pointer:
     return _wasm_module_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_module_const = dll.wasm_ref_as_module_const
+_wasm_ref_as_module_const.restype = POINTER(wasm_module_t)
+_wasm_ref_as_module_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_module_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_module_const(arg0)  # type: ignore
 
 class wasm_shared_module_t(Structure):
     pass
@@ -1063,6 +1183,18 @@ _wasm_module_exports.argtypes = [POINTER(wasm_module_t), POINTER(wasm_exporttype
 def wasm_module_exports(arg0: Any, out: Any) -> None:
     return _wasm_module_exports(arg0, out)  # type: ignore
 
+_wasm_module_serialize = dll.wasm_module_serialize
+_wasm_module_serialize.restype = None
+_wasm_module_serialize.argtypes = [POINTER(wasm_module_t), POINTER(wasm_byte_vec_t)]
+def wasm_module_serialize(arg0: Any, out: Any) -> None:
+    return _wasm_module_serialize(arg0, out)  # type: ignore
+
+_wasm_module_deserialize = dll.wasm_module_deserialize
+_wasm_module_deserialize.restype = POINTER(wasm_module_t)
+_wasm_module_deserialize.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
+def wasm_module_deserialize(arg0: Any, arg1: Any) -> pointer:
+    return _wasm_module_deserialize(arg0, arg1)  # type: ignore
+
 class wasm_func_t(Structure):
     pass
 
@@ -1087,7 +1219,7 @@ def wasm_func_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_func_get_host_info = dll.wasm_func_get_host_info
 _wasm_func_get_host_info.restype = c_void_p
 _wasm_func_get_host_info.argtypes = [POINTER(wasm_func_t)]
-def wasm_func_get_host_info(arg0: Any) -> pointer:
+def wasm_func_get_host_info(arg0: Any) -> int:
     return _wasm_func_get_host_info(arg0)  # type: ignore
 
 _wasm_func_set_host_info = dll.wasm_func_set_host_info
@@ -1108,11 +1240,23 @@ _wasm_func_as_ref.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_as_ref(arg0: Any) -> pointer:
     return _wasm_func_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_func = dll.wasm_ref_as_func
+_wasm_ref_as_func.restype = POINTER(wasm_func_t)
+_wasm_ref_as_func.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_func(arg0: Any) -> pointer:
+    return _wasm_ref_as_func(arg0)  # type: ignore
+
 _wasm_func_as_ref_const = dll.wasm_func_as_ref_const
 _wasm_func_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_func_as_ref_const.argtypes = [POINTER(wasm_func_t)]
 def wasm_func_as_ref_const(arg0: Any) -> pointer:
     return _wasm_func_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_func_const = dll.wasm_ref_as_func_const
+_wasm_ref_as_func_const.restype = POINTER(wasm_func_t)
+_wasm_ref_as_func_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_func_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_func_const(arg0)  # type: ignore
 
 wasm_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t))
 
@@ -1178,7 +1322,7 @@ def wasm_global_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_global_get_host_info = dll.wasm_global_get_host_info
 _wasm_global_get_host_info.restype = c_void_p
 _wasm_global_get_host_info.argtypes = [POINTER(wasm_global_t)]
-def wasm_global_get_host_info(arg0: Any) -> pointer:
+def wasm_global_get_host_info(arg0: Any) -> int:
     return _wasm_global_get_host_info(arg0)  # type: ignore
 
 _wasm_global_set_host_info = dll.wasm_global_set_host_info
@@ -1199,11 +1343,23 @@ _wasm_global_as_ref.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_as_ref(arg0: Any) -> pointer:
     return _wasm_global_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_global = dll.wasm_ref_as_global
+_wasm_ref_as_global.restype = POINTER(wasm_global_t)
+_wasm_ref_as_global.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_global(arg0: Any) -> pointer:
+    return _wasm_ref_as_global(arg0)  # type: ignore
+
 _wasm_global_as_ref_const = dll.wasm_global_as_ref_const
 _wasm_global_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_global_as_ref_const.argtypes = [POINTER(wasm_global_t)]
 def wasm_global_as_ref_const(arg0: Any) -> pointer:
     return _wasm_global_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_global_const = dll.wasm_ref_as_global_const
+_wasm_ref_as_global_const.restype = POINTER(wasm_global_t)
+_wasm_ref_as_global_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_global_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_global_const(arg0)  # type: ignore
 
 _wasm_global_new = dll.wasm_global_new
 _wasm_global_new.restype = POINTER(wasm_global_t)
@@ -1253,7 +1409,7 @@ def wasm_table_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_table_get_host_info = dll.wasm_table_get_host_info
 _wasm_table_get_host_info.restype = c_void_p
 _wasm_table_get_host_info.argtypes = [POINTER(wasm_table_t)]
-def wasm_table_get_host_info(arg0: Any) -> pointer:
+def wasm_table_get_host_info(arg0: Any) -> int:
     return _wasm_table_get_host_info(arg0)  # type: ignore
 
 _wasm_table_set_host_info = dll.wasm_table_set_host_info
@@ -1274,11 +1430,23 @@ _wasm_table_as_ref.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_as_ref(arg0: Any) -> pointer:
     return _wasm_table_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_table = dll.wasm_ref_as_table
+_wasm_ref_as_table.restype = POINTER(wasm_table_t)
+_wasm_ref_as_table.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_table(arg0: Any) -> pointer:
+    return _wasm_ref_as_table(arg0)  # type: ignore
+
 _wasm_table_as_ref_const = dll.wasm_table_as_ref_const
 _wasm_table_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_table_as_ref_const.argtypes = [POINTER(wasm_table_t)]
 def wasm_table_as_ref_const(arg0: Any) -> pointer:
     return _wasm_table_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_table_const = dll.wasm_ref_as_table_const
+_wasm_ref_as_table_const.restype = POINTER(wasm_table_t)
+_wasm_ref_as_table_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_table_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_table_const(arg0)  # type: ignore
 
 wasm_table_size_t = c_uint32
 
@@ -1342,7 +1510,7 @@ def wasm_memory_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_memory_get_host_info = dll.wasm_memory_get_host_info
 _wasm_memory_get_host_info.restype = c_void_p
 _wasm_memory_get_host_info.argtypes = [POINTER(wasm_memory_t)]
-def wasm_memory_get_host_info(arg0: Any) -> pointer:
+def wasm_memory_get_host_info(arg0: Any) -> int:
     return _wasm_memory_get_host_info(arg0)  # type: ignore
 
 _wasm_memory_set_host_info = dll.wasm_memory_set_host_info
@@ -1363,11 +1531,23 @@ _wasm_memory_as_ref.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_as_ref(arg0: Any) -> pointer:
     return _wasm_memory_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_memory = dll.wasm_ref_as_memory
+_wasm_ref_as_memory.restype = POINTER(wasm_memory_t)
+_wasm_ref_as_memory.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_memory(arg0: Any) -> pointer:
+    return _wasm_ref_as_memory(arg0)  # type: ignore
+
 _wasm_memory_as_ref_const = dll.wasm_memory_as_ref_const
 _wasm_memory_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_memory_as_ref_const.argtypes = [POINTER(wasm_memory_t)]
 def wasm_memory_as_ref_const(arg0: Any) -> pointer:
     return _wasm_memory_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_memory_const = dll.wasm_ref_as_memory_const
+_wasm_ref_as_memory_const.restype = POINTER(wasm_memory_t)
+_wasm_ref_as_memory_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_memory_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_memory_const(arg0)  # type: ignore
 
 wasm_memory_pages_t = c_uint32
 
@@ -1431,7 +1611,7 @@ def wasm_extern_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_extern_get_host_info = dll.wasm_extern_get_host_info
 _wasm_extern_get_host_info.restype = c_void_p
 _wasm_extern_get_host_info.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_get_host_info(arg0: Any) -> pointer:
+def wasm_extern_get_host_info(arg0: Any) -> int:
     return _wasm_extern_get_host_info(arg0)  # type: ignore
 
 _wasm_extern_set_host_info = dll.wasm_extern_set_host_info
@@ -1452,17 +1632,31 @@ _wasm_extern_as_ref.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_ref(arg0: Any) -> pointer:
     return _wasm_extern_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_extern = dll.wasm_ref_as_extern
+_wasm_ref_as_extern.restype = POINTER(wasm_extern_t)
+_wasm_ref_as_extern.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_extern(arg0: Any) -> pointer:
+    return _wasm_ref_as_extern(arg0)  # type: ignore
+
 _wasm_extern_as_ref_const = dll.wasm_extern_as_ref_const
 _wasm_extern_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_extern_as_ref_const.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_ref_const(arg0: Any) -> pointer:
     return _wasm_extern_as_ref_const(arg0)  # type: ignore
 
+_wasm_ref_as_extern_const = dll.wasm_ref_as_extern_const
+_wasm_ref_as_extern_const.restype = POINTER(wasm_extern_t)
+_wasm_ref_as_extern_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_extern_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_extern_const(arg0)  # type: ignore
+
 class wasm_extern_vec_t(Structure):
     _fields_ = [
         ("size", c_size_t),
         ("data", POINTER(POINTER(wasm_extern_t))),
     ]
+    size: int
+    data: pointer
 
 _wasm_extern_vec_new_empty = dll.wasm_extern_vec_new_empty
 _wasm_extern_vec_new_empty.restype = None
@@ -1554,6 +1748,30 @@ _wasm_extern_as_memory.argtypes = [POINTER(wasm_extern_t)]
 def wasm_extern_as_memory(arg0: Any) -> pointer:
     return _wasm_extern_as_memory(arg0)  # type: ignore
 
+_wasm_func_as_extern_const = dll.wasm_func_as_extern_const
+_wasm_func_as_extern_const.restype = POINTER(wasm_extern_t)
+_wasm_func_as_extern_const.argtypes = [POINTER(wasm_func_t)]
+def wasm_func_as_extern_const(arg0: Any) -> pointer:
+    return _wasm_func_as_extern_const(arg0)  # type: ignore
+
+_wasm_global_as_extern_const = dll.wasm_global_as_extern_const
+_wasm_global_as_extern_const.restype = POINTER(wasm_extern_t)
+_wasm_global_as_extern_const.argtypes = [POINTER(wasm_global_t)]
+def wasm_global_as_extern_const(arg0: Any) -> pointer:
+    return _wasm_global_as_extern_const(arg0)  # type: ignore
+
+_wasm_table_as_extern_const = dll.wasm_table_as_extern_const
+_wasm_table_as_extern_const.restype = POINTER(wasm_extern_t)
+_wasm_table_as_extern_const.argtypes = [POINTER(wasm_table_t)]
+def wasm_table_as_extern_const(arg0: Any) -> pointer:
+    return _wasm_table_as_extern_const(arg0)  # type: ignore
+
+_wasm_memory_as_extern_const = dll.wasm_memory_as_extern_const
+_wasm_memory_as_extern_const.restype = POINTER(wasm_extern_t)
+_wasm_memory_as_extern_const.argtypes = [POINTER(wasm_memory_t)]
+def wasm_memory_as_extern_const(arg0: Any) -> pointer:
+    return _wasm_memory_as_extern_const(arg0)  # type: ignore
+
 _wasm_extern_as_func_const = dll.wasm_extern_as_func_const
 _wasm_extern_as_func_const.restype = POINTER(wasm_func_t)
 _wasm_extern_as_func_const.argtypes = [POINTER(wasm_extern_t)]
@@ -1602,7 +1820,7 @@ def wasm_instance_same(arg0: Any, arg1: Any) -> c_bool:
 _wasm_instance_get_host_info = dll.wasm_instance_get_host_info
 _wasm_instance_get_host_info.restype = c_void_p
 _wasm_instance_get_host_info.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_get_host_info(arg0: Any) -> pointer:
+def wasm_instance_get_host_info(arg0: Any) -> int:
     return _wasm_instance_get_host_info(arg0)  # type: ignore
 
 _wasm_instance_set_host_info = dll.wasm_instance_set_host_info
@@ -1623,11 +1841,23 @@ _wasm_instance_as_ref.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_as_ref(arg0: Any) -> pointer:
     return _wasm_instance_as_ref(arg0)  # type: ignore
 
+_wasm_ref_as_instance = dll.wasm_ref_as_instance
+_wasm_ref_as_instance.restype = POINTER(wasm_instance_t)
+_wasm_ref_as_instance.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_instance(arg0: Any) -> pointer:
+    return _wasm_ref_as_instance(arg0)  # type: ignore
+
 _wasm_instance_as_ref_const = dll.wasm_instance_as_ref_const
 _wasm_instance_as_ref_const.restype = POINTER(wasm_ref_t)
 _wasm_instance_as_ref_const.argtypes = [POINTER(wasm_instance_t)]
 def wasm_instance_as_ref_const(arg0: Any) -> pointer:
     return _wasm_instance_as_ref_const(arg0)  # type: ignore
+
+_wasm_ref_as_instance_const = dll.wasm_ref_as_instance_const
+_wasm_ref_as_instance_const.restype = POINTER(wasm_instance_t)
+_wasm_ref_as_instance_const.argtypes = [POINTER(wasm_ref_t)]
+def wasm_ref_as_instance_const(arg0: Any) -> pointer:
+    return _wasm_ref_as_instance_const(arg0)  # type: ignore
 
 _wasm_instance_new = dll.wasm_instance_new
 _wasm_instance_new.restype = POINTER(wasm_instance_t)
@@ -1722,35 +1952,16 @@ _wasi_config_preopen_dir.argtypes = [POINTER(wasi_config_t), POINTER(c_char), PO
 def wasi_config_preopen_dir(config: Any, path: Any, guest_path: Any) -> c_bool:
     return _wasi_config_preopen_dir(config, path, guest_path)  # type: ignore
 
-class wasi_instance_t(Structure):
+class wasmtime_error(Structure):
     pass
 
-_wasi_instance_delete = dll.wasi_instance_delete
-_wasi_instance_delete.restype = None
-_wasi_instance_delete.argtypes = [POINTER(wasi_instance_t)]
-def wasi_instance_delete(arg0: Any) -> None:
-    return _wasi_instance_delete(arg0)  # type: ignore
-
-_wasi_instance_new = dll.wasi_instance_new
-_wasi_instance_new.restype = POINTER(wasi_instance_t)
-_wasi_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(c_char), POINTER(wasi_config_t), POINTER(POINTER(wasm_trap_t))]
-def wasi_instance_new(store: Any, name: Any, config: Any, trap: Any) -> pointer:
-    return _wasi_instance_new(store, name, config, trap)  # type: ignore
-
-_wasi_instance_bind_import = dll.wasi_instance_bind_import
-_wasi_instance_bind_import.restype = POINTER(wasm_extern_t)
-_wasi_instance_bind_import.argtypes = [POINTER(wasi_instance_t), POINTER(wasm_importtype_t)]
-def wasi_instance_bind_import(instance: Any, arg1: Any) -> pointer:
-    return _wasi_instance_bind_import(instance, arg1)  # type: ignore
-
-class wasmtime_error_t(Structure):
-    pass
+wasmtime_error_t = wasmtime_error
 
 _wasmtime_error_delete = dll.wasmtime_error_delete
 _wasmtime_error_delete.restype = None
 _wasmtime_error_delete.argtypes = [POINTER(wasmtime_error_t)]
-def wasmtime_error_delete(arg0: Any) -> None:
-    return _wasmtime_error_delete(arg0)  # type: ignore
+def wasmtime_error_delete(error: Any) -> None:
+    return _wasmtime_error_delete(error)  # type: ignore
 
 _wasmtime_error_message = dll.wasmtime_error_message
 _wasmtime_error_message.restype = None
@@ -1872,32 +2083,472 @@ _wasmtime_config_cache_config_load.argtypes = [POINTER(wasm_config_t), POINTER(c
 def wasmtime_config_cache_config_load(arg0: Any, arg1: Any) -> pointer:
     return _wasmtime_config_cache_config_load(arg0, arg1)  # type: ignore
 
-_wasmtime_wat2wasm = dll.wasmtime_wat2wasm
-_wasmtime_wat2wasm.restype = POINTER(wasmtime_error_t)
-_wasmtime_wat2wasm.argtypes = [POINTER(wasm_byte_vec_t), POINTER(wasm_byte_vec_t)]
-def wasmtime_wat2wasm(wat: Any, ret: Any) -> pointer:
-    return _wasmtime_wat2wasm(wat, ret)  # type: ignore
-
-_wasmtime_store_gc = dll.wasmtime_store_gc
-_wasmtime_store_gc.restype = None
-_wasmtime_store_gc.argtypes = [POINTER(wasm_store_t)]
-def wasmtime_store_gc(store: Any) -> None:
-    return _wasmtime_store_gc(store)  # type: ignore
-
-class wasmtime_linker_t(Structure):
+class wasmtime_moduletype(Structure):
     pass
+
+wasmtime_moduletype_t = wasmtime_moduletype
+
+_wasmtime_moduletype_delete = dll.wasmtime_moduletype_delete
+_wasmtime_moduletype_delete.restype = None
+_wasmtime_moduletype_delete.argtypes = [POINTER(wasmtime_moduletype_t)]
+def wasmtime_moduletype_delete(ty: Any) -> None:
+    return _wasmtime_moduletype_delete(ty)  # type: ignore
+
+_wasmtime_moduletype_imports = dll.wasmtime_moduletype_imports
+_wasmtime_moduletype_imports.restype = None
+_wasmtime_moduletype_imports.argtypes = [POINTER(wasmtime_moduletype_t), POINTER(wasm_importtype_vec_t)]
+def wasmtime_moduletype_imports(arg0: Any, out: Any) -> None:
+    return _wasmtime_moduletype_imports(arg0, out)  # type: ignore
+
+_wasmtime_moduletype_exports = dll.wasmtime_moduletype_exports
+_wasmtime_moduletype_exports.restype = None
+_wasmtime_moduletype_exports.argtypes = [POINTER(wasmtime_moduletype_t), POINTER(wasm_exporttype_vec_t)]
+def wasmtime_moduletype_exports(arg0: Any, out: Any) -> None:
+    return _wasmtime_moduletype_exports(arg0, out)  # type: ignore
+
+_wasmtime_moduletype_as_externtype = dll.wasmtime_moduletype_as_externtype
+_wasmtime_moduletype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasmtime_moduletype_as_externtype.argtypes = [POINTER(wasmtime_moduletype_t)]
+def wasmtime_moduletype_as_externtype(arg0: Any) -> pointer:
+    return _wasmtime_moduletype_as_externtype(arg0)  # type: ignore
+
+_wasmtime_externtype_as_moduletype = dll.wasmtime_externtype_as_moduletype
+_wasmtime_externtype_as_moduletype.restype = POINTER(wasmtime_moduletype_t)
+_wasmtime_externtype_as_moduletype.argtypes = [POINTER(wasm_externtype_t)]
+def wasmtime_externtype_as_moduletype(arg0: Any) -> pointer:
+    return _wasmtime_externtype_as_moduletype(arg0)  # type: ignore
+
+class wasmtime_module(Structure):
+    pass
+
+wasmtime_module_t = wasmtime_module
+
+_wasmtime_module_new = dll.wasmtime_module_new
+_wasmtime_module_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_new.argtypes = [POINTER(wasm_engine_t), POINTER(c_uint8), c_size_t, POINTER(POINTER(wasmtime_module_t))]
+def wasmtime_module_new(engine: Any, wasm: Any, wasm_len: Any, ret: Any) -> pointer:
+    return _wasmtime_module_new(engine, wasm, wasm_len, ret)  # type: ignore
+
+_wasmtime_module_delete = dll.wasmtime_module_delete
+_wasmtime_module_delete.restype = None
+_wasmtime_module_delete.argtypes = [POINTER(wasmtime_module_t)]
+def wasmtime_module_delete(m: Any) -> None:
+    return _wasmtime_module_delete(m)  # type: ignore
+
+_wasmtime_module_clone = dll.wasmtime_module_clone
+_wasmtime_module_clone.restype = POINTER(wasmtime_module_t)
+_wasmtime_module_clone.argtypes = [POINTER(wasmtime_module_t)]
+def wasmtime_module_clone(m: Any) -> pointer:
+    return _wasmtime_module_clone(m)  # type: ignore
+
+_wasmtime_module_validate = dll.wasmtime_module_validate
+_wasmtime_module_validate.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_validate.argtypes = [POINTER(wasm_engine_t), POINTER(c_uint8), c_size_t]
+def wasmtime_module_validate(engine: Any, wasm: Any, wasm_len: Any) -> pointer:
+    return _wasmtime_module_validate(engine, wasm, wasm_len)  # type: ignore
+
+_wasmtime_module_type = dll.wasmtime_module_type
+_wasmtime_module_type.restype = POINTER(wasmtime_moduletype_t)
+_wasmtime_module_type.argtypes = [POINTER(wasmtime_module_t)]
+def wasmtime_module_type(arg0: Any) -> pointer:
+    return _wasmtime_module_type(arg0)  # type: ignore
+
+_wasmtime_module_serialize = dll.wasmtime_module_serialize
+_wasmtime_module_serialize.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_serialize.argtypes = [POINTER(wasmtime_module_t), POINTER(wasm_byte_vec_t)]
+def wasmtime_module_serialize(module: Any, ret: Any) -> pointer:
+    return _wasmtime_module_serialize(module, ret)  # type: ignore
+
+_wasmtime_module_deserialize = dll.wasmtime_module_deserialize
+_wasmtime_module_deserialize.restype = POINTER(wasmtime_error_t)
+_wasmtime_module_deserialize.argtypes = [POINTER(wasm_engine_t), POINTER(c_uint8), c_size_t, POINTER(POINTER(wasmtime_module_t))]
+def wasmtime_module_deserialize(engine: Any, bytes: Any, bytes_len: Any, ret: Any) -> pointer:
+    return _wasmtime_module_deserialize(engine, bytes, bytes_len, ret)  # type: ignore
+
+class wasmtime_store(Structure):
+    pass
+
+wasmtime_store_t = wasmtime_store
+
+class wasmtime_context(Structure):
+    pass
+
+wasmtime_context_t = wasmtime_context
+
+_wasmtime_store_new = dll.wasmtime_store_new
+_wasmtime_store_new.restype = POINTER(wasmtime_store_t)
+_wasmtime_store_new.argtypes = [POINTER(wasm_engine_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasmtime_store_new(engine: Any, data: Any, finalizer: Any) -> pointer:
+    return _wasmtime_store_new(engine, data, finalizer)  # type: ignore
+
+_wasmtime_store_context = dll.wasmtime_store_context
+_wasmtime_store_context.restype = POINTER(wasmtime_context_t)
+_wasmtime_store_context.argtypes = [POINTER(wasmtime_store_t)]
+def wasmtime_store_context(store: Any) -> pointer:
+    return _wasmtime_store_context(store)  # type: ignore
+
+_wasmtime_store_delete = dll.wasmtime_store_delete
+_wasmtime_store_delete.restype = None
+_wasmtime_store_delete.argtypes = [POINTER(wasmtime_store_t)]
+def wasmtime_store_delete(store: Any) -> None:
+    return _wasmtime_store_delete(store)  # type: ignore
+
+_wasmtime_context_get_data = dll.wasmtime_context_get_data
+_wasmtime_context_get_data.restype = c_void_p
+_wasmtime_context_get_data.argtypes = [POINTER(wasmtime_context_t)]
+def wasmtime_context_get_data(context: Any) -> int:
+    return _wasmtime_context_get_data(context)  # type: ignore
+
+_wasmtime_context_set_data = dll.wasmtime_context_set_data
+_wasmtime_context_set_data.restype = None
+_wasmtime_context_set_data.argtypes = [POINTER(wasmtime_context_t), c_void_p]
+def wasmtime_context_set_data(context: Any, data: Any) -> None:
+    return _wasmtime_context_set_data(context, data)  # type: ignore
+
+_wasmtime_context_gc = dll.wasmtime_context_gc
+_wasmtime_context_gc.restype = None
+_wasmtime_context_gc.argtypes = [POINTER(wasmtime_context_t)]
+def wasmtime_context_gc(context: Any) -> None:
+    return _wasmtime_context_gc(context)  # type: ignore
+
+_wasmtime_context_add_fuel = dll.wasmtime_context_add_fuel
+_wasmtime_context_add_fuel.restype = POINTER(wasmtime_error_t)
+_wasmtime_context_add_fuel.argtypes = [POINTER(wasmtime_context_t), c_uint64]
+def wasmtime_context_add_fuel(store: Any, fuel: Any) -> pointer:
+    return _wasmtime_context_add_fuel(store, fuel)  # type: ignore
+
+_wasmtime_context_fuel_consumed = dll.wasmtime_context_fuel_consumed
+_wasmtime_context_fuel_consumed.restype = c_bool
+_wasmtime_context_fuel_consumed.argtypes = [POINTER(wasmtime_context_t), POINTER(c_uint64)]
+def wasmtime_context_fuel_consumed(context: Any, fuel: Any) -> c_bool:
+    return _wasmtime_context_fuel_consumed(context, fuel)  # type: ignore
+
+_wasmtime_context_set_wasi = dll.wasmtime_context_set_wasi
+_wasmtime_context_set_wasi.restype = POINTER(wasmtime_error_t)
+_wasmtime_context_set_wasi.argtypes = [POINTER(wasmtime_context_t), POINTER(wasi_config_t)]
+def wasmtime_context_set_wasi(context: Any, wasi: Any) -> pointer:
+    return _wasmtime_context_set_wasi(context, wasi)  # type: ignore
+
+class wasmtime_interrupt_handle(Structure):
+    pass
+
+wasmtime_interrupt_handle_t = wasmtime_interrupt_handle
+
+_wasmtime_interrupt_handle_new = dll.wasmtime_interrupt_handle_new
+_wasmtime_interrupt_handle_new.restype = POINTER(wasmtime_interrupt_handle_t)
+_wasmtime_interrupt_handle_new.argtypes = [POINTER(wasmtime_context_t)]
+def wasmtime_interrupt_handle_new(context: Any) -> pointer:
+    return _wasmtime_interrupt_handle_new(context)  # type: ignore
+
+_wasmtime_interrupt_handle_interrupt = dll.wasmtime_interrupt_handle_interrupt
+_wasmtime_interrupt_handle_interrupt.restype = None
+_wasmtime_interrupt_handle_interrupt.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
+def wasmtime_interrupt_handle_interrupt(handle: Any) -> None:
+    return _wasmtime_interrupt_handle_interrupt(handle)  # type: ignore
+
+_wasmtime_interrupt_handle_delete = dll.wasmtime_interrupt_handle_delete
+_wasmtime_interrupt_handle_delete.restype = None
+_wasmtime_interrupt_handle_delete.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
+def wasmtime_interrupt_handle_delete(handle: Any) -> None:
+    return _wasmtime_interrupt_handle_delete(handle)  # type: ignore
+
+class wasmtime_func(Structure):
+    _fields_ = [
+        ("store_id", c_uint64),
+        ("index", c_size_t),
+    ]
+    store_id: c_uint64
+    index: int
+
+wasmtime_func_t = wasmtime_func
+
+class wasmtime_table(Structure):
+    _fields_ = [
+        ("store_id", c_uint64),
+        ("index", c_size_t),
+    ]
+    store_id: c_uint64
+    index: int
+
+wasmtime_table_t = wasmtime_table
+
+class wasmtime_memory(Structure):
+    _fields_ = [
+        ("store_id", c_uint64),
+        ("index", c_size_t),
+    ]
+    store_id: c_uint64
+    index: int
+
+wasmtime_memory_t = wasmtime_memory
+
+class wasmtime_instance(Structure):
+    _fields_ = [
+        ("store_id", c_uint64),
+        ("index", c_size_t),
+    ]
+    store_id: c_uint64
+    index: int
+
+wasmtime_instance_t = wasmtime_instance
+
+class wasmtime_global(Structure):
+    _fields_ = [
+        ("store_id", c_uint64),
+        ("index", c_size_t),
+    ]
+    store_id: c_uint64
+    index: int
+
+wasmtime_global_t = wasmtime_global
+
+wasmtime_extern_kind_t = c_uint8
+
+class wasmtime_extern_union(Union):
+    _fields_ = [
+        ("func", wasmtime_func_t),
+        ("global_", wasmtime_global_t),
+        ("table", wasmtime_table_t),
+        ("memory", wasmtime_memory_t),
+        ("instance", wasmtime_instance_t),
+        ("module", POINTER(wasmtime_module_t)),
+    ]
+    func: wasmtime_func_t
+    global_: wasmtime_global_t
+    table: wasmtime_table_t
+    memory: wasmtime_memory_t
+    instance: wasmtime_instance_t
+    module: pointer
+
+wasmtime_extern_union_t = wasmtime_extern_union
+
+class wasmtime_extern(Structure):
+    _fields_ = [
+        ("kind", wasmtime_extern_kind_t),
+        ("of", wasmtime_extern_union_t),
+    ]
+    kind: wasmtime_extern_kind_t
+    of: wasmtime_extern_union_t
+
+wasmtime_extern_t = wasmtime_extern
+
+_wasmtime_extern_delete = dll.wasmtime_extern_delete
+_wasmtime_extern_delete.restype = None
+_wasmtime_extern_delete.argtypes = [POINTER(wasmtime_extern_t)]
+def wasmtime_extern_delete(val: Any) -> None:
+    return _wasmtime_extern_delete(val)  # type: ignore
+
+_wasmtime_extern_type = dll.wasmtime_extern_type
+_wasmtime_extern_type.restype = POINTER(wasm_externtype_t)
+_wasmtime_extern_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_extern_t)]
+def wasmtime_extern_type(context: Any, val: Any) -> pointer:
+    return _wasmtime_extern_type(context, val)  # type: ignore
+
+class wasmtime_externref(Structure):
+    pass
+
+wasmtime_externref_t = wasmtime_externref
+
+_wasmtime_externref_new = dll.wasmtime_externref_new
+_wasmtime_externref_new.restype = POINTER(wasmtime_externref_t)
+_wasmtime_externref_new.argtypes = [c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasmtime_externref_new(data: Any, finalizer: Any) -> pointer:
+    return _wasmtime_externref_new(data, finalizer)  # type: ignore
+
+_wasmtime_externref_data = dll.wasmtime_externref_data
+_wasmtime_externref_data.restype = c_void_p
+_wasmtime_externref_data.argtypes = [POINTER(wasmtime_externref_t)]
+def wasmtime_externref_data(data: Any) -> int:
+    return _wasmtime_externref_data(data)  # type: ignore
+
+_wasmtime_externref_clone = dll.wasmtime_externref_clone
+_wasmtime_externref_clone.restype = POINTER(wasmtime_externref_t)
+_wasmtime_externref_clone.argtypes = [POINTER(wasmtime_externref_t)]
+def wasmtime_externref_clone(ref: Any) -> pointer:
+    return _wasmtime_externref_clone(ref)  # type: ignore
+
+_wasmtime_externref_delete = dll.wasmtime_externref_delete
+_wasmtime_externref_delete.restype = None
+_wasmtime_externref_delete.argtypes = [POINTER(wasmtime_externref_t)]
+def wasmtime_externref_delete(ref: Any) -> None:
+    return _wasmtime_externref_delete(ref)  # type: ignore
+
+wasmtime_valkind_t = c_uint8
+
+wasmtime_v128 = c_uint8 * 16
+
+class wasmtime_valunion(Union):
+    _fields_ = [
+        ("i32", c_int32),
+        ("i64", c_int64),
+        ("f32", c_float),
+        ("f64", c_double),
+        ("funcref", wasmtime_func_t),
+        ("externref", POINTER(wasmtime_externref_t)),
+        ("v128", wasmtime_v128),
+    ]
+    i32: int
+    i64: int
+    f32: float
+    f64: float
+    funcref: wasmtime_func_t
+    externref: pointer
+    v128: wasmtime_v128  # type: ignore
+
+wasmtime_valunion_t = wasmtime_valunion
+
+class wasmtime_val(Structure):
+    _fields_ = [
+        ("kind", wasmtime_valkind_t),
+        ("of", wasmtime_valunion_t),
+    ]
+    kind: wasmtime_valkind_t
+    of: wasmtime_valunion_t
+
+wasmtime_val_t = wasmtime_val
+
+_wasmtime_val_delete = dll.wasmtime_val_delete
+_wasmtime_val_delete.restype = None
+_wasmtime_val_delete.argtypes = [POINTER(wasmtime_val_t)]
+def wasmtime_val_delete(val: Any) -> None:
+    return _wasmtime_val_delete(val)  # type: ignore
+
+_wasmtime_val_copy = dll.wasmtime_val_copy
+_wasmtime_val_copy.restype = None
+_wasmtime_val_copy.argtypes = [POINTER(wasmtime_val_t), POINTER(wasmtime_val_t)]
+def wasmtime_val_copy(dst: Any, src: Any) -> None:
+    return _wasmtime_val_copy(dst, src)  # type: ignore
+
+class wasmtime_caller(Structure):
+    pass
+
+wasmtime_caller_t = wasmtime_caller
+
+wasmtime_func_callback_t = CFUNCTYPE(c_size_t, c_void_p, POINTER(wasmtime_caller_t), POINTER(wasmtime_val_t), c_size_t, POINTER(wasmtime_val_t), c_size_t)
+
+_wasmtime_func_new = dll.wasmtime_func_new
+_wasmtime_func_new.restype = None
+_wasmtime_func_new.argtypes = [POINTER(wasmtime_context_t), POINTER(wasm_functype_t), wasmtime_func_callback_t, c_void_p, CFUNCTYPE(None, c_void_p), POINTER(wasmtime_func_t)]
+def wasmtime_func_new(store: Any, type: Any, callback: Any, env: Any, finalizer: Any, ret: Any) -> None:
+    return _wasmtime_func_new(store, type, callback, env, finalizer, ret)  # type: ignore
+
+_wasmtime_func_type = dll.wasmtime_func_type
+_wasmtime_func_type.restype = POINTER(wasm_functype_t)
+_wasmtime_func_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_func_t)]
+def wasmtime_func_type(store: Any, func: Any) -> pointer:
+    return _wasmtime_func_type(store, func)  # type: ignore
+
+_wasmtime_func_call = dll.wasmtime_func_call
+_wasmtime_func_call.restype = POINTER(wasmtime_error_t)
+_wasmtime_func_call.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_func_t), POINTER(wasmtime_val_t), c_size_t, POINTER(wasmtime_val_t), c_size_t, POINTER(POINTER(wasm_trap_t))]
+def wasmtime_func_call(store: Any, func: Any, args: Any, nargs: Any, results: Any, nresults: Any, trap: Any) -> pointer:
+    return _wasmtime_func_call(store, func, args, nargs, results, nresults, trap)  # type: ignore
+
+_wasmtime_caller_export_get = dll.wasmtime_caller_export_get
+_wasmtime_caller_export_get.restype = c_bool
+_wasmtime_caller_export_get.argtypes = [POINTER(wasmtime_caller_t), POINTER(c_char), c_size_t, POINTER(wasmtime_extern_t)]
+def wasmtime_caller_export_get(caller: Any, name: Any, name_len: Any, item: Any) -> c_bool:
+    return _wasmtime_caller_export_get(caller, name, name_len, item)  # type: ignore
+
+_wasmtime_caller_context = dll.wasmtime_caller_context
+_wasmtime_caller_context.restype = POINTER(wasmtime_context_t)
+_wasmtime_caller_context.argtypes = [POINTER(wasmtime_caller_t)]
+def wasmtime_caller_context(caller: Any) -> pointer:
+    return _wasmtime_caller_context(caller)  # type: ignore
+
+_wasmtime_global_new = dll.wasmtime_global_new
+_wasmtime_global_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_global_new.argtypes = [POINTER(wasmtime_context_t), POINTER(wasm_globaltype_t), POINTER(wasmtime_val_t), POINTER(wasmtime_global_t)]
+def wasmtime_global_new(store: Any, type: Any, val: Any, ret: Any) -> pointer:
+    return _wasmtime_global_new(store, type, val, ret)  # type: ignore
+
+_wasmtime_global_type = dll.wasmtime_global_type
+_wasmtime_global_type.restype = POINTER(wasm_globaltype_t)
+_wasmtime_global_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_global_t)]
+def wasmtime_global_type(store: Any, arg1: Any) -> pointer:
+    return _wasmtime_global_type(store, arg1)  # type: ignore
+
+_wasmtime_global_get = dll.wasmtime_global_get
+_wasmtime_global_get.restype = None
+_wasmtime_global_get.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_global_t), POINTER(wasmtime_val_t)]
+def wasmtime_global_get(store: Any, arg1: Any, out: Any) -> None:
+    return _wasmtime_global_get(store, arg1, out)  # type: ignore
+
+_wasmtime_global_set = dll.wasmtime_global_set
+_wasmtime_global_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_global_set.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_global_t), POINTER(wasmtime_val_t)]
+def wasmtime_global_set(store: Any, arg1: Any, val: Any) -> pointer:
+    return _wasmtime_global_set(store, arg1, val)  # type: ignore
+
+class wasmtime_instancetype(Structure):
+    pass
+
+wasmtime_instancetype_t = wasmtime_instancetype
+
+_wasmtime_instancetype_delete = dll.wasmtime_instancetype_delete
+_wasmtime_instancetype_delete.restype = None
+_wasmtime_instancetype_delete.argtypes = [POINTER(wasmtime_instancetype_t)]
+def wasmtime_instancetype_delete(ty: Any) -> None:
+    return _wasmtime_instancetype_delete(ty)  # type: ignore
+
+_wasmtime_instancetype_exports = dll.wasmtime_instancetype_exports
+_wasmtime_instancetype_exports.restype = None
+_wasmtime_instancetype_exports.argtypes = [POINTER(wasmtime_instancetype_t), POINTER(wasm_exporttype_vec_t)]
+def wasmtime_instancetype_exports(arg0: Any, out: Any) -> None:
+    return _wasmtime_instancetype_exports(arg0, out)  # type: ignore
+
+_wasmtime_instancetype_as_externtype = dll.wasmtime_instancetype_as_externtype
+_wasmtime_instancetype_as_externtype.restype = POINTER(wasm_externtype_t)
+_wasmtime_instancetype_as_externtype.argtypes = [POINTER(wasmtime_instancetype_t)]
+def wasmtime_instancetype_as_externtype(arg0: Any) -> pointer:
+    return _wasmtime_instancetype_as_externtype(arg0)  # type: ignore
+
+_wasmtime_externtype_as_instancetype = dll.wasmtime_externtype_as_instancetype
+_wasmtime_externtype_as_instancetype.restype = POINTER(wasmtime_instancetype_t)
+_wasmtime_externtype_as_instancetype.argtypes = [POINTER(wasm_externtype_t)]
+def wasmtime_externtype_as_instancetype(arg0: Any) -> pointer:
+    return _wasmtime_externtype_as_instancetype(arg0)  # type: ignore
+
+_wasmtime_instance_new = dll.wasmtime_instance_new
+_wasmtime_instance_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_instance_new.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_module_t), POINTER(wasmtime_extern_t), c_size_t, POINTER(wasmtime_instance_t), POINTER(POINTER(wasm_trap_t))]
+def wasmtime_instance_new(store: Any, module: Any, imports: Any, nimports: Any, instance: Any, trap: Any) -> pointer:
+    return _wasmtime_instance_new(store, module, imports, nimports, instance, trap)  # type: ignore
+
+_wasmtime_instance_type = dll.wasmtime_instance_type
+_wasmtime_instance_type.restype = POINTER(wasmtime_instancetype_t)
+_wasmtime_instance_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_instance_t)]
+def wasmtime_instance_type(store: Any, instance: Any) -> pointer:
+    return _wasmtime_instance_type(store, instance)  # type: ignore
+
+_wasmtime_instance_export_get = dll.wasmtime_instance_export_get
+_wasmtime_instance_export_get.restype = c_bool
+_wasmtime_instance_export_get.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_instance_t), POINTER(c_char), c_size_t, POINTER(wasmtime_extern_t)]
+def wasmtime_instance_export_get(store: Any, instance: Any, name: Any, name_len: Any, item: Any) -> c_bool:
+    return _wasmtime_instance_export_get(store, instance, name, name_len, item)  # type: ignore
+
+_wasmtime_instance_export_nth = dll.wasmtime_instance_export_nth
+_wasmtime_instance_export_nth.restype = c_bool
+_wasmtime_instance_export_nth.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_instance_t), c_size_t, POINTER(POINTER(c_char)), POINTER(c_size_t), POINTER(wasmtime_extern_t)]
+def wasmtime_instance_export_nth(store: Any, instance: Any, index: Any, name: Any, name_len: Any, item: Any) -> c_bool:
+    return _wasmtime_instance_export_nth(store, instance, index, name, name_len, item)  # type: ignore
+
+class wasmtime_linker(Structure):
+    pass
+
+wasmtime_linker_t = wasmtime_linker
+
+_wasmtime_linker_new = dll.wasmtime_linker_new
+_wasmtime_linker_new.restype = POINTER(wasmtime_linker_t)
+_wasmtime_linker_new.argtypes = [POINTER(wasm_engine_t)]
+def wasmtime_linker_new(engine: Any) -> pointer:
+    return _wasmtime_linker_new(engine)  # type: ignore
 
 _wasmtime_linker_delete = dll.wasmtime_linker_delete
 _wasmtime_linker_delete.restype = None
 _wasmtime_linker_delete.argtypes = [POINTER(wasmtime_linker_t)]
-def wasmtime_linker_delete(arg0: Any) -> None:
-    return _wasmtime_linker_delete(arg0)  # type: ignore
-
-_wasmtime_linker_new = dll.wasmtime_linker_new
-_wasmtime_linker_new.restype = POINTER(wasmtime_linker_t)
-_wasmtime_linker_new.argtypes = [POINTER(wasm_store_t)]
-def wasmtime_linker_new(store: Any) -> pointer:
-    return _wasmtime_linker_new(store)  # type: ignore
+def wasmtime_linker_delete(linker: Any) -> None:
+    return _wasmtime_linker_delete(linker)  # type: ignore
 
 _wasmtime_linker_allow_shadowing = dll.wasmtime_linker_allow_shadowing
 _wasmtime_linker_allow_shadowing.restype = None
@@ -1907,115 +2558,123 @@ def wasmtime_linker_allow_shadowing(linker: Any, allow_shadowing: Any) -> None:
 
 _wasmtime_linker_define = dll.wasmtime_linker_define
 _wasmtime_linker_define.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_define.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(wasm_extern_t)]
-def wasmtime_linker_define(linker: Any, module: Any, name: Any, item: Any) -> pointer:
-    return _wasmtime_linker_define(linker, module, name, item)  # type: ignore
+_wasmtime_linker_define.argtypes = [POINTER(wasmtime_linker_t), POINTER(c_char), c_size_t, POINTER(c_char), c_size_t, POINTER(wasmtime_extern_t)]
+def wasmtime_linker_define(linker: Any, module: Any, module_len: Any, name: Any, name_len: Any, item: Any) -> pointer:
+    return _wasmtime_linker_define(linker, module, module_len, name, name_len, item)  # type: ignore
 
 _wasmtime_linker_define_wasi = dll.wasmtime_linker_define_wasi
 _wasmtime_linker_define_wasi.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_define_wasi.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasi_instance_t)]
-def wasmtime_linker_define_wasi(linker: Any, instance: Any) -> pointer:
-    return _wasmtime_linker_define_wasi(linker, instance)  # type: ignore
+_wasmtime_linker_define_wasi.argtypes = [POINTER(wasmtime_linker_t)]
+def wasmtime_linker_define_wasi(linker: Any) -> pointer:
+    return _wasmtime_linker_define_wasi(linker)  # type: ignore
 
 _wasmtime_linker_define_instance = dll.wasmtime_linker_define_instance
 _wasmtime_linker_define_instance.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_define_instance.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_instance_t)]
-def wasmtime_linker_define_instance(linker: Any, name: Any, instance: Any) -> pointer:
-    return _wasmtime_linker_define_instance(linker, name, instance)  # type: ignore
+_wasmtime_linker_define_instance.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasmtime_context_t), POINTER(c_char), c_size_t, POINTER(wasmtime_instance_t)]
+def wasmtime_linker_define_instance(linker: Any, store: Any, name: Any, name_len: Any, instance: Any) -> pointer:
+    return _wasmtime_linker_define_instance(linker, store, name, name_len, instance)  # type: ignore
 
 _wasmtime_linker_instantiate = dll.wasmtime_linker_instantiate
 _wasmtime_linker_instantiate.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_instantiate.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_module_t), POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
-def wasmtime_linker_instantiate(linker: Any, module: Any, instance: Any, trap: Any) -> pointer:
-    return _wasmtime_linker_instantiate(linker, module, instance, trap)  # type: ignore
+_wasmtime_linker_instantiate.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasmtime_context_t), POINTER(wasmtime_module_t), POINTER(wasmtime_instance_t), POINTER(POINTER(wasm_trap_t))]
+def wasmtime_linker_instantiate(linker: Any, store: Any, module: Any, instance: Any, trap: Any) -> pointer:
+    return _wasmtime_linker_instantiate(linker, store, module, instance, trap)  # type: ignore
 
 _wasmtime_linker_module = dll.wasmtime_linker_module
 _wasmtime_linker_module.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_module.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_module_t)]
-def wasmtime_linker_module(linker: Any, name: Any, module: Any) -> pointer:
-    return _wasmtime_linker_module(linker, name, module)  # type: ignore
+_wasmtime_linker_module.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasmtime_context_t), POINTER(c_char), c_size_t, POINTER(wasmtime_module_t)]
+def wasmtime_linker_module(linker: Any, store: Any, name: Any, name_len: Any, module: Any) -> pointer:
+    return _wasmtime_linker_module(linker, store, name, name_len, module)  # type: ignore
 
 _wasmtime_linker_get_default = dll.wasmtime_linker_get_default
 _wasmtime_linker_get_default.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_get_default.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(POINTER(wasm_func_t))]
-def wasmtime_linker_get_default(linker: Any, name: Any, func: Any) -> pointer:
-    return _wasmtime_linker_get_default(linker, name, func)  # type: ignore
+_wasmtime_linker_get_default.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasmtime_context_t), POINTER(c_char), c_size_t, POINTER(wasmtime_func_t)]
+def wasmtime_linker_get_default(linker: Any, store: Any, name: Any, name_len: Any, func: Any) -> pointer:
+    return _wasmtime_linker_get_default(linker, store, name, name_len, func)  # type: ignore
 
-_wasmtime_linker_get_one_by_name = dll.wasmtime_linker_get_one_by_name
-_wasmtime_linker_get_one_by_name.restype = POINTER(wasmtime_error_t)
-_wasmtime_linker_get_one_by_name.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasm_name_t), POINTER(wasm_name_t), POINTER(POINTER(wasm_extern_t))]
-def wasmtime_linker_get_one_by_name(linker: Any, module: Any, name: Any, item: Any) -> pointer:
-    return _wasmtime_linker_get_one_by_name(linker, module, name, item)  # type: ignore
+_wasmtime_linker_get = dll.wasmtime_linker_get
+_wasmtime_linker_get.restype = c_bool
+_wasmtime_linker_get.argtypes = [POINTER(wasmtime_linker_t), POINTER(wasmtime_context_t), POINTER(c_char), c_size_t, POINTER(c_char), c_size_t, POINTER(wasmtime_extern_t)]
+def wasmtime_linker_get(linker: Any, store: Any, module: Any, module_len: Any, name: Any, name_len: Any, item: Any) -> c_bool:
+    return _wasmtime_linker_get(linker, store, module, module_len, name, name_len, item)  # type: ignore
 
-class wasmtime_caller_t(Structure):
-    pass
+_wasmtime_memory_new = dll.wasmtime_memory_new
+_wasmtime_memory_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_memory_new.argtypes = [POINTER(wasmtime_context_t), POINTER(wasm_memorytype_t), POINTER(wasmtime_memory_t)]
+def wasmtime_memory_new(store: Any, ty: Any, ret: Any) -> pointer:
+    return _wasmtime_memory_new(store, ty, ret)  # type: ignore
 
-wasmtime_func_callback_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_t), POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t))
+_wasmtime_memory_type = dll.wasmtime_memory_type
+_wasmtime_memory_type.restype = POINTER(wasm_memorytype_t)
+_wasmtime_memory_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_memory_t)]
+def wasmtime_memory_type(store: Any, memory: Any) -> pointer:
+    return _wasmtime_memory_type(store, memory)  # type: ignore
 
-wasmtime_func_callback_with_env_t = CFUNCTYPE(c_size_t, POINTER(wasmtime_caller_t), c_void_p, POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t))
+_wasmtime_memory_data = dll.wasmtime_memory_data
+_wasmtime_memory_data.restype = POINTER(c_uint8)
+_wasmtime_memory_data.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_memory_t)]
+def wasmtime_memory_data(store: Any, memory: Any) -> pointer:
+    return _wasmtime_memory_data(store, memory)  # type: ignore
 
-_wasmtime_func_new = dll.wasmtime_func_new
-_wasmtime_func_new.restype = POINTER(wasm_func_t)
-_wasmtime_func_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_t]
-def wasmtime_func_new(arg0: Any, arg1: Any, callback: Any) -> pointer:
-    return _wasmtime_func_new(arg0, arg1, callback)  # type: ignore
+_wasmtime_memory_data_size = dll.wasmtime_memory_data_size
+_wasmtime_memory_data_size.restype = c_size_t
+_wasmtime_memory_data_size.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_memory_t)]
+def wasmtime_memory_data_size(store: Any, memory: Any) -> int:
+    return _wasmtime_memory_data_size(store, memory)  # type: ignore
 
-_wasmtime_func_new_with_env = dll.wasmtime_func_new_with_env
-_wasmtime_func_new_with_env.restype = POINTER(wasm_func_t)
-_wasmtime_func_new_with_env.argtypes = [POINTER(wasm_store_t), POINTER(wasm_functype_t), wasmtime_func_callback_with_env_t, c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasmtime_func_new_with_env(store: Any, type: Any, callback: Any, env: Any, finalizer: Any) -> pointer:
-    return _wasmtime_func_new_with_env(store, type, callback, env, finalizer)  # type: ignore
+_wasmtime_memory_size = dll.wasmtime_memory_size
+_wasmtime_memory_size.restype = c_uint32
+_wasmtime_memory_size.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_memory_t)]
+def wasmtime_memory_size(store: Any, memory: Any) -> int:
+    return _wasmtime_memory_size(store, memory)  # type: ignore
 
-_wasmtime_func_as_funcref = dll.wasmtime_func_as_funcref
-_wasmtime_func_as_funcref.restype = None
-_wasmtime_func_as_funcref.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_t)]
-def wasmtime_func_as_funcref(func: Any, funcrefp: Any) -> None:
-    return _wasmtime_func_as_funcref(func, funcrefp)  # type: ignore
+_wasmtime_memory_grow = dll.wasmtime_memory_grow
+_wasmtime_memory_grow.restype = POINTER(wasmtime_error_t)
+_wasmtime_memory_grow.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_memory_t), c_uint32, POINTER(c_uint32)]
+def wasmtime_memory_grow(store: Any, memory: Any, delta: Any, prev_size: Any) -> pointer:
+    return _wasmtime_memory_grow(store, memory, delta, prev_size)  # type: ignore
 
-_wasmtime_funcref_as_func = dll.wasmtime_funcref_as_func
-_wasmtime_funcref_as_func.restype = POINTER(wasm_func_t)
-_wasmtime_funcref_as_func.argtypes = [POINTER(wasm_val_t)]
-def wasmtime_funcref_as_func(val: Any) -> pointer:
-    return _wasmtime_funcref_as_func(val)  # type: ignore
+_wasmtime_table_new = dll.wasmtime_table_new
+_wasmtime_table_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_table_new.argtypes = [POINTER(wasmtime_context_t), POINTER(wasm_tabletype_t), POINTER(wasmtime_val_t), POINTER(wasmtime_table_t)]
+def wasmtime_table_new(store: Any, ty: Any, init: Any, table: Any) -> pointer:
+    return _wasmtime_table_new(store, ty, init, table)  # type: ignore
 
-_wasmtime_caller_export_get = dll.wasmtime_caller_export_get
-_wasmtime_caller_export_get.restype = POINTER(wasm_extern_t)
-_wasmtime_caller_export_get.argtypes = [POINTER(wasmtime_caller_t), POINTER(wasm_name_t)]
-def wasmtime_caller_export_get(caller: Any, name: Any) -> pointer:
-    return _wasmtime_caller_export_get(caller, name)  # type: ignore
+_wasmtime_table_type = dll.wasmtime_table_type
+_wasmtime_table_type.restype = POINTER(wasm_tabletype_t)
+_wasmtime_table_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_table_t)]
+def wasmtime_table_type(store: Any, table: Any) -> pointer:
+    return _wasmtime_table_type(store, table)  # type: ignore
 
-class wasmtime_interrupt_handle_t(Structure):
-    pass
+_wasmtime_table_get = dll.wasmtime_table_get
+_wasmtime_table_get.restype = c_bool
+_wasmtime_table_get.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_table_t), c_uint32, POINTER(wasmtime_val_t)]
+def wasmtime_table_get(store: Any, table: Any, index: Any, val: Any) -> c_bool:
+    return _wasmtime_table_get(store, table, index, val)  # type: ignore
 
-_wasmtime_interrupt_handle_delete = dll.wasmtime_interrupt_handle_delete
-_wasmtime_interrupt_handle_delete.restype = None
-_wasmtime_interrupt_handle_delete.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
-def wasmtime_interrupt_handle_delete(arg0: Any) -> None:
-    return _wasmtime_interrupt_handle_delete(arg0)  # type: ignore
+_wasmtime_table_set = dll.wasmtime_table_set
+_wasmtime_table_set.restype = POINTER(wasmtime_error_t)
+_wasmtime_table_set.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_table_t), c_uint32, POINTER(wasmtime_val_t)]
+def wasmtime_table_set(store: Any, table: Any, index: Any, value: Any) -> pointer:
+    return _wasmtime_table_set(store, table, index, value)  # type: ignore
 
-_wasmtime_interrupt_handle_new = dll.wasmtime_interrupt_handle_new
-_wasmtime_interrupt_handle_new.restype = POINTER(wasmtime_interrupt_handle_t)
-_wasmtime_interrupt_handle_new.argtypes = [POINTER(wasm_store_t)]
-def wasmtime_interrupt_handle_new(store: Any) -> pointer:
-    return _wasmtime_interrupt_handle_new(store)  # type: ignore
+_wasmtime_table_size = dll.wasmtime_table_size
+_wasmtime_table_size.restype = c_uint32
+_wasmtime_table_size.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_table_t)]
+def wasmtime_table_size(store: Any, table: Any) -> int:
+    return _wasmtime_table_size(store, table)  # type: ignore
 
-_wasmtime_store_add_fuel = dll.wasmtime_store_add_fuel
-_wasmtime_store_add_fuel.restype = POINTER(wasmtime_error_t)
-_wasmtime_store_add_fuel.argtypes = [POINTER(wasm_store_t), c_uint64]
-def wasmtime_store_add_fuel(store: Any, fuel: Any) -> pointer:
-    return _wasmtime_store_add_fuel(store, fuel)  # type: ignore
+_wasmtime_table_grow = dll.wasmtime_table_grow
+_wasmtime_table_grow.restype = POINTER(wasmtime_error_t)
+_wasmtime_table_grow.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_table_t), c_uint32, POINTER(wasmtime_val_t), POINTER(c_uint32)]
+def wasmtime_table_grow(store: Any, table: Any, delta: Any, init: Any, prev_size: Any) -> pointer:
+    return _wasmtime_table_grow(store, table, delta, init, prev_size)  # type: ignore
 
-_wasmtime_store_fuel_consumed = dll.wasmtime_store_fuel_consumed
-_wasmtime_store_fuel_consumed.restype = c_bool
-_wasmtime_store_fuel_consumed.argtypes = [POINTER(wasm_store_t), POINTER(c_uint64)]
-def wasmtime_store_fuel_consumed(store: Any, fuel: Any) -> c_bool:
-    return _wasmtime_store_fuel_consumed(store, fuel)  # type: ignore
-
-_wasmtime_interrupt_handle_interrupt = dll.wasmtime_interrupt_handle_interrupt
-_wasmtime_interrupt_handle_interrupt.restype = None
-_wasmtime_interrupt_handle_interrupt.argtypes = [POINTER(wasmtime_interrupt_handle_t)]
-def wasmtime_interrupt_handle_interrupt(handle: Any) -> None:
-    return _wasmtime_interrupt_handle_interrupt(handle)  # type: ignore
+_wasmtime_trap_new = dll.wasmtime_trap_new
+_wasmtime_trap_new.restype = POINTER(wasm_trap_t)
+_wasmtime_trap_new.argtypes = [POINTER(c_char), c_size_t]
+def wasmtime_trap_new(msg: Any, msg_len: Any) -> pointer:
+    return _wasmtime_trap_new(msg, msg_len)  # type: ignore
 
 _wasmtime_trap_exit_status = dll.wasmtime_trap_exit_status
 _wasmtime_trap_exit_status.restype = c_bool
@@ -2035,310 +2694,8 @@ _wasmtime_frame_module_name.argtypes = [POINTER(wasm_frame_t)]
 def wasmtime_frame_module_name(arg0: Any) -> pointer:
     return _wasmtime_frame_module_name(arg0)  # type: ignore
 
-_wasmtime_func_call = dll.wasmtime_func_call
-_wasmtime_func_call.restype = POINTER(wasmtime_error_t)
-_wasmtime_func_call.argtypes = [POINTER(wasm_func_t), POINTER(wasm_val_vec_t), POINTER(wasm_val_vec_t), POINTER(POINTER(wasm_trap_t))]
-def wasmtime_func_call(func: Any, args: Any, results: Any, trap: Any) -> pointer:
-    return _wasmtime_func_call(func, args, results, trap)  # type: ignore
-
-_wasmtime_global_new = dll.wasmtime_global_new
-_wasmtime_global_new.restype = POINTER(wasmtime_error_t)
-_wasmtime_global_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_globaltype_t), POINTER(wasm_val_t), POINTER(POINTER(wasm_global_t))]
-def wasmtime_global_new(store: Any, type: Any, val: Any, ret: Any) -> pointer:
-    return _wasmtime_global_new(store, type, val, ret)  # type: ignore
-
-_wasmtime_global_set = dll.wasmtime_global_set
-_wasmtime_global_set.restype = POINTER(wasmtime_error_t)
-_wasmtime_global_set.argtypes = [POINTER(wasm_global_t), POINTER(wasm_val_t)]
-def wasmtime_global_set(arg0: Any, val: Any) -> pointer:
-    return _wasmtime_global_set(arg0, val)  # type: ignore
-
-_wasmtime_instance_new = dll.wasmtime_instance_new
-_wasmtime_instance_new.restype = POINTER(wasmtime_error_t)
-_wasmtime_instance_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_module_t), POINTER(wasm_extern_vec_t), POINTER(POINTER(wasm_instance_t)), POINTER(POINTER(wasm_trap_t))]
-def wasmtime_instance_new(store: Any, module: Any, imports: Any, instance: Any, trap: Any) -> pointer:
-    return _wasmtime_instance_new(store, module, imports, instance, trap)  # type: ignore
-
-_wasmtime_module_new = dll.wasmtime_module_new
-_wasmtime_module_new.restype = POINTER(wasmtime_error_t)
-_wasmtime_module_new.argtypes = [POINTER(wasm_engine_t), POINTER(wasm_byte_vec_t), POINTER(POINTER(wasm_module_t))]
-def wasmtime_module_new(engine: Any, binary: Any, ret: Any) -> pointer:
-    return _wasmtime_module_new(engine, binary, ret)  # type: ignore
-
-_wasmtime_module_validate = dll.wasmtime_module_validate
-_wasmtime_module_validate.restype = POINTER(wasmtime_error_t)
-_wasmtime_module_validate.argtypes = [POINTER(wasm_store_t), POINTER(wasm_byte_vec_t)]
-def wasmtime_module_validate(store: Any, binary: Any) -> pointer:
-    return _wasmtime_module_validate(store, binary)  # type: ignore
-
-_wasmtime_funcref_table_new = dll.wasmtime_funcref_table_new
-_wasmtime_funcref_table_new.restype = POINTER(wasmtime_error_t)
-_wasmtime_funcref_table_new.argtypes = [POINTER(wasm_store_t), POINTER(wasm_tabletype_t), POINTER(wasm_func_t), POINTER(POINTER(wasm_table_t))]
-def wasmtime_funcref_table_new(store: Any, element_ty: Any, init: Any, table: Any) -> pointer:
-    return _wasmtime_funcref_table_new(store, element_ty, init, table)  # type: ignore
-
-_wasmtime_funcref_table_get = dll.wasmtime_funcref_table_get
-_wasmtime_funcref_table_get.restype = c_bool
-_wasmtime_funcref_table_get.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(POINTER(wasm_func_t))]
-def wasmtime_funcref_table_get(table: Any, index: Any, func: Any) -> c_bool:
-    return _wasmtime_funcref_table_get(table, index, func)  # type: ignore
-
-_wasmtime_funcref_table_set = dll.wasmtime_funcref_table_set
-_wasmtime_funcref_table_set.restype = POINTER(wasmtime_error_t)
-_wasmtime_funcref_table_set.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t)]
-def wasmtime_funcref_table_set(table: Any, index: Any, value: Any) -> pointer:
-    return _wasmtime_funcref_table_set(table, index, value)  # type: ignore
-
-_wasmtime_funcref_table_grow = dll.wasmtime_funcref_table_grow
-_wasmtime_funcref_table_grow.restype = POINTER(wasmtime_error_t)
-_wasmtime_funcref_table_grow.argtypes = [POINTER(wasm_table_t), wasm_table_size_t, POINTER(wasm_func_t), POINTER(wasm_table_size_t)]
-def wasmtime_funcref_table_grow(table: Any, delta: Any, init: Any, prev_size: Any) -> pointer:
-    return _wasmtime_funcref_table_grow(table, delta, init, prev_size)  # type: ignore
-
-_wasmtime_externref_new = dll.wasmtime_externref_new
-_wasmtime_externref_new.restype = None
-_wasmtime_externref_new.argtypes = [c_void_p, POINTER(wasm_val_t)]
-def wasmtime_externref_new(data: Any, valp: Any) -> None:
-    return _wasmtime_externref_new(data, valp)  # type: ignore
-
-wasmtime_externref_finalizer_t = CFUNCTYPE(None, c_void_p)
-
-_wasmtime_externref_new_with_finalizer = dll.wasmtime_externref_new_with_finalizer
-_wasmtime_externref_new_with_finalizer.restype = None
-_wasmtime_externref_new_with_finalizer.argtypes = [c_void_p, wasmtime_externref_finalizer_t, POINTER(wasm_val_t)]
-def wasmtime_externref_new_with_finalizer(data: Any, finalizer: Any, valp: Any) -> None:
-    return _wasmtime_externref_new_with_finalizer(data, finalizer, valp)  # type: ignore
-
-_wasmtime_externref_data = dll.wasmtime_externref_data
-_wasmtime_externref_data.restype = c_bool
-_wasmtime_externref_data.argtypes = [POINTER(wasm_val_t), POINTER(c_void_p)]
-def wasmtime_externref_data(val: Any, datap: Any) -> c_bool:
-    return _wasmtime_externref_data(val, datap)  # type: ignore
-
-_wasmtime_module_serialize = dll.wasmtime_module_serialize
-_wasmtime_module_serialize.restype = POINTER(wasmtime_error_t)
-_wasmtime_module_serialize.argtypes = [POINTER(wasm_module_t), POINTER(wasm_byte_vec_t)]
-def wasmtime_module_serialize(module: Any, ret: Any) -> pointer:
-    return _wasmtime_module_serialize(module, ret)  # type: ignore
-
-_wasmtime_module_deserialize = dll.wasmtime_module_deserialize
-_wasmtime_module_deserialize.restype = POINTER(wasmtime_error_t)
-_wasmtime_module_deserialize.argtypes = [POINTER(wasm_engine_t), POINTER(wasm_byte_vec_t), POINTER(POINTER(wasm_module_t))]
-def wasmtime_module_deserialize(engine: Any, serialized: Any, ret: Any) -> pointer:
-    return _wasmtime_module_deserialize(engine, serialized, ret)  # type: ignore
-
-class wasm_instancetype_t(Structure):
-    pass
-
-_wasm_instancetype_delete = dll.wasm_instancetype_delete
-_wasm_instancetype_delete.restype = None
-_wasm_instancetype_delete.argtypes = [POINTER(wasm_instancetype_t)]
-def wasm_instancetype_delete(arg0: Any) -> None:
-    return _wasm_instancetype_delete(arg0)  # type: ignore
-
-class wasm_instancetype_vec_t(Structure):
-    _fields_ = [
-        ("size", c_size_t),
-        ("data", POINTER(POINTER(wasm_instancetype_t))),
-    ]
-
-_wasm_instancetype_vec_new_empty = dll.wasm_instancetype_vec_new_empty
-_wasm_instancetype_vec_new_empty.restype = None
-_wasm_instancetype_vec_new_empty.argtypes = [POINTER(wasm_instancetype_vec_t)]
-def wasm_instancetype_vec_new_empty(out: Any) -> None:
-    return _wasm_instancetype_vec_new_empty(out)  # type: ignore
-
-_wasm_instancetype_vec_new_uninitialized = dll.wasm_instancetype_vec_new_uninitialized
-_wasm_instancetype_vec_new_uninitialized.restype = None
-_wasm_instancetype_vec_new_uninitialized.argtypes = [POINTER(wasm_instancetype_vec_t), c_size_t]
-def wasm_instancetype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_instancetype_vec_new_uninitialized(out, arg1)  # type: ignore
-
-_wasm_instancetype_vec_new = dll.wasm_instancetype_vec_new
-_wasm_instancetype_vec_new.restype = None
-_wasm_instancetype_vec_new.argtypes = [POINTER(wasm_instancetype_vec_t), c_size_t, POINTER(POINTER(wasm_instancetype_t))]
-def wasm_instancetype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_instancetype_vec_new(out, arg1, arg2)  # type: ignore
-
-_wasm_instancetype_vec_copy = dll.wasm_instancetype_vec_copy
-_wasm_instancetype_vec_copy.restype = None
-_wasm_instancetype_vec_copy.argtypes = [POINTER(wasm_instancetype_vec_t), POINTER(wasm_instancetype_vec_t)]
-def wasm_instancetype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_instancetype_vec_copy(out, arg1)  # type: ignore
-
-_wasm_instancetype_vec_delete = dll.wasm_instancetype_vec_delete
-_wasm_instancetype_vec_delete.restype = None
-_wasm_instancetype_vec_delete.argtypes = [POINTER(wasm_instancetype_vec_t)]
-def wasm_instancetype_vec_delete(arg0: Any) -> None:
-    return _wasm_instancetype_vec_delete(arg0)  # type: ignore
-
-_wasm_instancetype_copy = dll.wasm_instancetype_copy
-_wasm_instancetype_copy.restype = POINTER(wasm_instancetype_t)
-_wasm_instancetype_copy.argtypes = [POINTER(wasm_instancetype_t)]
-def wasm_instancetype_copy(arg0: Any) -> pointer:
-    return _wasm_instancetype_copy(arg0)  # type: ignore
-
-_wasm_instancetype_exports = dll.wasm_instancetype_exports
-_wasm_instancetype_exports.restype = None
-_wasm_instancetype_exports.argtypes = [POINTER(wasm_instancetype_t), POINTER(wasm_exporttype_vec_t)]
-def wasm_instancetype_exports(arg0: Any, out: Any) -> None:
-    return _wasm_instancetype_exports(arg0, out)  # type: ignore
-
-_wasm_instancetype_as_externtype = dll.wasm_instancetype_as_externtype
-_wasm_instancetype_as_externtype.restype = POINTER(wasm_externtype_t)
-_wasm_instancetype_as_externtype.argtypes = [POINTER(wasm_instancetype_t)]
-def wasm_instancetype_as_externtype(arg0: Any) -> pointer:
-    return _wasm_instancetype_as_externtype(arg0)  # type: ignore
-
-_wasm_externtype_as_instancetype = dll.wasm_externtype_as_instancetype
-_wasm_externtype_as_instancetype.restype = POINTER(wasm_instancetype_t)
-_wasm_externtype_as_instancetype.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_instancetype(arg0: Any) -> pointer:
-    return _wasm_externtype_as_instancetype(arg0)  # type: ignore
-
-_wasm_instancetype_as_externtype_const = dll.wasm_instancetype_as_externtype_const
-_wasm_instancetype_as_externtype_const.restype = POINTER(wasm_externtype_t)
-_wasm_instancetype_as_externtype_const.argtypes = [POINTER(wasm_instancetype_t)]
-def wasm_instancetype_as_externtype_const(arg0: Any) -> pointer:
-    return _wasm_instancetype_as_externtype_const(arg0)  # type: ignore
-
-_wasm_externtype_as_instancetype_const = dll.wasm_externtype_as_instancetype_const
-_wasm_externtype_as_instancetype_const.restype = POINTER(wasm_instancetype_t)
-_wasm_externtype_as_instancetype_const.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_instancetype_const(arg0: Any) -> pointer:
-    return _wasm_externtype_as_instancetype_const(arg0)  # type: ignore
-
-class wasm_moduletype_t(Structure):
-    pass
-
-_wasm_moduletype_delete = dll.wasm_moduletype_delete
-_wasm_moduletype_delete.restype = None
-_wasm_moduletype_delete.argtypes = [POINTER(wasm_moduletype_t)]
-def wasm_moduletype_delete(arg0: Any) -> None:
-    return _wasm_moduletype_delete(arg0)  # type: ignore
-
-class wasm_moduletype_vec_t(Structure):
-    _fields_ = [
-        ("size", c_size_t),
-        ("data", POINTER(POINTER(wasm_moduletype_t))),
-    ]
-
-_wasm_moduletype_vec_new_empty = dll.wasm_moduletype_vec_new_empty
-_wasm_moduletype_vec_new_empty.restype = None
-_wasm_moduletype_vec_new_empty.argtypes = [POINTER(wasm_moduletype_vec_t)]
-def wasm_moduletype_vec_new_empty(out: Any) -> None:
-    return _wasm_moduletype_vec_new_empty(out)  # type: ignore
-
-_wasm_moduletype_vec_new_uninitialized = dll.wasm_moduletype_vec_new_uninitialized
-_wasm_moduletype_vec_new_uninitialized.restype = None
-_wasm_moduletype_vec_new_uninitialized.argtypes = [POINTER(wasm_moduletype_vec_t), c_size_t]
-def wasm_moduletype_vec_new_uninitialized(out: Any, arg1: Any) -> None:
-    return _wasm_moduletype_vec_new_uninitialized(out, arg1)  # type: ignore
-
-_wasm_moduletype_vec_new = dll.wasm_moduletype_vec_new
-_wasm_moduletype_vec_new.restype = None
-_wasm_moduletype_vec_new.argtypes = [POINTER(wasm_moduletype_vec_t), c_size_t, POINTER(POINTER(wasm_moduletype_t))]
-def wasm_moduletype_vec_new(out: Any, arg1: Any, arg2: Any) -> None:
-    return _wasm_moduletype_vec_new(out, arg1, arg2)  # type: ignore
-
-_wasm_moduletype_vec_copy = dll.wasm_moduletype_vec_copy
-_wasm_moduletype_vec_copy.restype = None
-_wasm_moduletype_vec_copy.argtypes = [POINTER(wasm_moduletype_vec_t), POINTER(wasm_moduletype_vec_t)]
-def wasm_moduletype_vec_copy(out: Any, arg1: Any) -> None:
-    return _wasm_moduletype_vec_copy(out, arg1)  # type: ignore
-
-_wasm_moduletype_vec_delete = dll.wasm_moduletype_vec_delete
-_wasm_moduletype_vec_delete.restype = None
-_wasm_moduletype_vec_delete.argtypes = [POINTER(wasm_moduletype_vec_t)]
-def wasm_moduletype_vec_delete(arg0: Any) -> None:
-    return _wasm_moduletype_vec_delete(arg0)  # type: ignore
-
-_wasm_moduletype_copy = dll.wasm_moduletype_copy
-_wasm_moduletype_copy.restype = POINTER(wasm_moduletype_t)
-_wasm_moduletype_copy.argtypes = [POINTER(wasm_moduletype_t)]
-def wasm_moduletype_copy(arg0: Any) -> pointer:
-    return _wasm_moduletype_copy(arg0)  # type: ignore
-
-_wasm_moduletype_imports = dll.wasm_moduletype_imports
-_wasm_moduletype_imports.restype = None
-_wasm_moduletype_imports.argtypes = [POINTER(wasm_moduletype_t), POINTER(wasm_importtype_vec_t)]
-def wasm_moduletype_imports(arg0: Any, out: Any) -> None:
-    return _wasm_moduletype_imports(arg0, out)  # type: ignore
-
-_wasm_moduletype_exports = dll.wasm_moduletype_exports
-_wasm_moduletype_exports.restype = None
-_wasm_moduletype_exports.argtypes = [POINTER(wasm_moduletype_t), POINTER(wasm_exporttype_vec_t)]
-def wasm_moduletype_exports(arg0: Any, out: Any) -> None:
-    return _wasm_moduletype_exports(arg0, out)  # type: ignore
-
-_wasm_moduletype_as_externtype = dll.wasm_moduletype_as_externtype
-_wasm_moduletype_as_externtype.restype = POINTER(wasm_externtype_t)
-_wasm_moduletype_as_externtype.argtypes = [POINTER(wasm_moduletype_t)]
-def wasm_moduletype_as_externtype(arg0: Any) -> pointer:
-    return _wasm_moduletype_as_externtype(arg0)  # type: ignore
-
-_wasm_externtype_as_moduletype = dll.wasm_externtype_as_moduletype
-_wasm_externtype_as_moduletype.restype = POINTER(wasm_moduletype_t)
-_wasm_externtype_as_moduletype.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_moduletype(arg0: Any) -> pointer:
-    return _wasm_externtype_as_moduletype(arg0)  # type: ignore
-
-_wasm_moduletype_as_externtype_const = dll.wasm_moduletype_as_externtype_const
-_wasm_moduletype_as_externtype_const.restype = POINTER(wasm_externtype_t)
-_wasm_moduletype_as_externtype_const.argtypes = [POINTER(wasm_moduletype_t)]
-def wasm_moduletype_as_externtype_const(arg0: Any) -> pointer:
-    return _wasm_moduletype_as_externtype_const(arg0)  # type: ignore
-
-_wasm_externtype_as_moduletype_const = dll.wasm_externtype_as_moduletype_const
-_wasm_externtype_as_moduletype_const.restype = POINTER(wasm_moduletype_t)
-_wasm_externtype_as_moduletype_const.argtypes = [POINTER(wasm_externtype_t)]
-def wasm_externtype_as_moduletype_const(arg0: Any) -> pointer:
-    return _wasm_externtype_as_moduletype_const(arg0)  # type: ignore
-
-_wasm_module_as_extern = dll.wasm_module_as_extern
-_wasm_module_as_extern.restype = POINTER(wasm_extern_t)
-_wasm_module_as_extern.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_as_extern(arg0: Any) -> pointer:
-    return _wasm_module_as_extern(arg0)  # type: ignore
-
-_wasm_extern_as_module = dll.wasm_extern_as_module
-_wasm_extern_as_module.restype = POINTER(wasm_module_t)
-_wasm_extern_as_module.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_module(arg0: Any) -> pointer:
-    return _wasm_extern_as_module(arg0)  # type: ignore
-
-_wasm_extern_as_module_const = dll.wasm_extern_as_module_const
-_wasm_extern_as_module_const.restype = POINTER(wasm_module_t)
-_wasm_extern_as_module_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_module_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_module_const(arg0)  # type: ignore
-
-_wasm_instance_as_extern = dll.wasm_instance_as_extern
-_wasm_instance_as_extern.restype = POINTER(wasm_extern_t)
-_wasm_instance_as_extern.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_as_extern(arg0: Any) -> pointer:
-    return _wasm_instance_as_extern(arg0)  # type: ignore
-
-_wasm_extern_as_instance = dll.wasm_extern_as_instance
-_wasm_extern_as_instance.restype = POINTER(wasm_instance_t)
-_wasm_extern_as_instance.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_instance(arg0: Any) -> pointer:
-    return _wasm_extern_as_instance(arg0)  # type: ignore
-
-_wasm_extern_as_instance_const = dll.wasm_extern_as_instance_const
-_wasm_extern_as_instance_const.restype = POINTER(wasm_instance_t)
-_wasm_extern_as_instance_const.argtypes = [POINTER(wasm_extern_t)]
-def wasm_extern_as_instance_const(arg0: Any) -> pointer:
-    return _wasm_extern_as_instance_const(arg0)  # type: ignore
-
-_wasm_instance_type = dll.wasm_instance_type
-_wasm_instance_type.restype = POINTER(wasm_instancetype_t)
-_wasm_instance_type.argtypes = [POINTER(wasm_instance_t)]
-def wasm_instance_type(arg0: Any) -> pointer:
-    return _wasm_instance_type(arg0)  # type: ignore
-
-_wasm_module_type = dll.wasm_module_type
-_wasm_module_type.restype = POINTER(wasm_moduletype_t)
-_wasm_module_type.argtypes = [POINTER(wasm_module_t)]
-def wasm_module_type(arg0: Any) -> pointer:
-    return _wasm_module_type(arg0)  # type: ignore
+_wasmtime_wat2wasm = dll.wasmtime_wat2wasm
+_wasmtime_wat2wasm.restype = POINTER(wasmtime_error_t)
+_wasmtime_wat2wasm.argtypes = [POINTER(c_char), c_size_t, POINTER(wasm_byte_vec_t)]
+def wasmtime_wat2wasm(wat: Any, wat_len: Any, ret: Any) -> pointer:
+    return _wasmtime_wat2wasm(wat, wat_len, ret)  # type: ignore

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -35,9 +35,27 @@ WASM_F32 = c_uint8(2)
 WASM_F64 = c_uint8(3)
 WASM_ANYREF = c_uint8(128)
 WASM_FUNCREF = c_uint8(129)
+# WASM_V128 = c_uint8(4)
+
+WASMTIME_I32 = c_uint8(0)
+WASMTIME_I64 = c_uint8(1)
+WASMTIME_F32 = c_uint8(2)
+WASMTIME_F64 = c_uint8(3)
+WASMTIME_V128 = c_uint8(4)
+WASMTIME_FUNCREF = c_uint8(5)
+WASMTIME_EXTERNREF = c_uint8(6)
 
 WASM_CONST = c_uint8(0)
 WASM_VAR = c_uint8(1)
+
+WASMTIME_EXTERN_FUNC = c_uint8(0)
+WASMTIME_EXTERN_GLOBAL = c_uint8(1)
+WASMTIME_EXTERN_TABLE = c_uint8(2)
+WASMTIME_EXTERN_MEMORY = c_uint8(3)
+WASMTIME_EXTERN_INSTANCE = c_uint8(4)
+WASMTIME_EXTERN_MODULE = c_uint8(5)
+
+WASMTIME_FUNCREF_NULL = (1 << 64) - 1
 
 
 class wasm_ref_t(Structure):
@@ -67,7 +85,7 @@ class wasm_val_t(Structure):
     of: wasm_val_union
 
 
-from ._bindings import * # noqa
+from ._bindings import *  # noqa
 
 
 def to_bytes(vec: wasm_byte_vec_t) -> bytearray:
@@ -77,6 +95,10 @@ def to_bytes(vec: wasm_byte_vec_t) -> bytearray:
 
 def to_str(vec: wasm_byte_vec_t) -> str:
     return to_bytes(vec).decode("utf-8")
+
+
+def to_str_raw(ptr: pointer, size: int) -> str:
+    return string_at(ptr, size).decode("utf-8")
 
 
 def str_to_name(s: str, trailing_nul: bool = False) -> wasm_byte_vec_t:

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -8,6 +8,11 @@ from ._exportable import AsExtern
 from ._store import Storelike
 
 
+T = TypeVar('T')
+FUNCTIONS: "Slab[Tuple]"
+LAST_EXCEPTION: Optional[Exception] = None
+
+
 class Func:
     _func: ffi.wasmtime_func_t
 
@@ -216,9 +221,6 @@ def finalize(idx):  # type: ignore
     FUNCTIONS.deallocate(idx or 0)
 
 
-T = TypeVar('T')
-
-
 class Slab(Generic[T]):
     list: List[Union[int, T]]
     next: int
@@ -247,8 +249,7 @@ class Slab(Generic[T]):
         self.next = idx
 
 
-FUNCTIONS: Slab[Tuple] = Slab()
-LAST_EXCEPTION: Optional[Exception] = None
+FUNCTIONS = Slab()
 
 
 @contextmanager

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -1,73 +1,63 @@
 from . import _ffi as ffi
 from ctypes import *
-from wasmtime import Store, GlobalType, Val, WasmtimeError, IntoVal
-from typing import Optional, Any
+from wasmtime import GlobalType, Val, WasmtimeError, IntoVal
+from ._store import Storelike
 
 
 class Global:
-    def __init__(self, store: Store, ty: GlobalType, val: IntoVal):
-        if not isinstance(store, Store):
-            raise TypeError("expected a Store")
+    _global: ffi.wasmtime_global_t
+
+    def __init__(self, store: Storelike, ty: GlobalType, val: IntoVal):
         if not isinstance(ty, GlobalType):
             raise TypeError("expected a GlobalType")
         val = Val._convert(ty.content, val)
-        ptr = POINTER(ffi.wasm_global_t)()
+        global_ = ffi.wasmtime_global_t()
         error = ffi.wasmtime_global_new(
-            store._ptr,
+            store._context,
             ty._ptr,
             byref(val._unwrap_raw()),
-            byref(ptr))
+            byref(global_))
         if error:
             raise WasmtimeError._from_ptr(error)
-        self._ptr = ptr
-        self._owner = None
+        self._global = global_
 
     @classmethod
-    def _from_ptr(cls, ptr: "pointer[ffi.wasm_global_t]", owner: Optional[Any]) -> "Global":
+    def _from_raw(cls, global_: ffi.wasmtime_global_t) -> "Global":
         ty: "Global" = cls.__new__(cls)
-        if not isinstance(ptr, POINTER(ffi.wasm_global_t)):
-            raise TypeError("wrong pointer type")
-        ty._ptr = ptr
-        ty._owner = owner
+        ty._global = global_
         return ty
 
-    @property
-    def type(self) -> GlobalType:
+    def type(self, store: Storelike) -> GlobalType:
         """
         Gets the type of this global as a `GlobalType`
         """
 
-        ptr = ffi.wasm_global_type(self._ptr)
+        ptr = ffi.wasmtime_global_type(store._context, byref(self._global))
         return GlobalType._from_ptr(ptr, None)
 
-    @property
-    def value(self) -> IntoVal:
+    def value(self, store: Storelike) -> IntoVal:
         """
         Gets the current value of this global
 
         Returns a native python type
         """
-        raw = ffi.wasm_val_t()
-        ffi.wasm_global_get(self._ptr, byref(raw))
+        raw = ffi.wasmtime_val_t()
+        ffi.wasmtime_global_get(store._context, byref(self._global), byref(raw))
         val = Val(raw)
         if val.value:
             return val.value
         else:
             return val
 
-    @value.setter
-    def value(self, val: IntoVal) -> None:
+    def set_value(self, store: Storelike, val: IntoVal) -> None:
         """
         Sets the value of this global to a new value
         """
-        val = Val._convert(self.type.content, val)
-        error = ffi.wasmtime_global_set(self._ptr, byref(val._unwrap_raw()))
+        val = Val._convert(self.type(store).content, val)
+        error = ffi.wasmtime_global_set(store._context, byref(self._global), byref(val._unwrap_raw()))
         if error:
             raise WasmtimeError._from_ptr(error)
 
-    def _as_extern(self) -> "pointer[ffi.wasm_extern_t]":
-        return ffi.wasm_global_as_extern(self._ptr)
-
-    def __del__(self) -> None:
-        if hasattr(self, '_owner') and self._owner is None:
-            ffi.wasm_global_delete(self._ptr)
+    def _as_extern(self) -> ffi.wasmtime_extern_t:
+        union = ffi.wasmtime_extern_union(global_=self._global)
+        return ffi.wasmtime_extern_t(ffi.WASMTIME_EXTERN_GLOBAL, union)

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -1,18 +1,41 @@
 from . import _ffi as ffi
-from ctypes import pointer, byref, c_uint64
+from ctypes import pointer, byref, c_uint64, cast, c_void_p, CFUNCTYPE
 from wasmtime import Engine, WasmtimeError
+from . import _value as value
+import typing
+
+if typing.TYPE_CHECKING:
+    from ._wasi import WasiConfig
 
 
 class Store:
-    _ptr: "pointer[ffi.wasm_store_t]"
+    _ptr: "pointer[ffi.wasmtime_store_t]"
+    _context: "pointer[ffi.wasmtime_context_t]"
 
-    def __init__(self, engine: Engine = None):
+    def __init__(self, engine: Engine = None, data: typing.Optional[typing.Any] = None):
+
         if engine is None:
             engine = Engine()
         elif not isinstance(engine, Engine):
             raise TypeError("expected an Engine")
-        self._ptr = ffi.wasm_store_new(engine._ptr)
+        data_id = ffi.c_void_p(0)
+        finalize = cast(0, CFUNCTYPE(None, c_void_p))
+        if data:
+            data_id = value._intern(data)
+            finalize = value._externref_finalizer
+        self._ptr = ffi.wasmtime_store_new(engine._ptr, data_id, finalize)
+        self._context = ffi.wasmtime_store_context(self._ptr)
         self.engine = engine
+
+    def data(self) -> typing.Optional[typing.Any]:
+        """
+        TODO
+        """
+        data = ffi.wasmtime_context_get_data(self._context)
+        if data:
+            return value._unintern(data)
+        else:
+            return None
 
     def interrupt_handle(self) -> "InterruptHandle":
         """
@@ -37,7 +60,7 @@ class Store:
         like more precise control over when unreferenced `externref` values are
         deallocated.
         """
-        ffi.wasmtime_store_gc(self._ptr)
+        ffi.wasmtime_context_gc(self._context)
 
     def add_fuel(self, fuel: int) -> None:
         """
@@ -51,7 +74,7 @@ class Store:
         Raises a `WasmtimeError` if this store's configuration is not configured
         to consume fuel.
         """
-        err = ffi.wasmtime_store_add_fuel(self._ptr, fuel)
+        err = ffi.wasmtime_context_add_fuel(self._context, fuel)
         if err:
             raise WasmtimeError._from_ptr(err)
 
@@ -63,14 +86,23 @@ class Store:
         to consume fuel.
         """
         fuel = c_uint64(0)
-        ok = ffi.wasmtime_store_fuel_consumed(self._ptr, byref(fuel))
+        ok = ffi.wasmtime_context_fuel_consumed(self._context, byref(fuel))
         if ok:
             return fuel.value
         raise WasmtimeError("fuel is not enabled in this store's configuration")
 
+    def set_wasi(self, wasi: "WasiConfig") -> None:
+        """
+        TODO
+        """
+        error = ffi.wasmtime_context_set_wasi(self._context, wasi._ptr)
+        delattr(wasi, '_ptr')
+        if error:
+            raise WasmtimeError._from_ptr(error)
+
     def __del__(self) -> None:
         if hasattr(self, '_ptr'):
-            ffi.wasm_store_delete(self._ptr)
+            ffi.wasmtime_store_delete(self._ptr)
 
 
 class InterruptHandle:
@@ -85,7 +117,7 @@ class InterruptHandle:
     def __init__(self, store: Store):
         if not isinstance(store, Store):
             raise TypeError("expected a Store")
-        ptr = ffi.wasmtime_interrupt_handle_new(store._ptr)
+        ptr = ffi.wasmtime_interrupt_handle_new(store._context)
         if not ptr:
             raise WasmtimeError("interrupts not enabled on Store")
         self._ptr = ptr
@@ -100,3 +132,10 @@ class InterruptHandle:
     def __del__(self) -> None:
         if hasattr(self, '_ptr'):
             ffi.wasmtime_interrupt_handle_delete(self._ptr)
+
+
+if typing.TYPE_CHECKING:
+    from ._func import Caller
+
+
+Storelike = typing.Union[Store, "Caller"]

--- a/wasmtime/_trap.py
+++ b/wasmtime/_trap.py
@@ -1,24 +1,16 @@
 from . import _ffi as ffi
 from ctypes import byref, POINTER, pointer, c_int
-from wasmtime import Store, WasmtimeError
 from typing import Optional, Any, List
 
 
 class Trap(Exception):
-    def __init__(self, store: Store, message: str):
+    def __init__(self, message: str):
         """
-        Creates a new trap in `store` with the given `message`
+        Creates a new trap with the given `message`
         """
 
-        if not isinstance(store, Store):
-            raise TypeError("expected a Store")
-        if not isinstance(message, str):
-            raise TypeError("expected a string")
-        message_raw = ffi.str_to_name(message, trailing_nul=True)
-        ptr = ffi.wasm_trap_new(store._ptr, byref(message_raw))
-        if not ptr:
-            raise WasmtimeError("failed to create trap")
-        self._ptr = ptr
+        vec = message.encode('utf-8')
+        self._ptr = ffi.wasmtime_trap_new(ffi.create_string_buffer(vec), len(vec))
 
     @classmethod
     def _from_ptr(cls, ptr: "pointer[ffi.wasm_trap_t]") -> "Trap":

--- a/wasmtime/_types.py
+++ b/wasmtime/_types.py
@@ -238,7 +238,7 @@ class Limits:
         min = val.contents.min
         max = val.contents.max
         if max == 0xffffffff:
-            max = None
+            return Limits(min, None)
         return Limits(min, max)
 
 
@@ -322,16 +322,16 @@ class MemoryType:
 
 
 class ModuleType:
-    _ptr: "pointer[ffi.wasm_moduletype_t]"
+    _ptr: "pointer[ffi.wasmtime_moduletype_t]"
     _owner: Optional[Any]
 
     def __init__(self) -> None:
         raise WasmtimeError("cannot create a `ModuleType` currently")
 
     @classmethod
-    def _from_ptr(cls, ptr: "pointer[ffi.wasm_moduletype_t]", owner: Optional[Any]) -> "ModuleType":
+    def _from_ptr(cls, ptr: "pointer[ffi.wasmtime_moduletype_t]", owner: Optional[Any]) -> "ModuleType":
         ty: "ModuleType" = cls.__new__(cls)
-        if not isinstance(ptr, POINTER(ffi.wasm_moduletype_t)):
+        if not isinstance(ptr, POINTER(ffi.wasmtime_moduletype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
         ty._owner = owner
@@ -344,7 +344,7 @@ class ModuleType:
         """
 
         exports = ExportTypeList()
-        ffi.wasm_moduletype_exports(self._ptr, byref(exports.vec))
+        ffi.wasmtime_moduletype_exports(self._ptr, byref(exports.vec))
         ret = []
         for i in range(0, exports.vec.size):
             ret.append(ExportType._from_ptr(exports.vec.data[i], exports))
@@ -357,31 +357,31 @@ class ModuleType:
         """
 
         imports = ImportTypeList()
-        ffi.wasm_moduletype_imports(self._ptr, byref(imports.vec))
+        ffi.wasmtime_moduletype_imports(self._ptr, byref(imports.vec))
         ret = []
         for i in range(0, imports.vec.size):
             ret.append(ImportType._from_ptr(imports.vec.data[i], imports))
         return ret
 
     def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
-        return ffi.wasm_moduletype_as_externtype_const(self._ptr)
+        return ffi.wasmtime_moduletype_as_externtype(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '_owner') and self._owner is None:
-            ffi.wasm_moduletype_delete(self._ptr)
+            ffi.wasmtime_moduletype_delete(self._ptr)
 
 
 class InstanceType:
-    _ptr: "pointer[ffi.wasm_instancetype_t]"
+    _ptr: "pointer[ffi.wasmtime_instancetype_t]"
     _owner: Optional[Any]
 
     def __init__(self) -> None:
         raise WasmtimeError("cannot create an `InstanceType` currently")
 
     @classmethod
-    def _from_ptr(cls, ptr: "pointer[ffi.wasm_instancetype_t]", owner: Optional[Any]) -> "InstanceType":
+    def _from_ptr(cls, ptr: "pointer[ffi.wasmtime_instancetype_t]", owner: Optional[Any]) -> "InstanceType":
         ty: "InstanceType" = cls.__new__(cls)
-        if not isinstance(ptr, POINTER(ffi.wasm_instancetype_t)):
+        if not isinstance(ptr, POINTER(ffi.wasmtime_instancetype_t)):
             raise TypeError("wrong pointer type")
         ty._ptr = ptr
         ty._owner = owner
@@ -394,39 +394,39 @@ class InstanceType:
         """
 
         exports = ExportTypeList()
-        ffi.wasm_instancetype_exports(self._ptr, byref(exports.vec))
+        ffi.wasmtime_instancetype_exports(self._ptr, byref(exports.vec))
         ret = []
         for i in range(0, exports.vec.size):
             ret.append(ExportType._from_ptr(exports.vec.data[i], exports))
         return ret
 
     def _as_extern(self) -> "pointer[ffi.wasm_externtype_t]":
-        return ffi.wasm_instancetype_as_externtype_const(self._ptr)
+        return ffi.wasmtime_instancetype_as_externtype(self._ptr)
 
     def __del__(self) -> None:
         if hasattr(self, '_owner') and self._owner is None:
-            ffi.wasm_instancetype_delete(self._ptr)
+            ffi.wasmtime_instancetype_delete(self._ptr)
 
 
 def wrap_externtype(ptr: "pointer[ffi.wasm_externtype_t]", owner: Optional[Any]) -> "AsExternType":
     if not isinstance(ptr, POINTER(ffi.wasm_externtype_t)):
         raise TypeError("wrong pointer type")
-    val = ffi.wasm_externtype_as_functype_const(ptr)
+    val = ffi.wasm_externtype_as_functype(ptr)
     if val:
         return FuncType._from_ptr(val, owner)
-    val = ffi.wasm_externtype_as_tabletype_const(ptr)
+    val = ffi.wasm_externtype_as_tabletype(ptr)
     if val:
         return TableType._from_ptr(val, owner)
-    val = ffi.wasm_externtype_as_globaltype_const(ptr)
+    val = ffi.wasm_externtype_as_globaltype(ptr)
     if val:
         return GlobalType._from_ptr(val, owner)
-    val = ffi.wasm_externtype_as_memorytype_const(ptr)
+    val = ffi.wasm_externtype_as_memorytype(ptr)
     if val:
         return MemoryType._from_ptr(val, owner)
-    val = ffi.wasm_externtype_as_moduletype_const(ptr)
+    val = ffi.wasmtime_externtype_as_moduletype(ptr)
     if val:
         return ModuleType._from_ptr(val, owner)
-    val = ffi.wasm_externtype_as_instancetype_const(ptr)
+    val = ffi.wasmtime_externtype_as_instancetype(ptr)
     if val:
         return InstanceType._from_ptr(val, owner)
     raise WasmtimeError("unknown extern type")

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -1,18 +1,28 @@
 from ._error import WasmtimeError
 from ._ffi import *
-from wasmtime import ValType
+from ._types import ValType
 import ctypes
-import threading
 import typing
 
 
 @ctypes.CFUNCTYPE(None, c_void_p)
 def _externref_finalizer(extern_id: int) -> None:
-    with Val._pinned_refs_lock:
-        Val._id_to_ref_count[extern_id] -= 1
-        if Val._id_to_ref_count[extern_id] == 0:
-            del Val._id_to_ref_count[extern_id]
-            del Val._id_to_extern[extern_id]
+    Val._id_to_ref_count[extern_id] -= 1
+    if Val._id_to_ref_count[extern_id] == 0:
+        del Val._id_to_ref_count[extern_id]
+        del Val._id_to_extern[extern_id]
+
+
+def _intern(obj: typing.Any) -> c_void_p:
+    extern_id = id(obj)
+    Val._id_to_ref_count.setdefault(extern_id, 0)
+    Val._id_to_ref_count[extern_id] += 1
+    Val._id_to_extern[extern_id] = obj
+    return ctypes.c_void_p(extern_id)
+
+
+def _unintern(val: int) -> typing.Any:
+    return Val._id_to_extern.get(val)
 
 
 class Val:
@@ -20,14 +30,11 @@ class Val:
     # pin them in `_id_to_extern`. Additionally, we might make multiple
     # `externref`s to the same extern value, so we count how many references
     # we've created in `_id_to_ref_count`, and only remove a value's entry from
-    # `_id_to_extern` once the ref count is zero. Finally, we protect both of
-    # these maps with a mutex because `externref`s can be created from any
-    # thread.
-    _pinned_refs_lock = threading.Lock()
+    # `_id_to_extern` once the ref count is zero.
     _id_to_extern: typing.Dict[int, typing.Any] = {}
     _id_to_ref_count: typing.Dict[int, int] = {}
 
-    _raw: typing.Optional[wasm_val_t]
+    _raw: typing.Optional[wasmtime_val_t]
 
     @classmethod
     def i32(cls, val: int) -> "Val":
@@ -36,8 +43,7 @@ class Val:
         """
         if not isinstance(val, int):
             raise TypeError("expected an integer")
-        ffi = wasm_val_t(WASM_I32)
-        ffi.of.i32 = val
+        ffi = wasmtime_val_t(WASMTIME_I32, wasmtime_valunion(i32=val))
         return Val(ffi)
 
     @classmethod
@@ -47,8 +53,7 @@ class Val:
         """
         if not isinstance(val, int):
             raise TypeError("expected an integer")
-        ffi = wasm_val_t(WASM_I64)
-        ffi.of.i64 = val
+        ffi = wasmtime_val_t(WASMTIME_I64, wasmtime_valunion(i64=val))
         return Val(ffi)
 
     @classmethod
@@ -58,8 +63,7 @@ class Val:
         """
         if not isinstance(val, float):
             raise TypeError("expected a float")
-        ffi = wasm_val_t(WASM_F32)
-        ffi.of.f32 = val
+        ffi = wasmtime_val_t(WASMTIME_F32, wasmtime_valunion(f32=val))
         return Val(ffi)
 
     @classmethod
@@ -69,36 +73,24 @@ class Val:
         """
         if not isinstance(val, float):
             raise TypeError("expected a float")
-        ffi = wasm_val_t(WASM_F64)
-        ffi.of.f64 = val
+        ffi = wasmtime_val_t(WASMTIME_F64, wasmtime_valunion(f64=val))
         return Val(ffi)
 
     @classmethod
     def externref(cls, extern: typing.Optional[typing.Any]) -> "Val":
-        ffi = wasm_val_t(WASM_ANYREF)
-        ffi.of.ref = None
-
-        extern_id = id(extern)
-        with Val._pinned_refs_lock:
-            Val._id_to_ref_count.setdefault(extern_id, 0)
-            Val._id_to_ref_count[extern_id] += 1
-            Val._id_to_extern[extern_id] = extern
-        wasmtime_externref_new_with_finalizer(ctypes.c_void_p(extern_id),
-                                              _externref_finalizer,
-                                              ctypes.byref(ffi))
+        ffi = wasmtime_val_t(WASMTIME_EXTERNREF)
+        ffi.of.externref = POINTER(wasmtime_externref_t)()
+        if extern is not None:
+            extern_id = _intern(extern)
+            ptr = wasmtime_externref_new(extern_id, _externref_finalizer)
+            ffi.of.externref = ptr
         return Val(ffi)
 
     @classmethod
     def funcref(cls, f: "typing.Optional[wasmtime.Func]") -> "Val":
-        ffi = wasm_val_t(WASM_FUNCREF)
-        ffi.of.ref = None
-        if f is None:
-            return Val(ffi)
-
-        if not isinstance(f, wasmtime.Func):
-            raise TypeError("Expected a Func or None")
-
-        wasmtime_func_as_funcref(f._ptr, ctypes.byref(ffi))
+        ffi = wasmtime_val_t(WASMTIME_FUNCREF)
+        if f:
+            ffi.of.funcref = f._func
         return Val(ffi)
 
     @classmethod
@@ -114,9 +106,7 @@ class Val:
             return Val.funcref(None)
         raise WasmtimeError("Invalid reference type for `ref_null`: %s" % ty)
 
-    def __init__(self, raw: wasm_val_t):
-        if not isinstance(raw, wasm_val_t):
-            raise TypeError("expected a raw value")
+    def __init__(self, raw: wasmtime_val_t):
         self._raw = raw
 
     def __eq__(self, rhs: typing.Any) -> typing.Any:
@@ -126,13 +116,15 @@ class Val:
 
     def __del__(self) -> None:
         if hasattr(self, "_raw") and self._raw is not None:
-            wasm_val_delete(ctypes.byref(self._raw))
+            wasmtime_val_delete(ctypes.byref(self._raw))
 
     def _clone(self) -> "Val":
         raw = self._unwrap_raw()
-        clone = wasm_val_t(WASM_I32)
-        wasm_val_copy(ctypes.byref(clone), byref(raw))
-        return Val(clone)
+        if raw.kind == WASMTIME_EXTERNREF and raw.of.externref:
+            externref = wasmtime_externref_clone(raw.of.externref)
+            raw = wasmtime_val_t(WASMTIME_EXTERNREF)
+            raw.of.externref = externref
+        return Val(raw)
 
     @classmethod
     def _convert(cls, ty: ValType, val: "IntoVal") -> "Val":
@@ -161,32 +153,32 @@ class Val:
             return Val.externref(val)
         raise TypeError("don't know how to convert %r to %s" % (val, ty))
 
-    def _into_raw(self) -> wasm_val_t:
+    def _into_raw(self) -> wasmtime_val_t:
         raw = self._unwrap_raw()
         self._raw = None
         return raw
 
-    def _unwrap_raw(self) -> wasm_val_t:
-        if isinstance(self._raw, wasm_val_t):
+    def _unwrap_raw(self) -> wasmtime_val_t:
+        if isinstance(self._raw, wasmtime_val_t):
             return self._raw
         else:
             raise WasmtimeError("use of moved `Val`")
 
     @classmethod
-    def _value(cls, raw: wasm_val_t) -> typing.Union[int, float, "wasmtime.Func", typing.Any]:
-        if raw.kind == WASM_I32.value:
+    def _value(cls, raw: wasmtime_val_t) -> typing.Union[int, float, "wasmtime.Func", typing.Any]:
+        if raw.kind == WASMTIME_I32.value:
             return raw.of.i32
-        if raw.kind == WASM_I64.value:
+        if raw.kind == WASMTIME_I64.value:
             return raw.of.i64
-        if raw.kind == WASM_F32.value:
+        if raw.kind == WASMTIME_F32.value:
             return raw.of.f32
-        if raw.kind == WASM_F64.value:
+        if raw.kind == WASMTIME_F64.value:
             return raw.of.f64
-        if raw.kind == WASM_ANYREF.value:
+        if raw.kind == WASMTIME_EXTERNREF.value:
             return Val._as_externref(raw)
-        if raw.kind == WASM_FUNCREF.value:
+        if raw.kind == WASMTIME_FUNCREF.value:
             return Val._as_funcref(raw)
-        raise WasmtimeError("Unkown `wasm_valkind_t`: {}".format(raw.kind))
+        raise WasmtimeError("Unkown `wasmtime_valkind_t`: {}".format(raw.kind))
 
     @property
     def value(self) -> typing.Union[int, float, "wasmtime.Func", typing.Any]:
@@ -203,8 +195,8 @@ class Val:
         Get the 32-bit integer value of this value, or `None` if it's not an i32
         """
         raw = self._unwrap_raw()
-        if raw.kind == WASM_I32.value:
-            return raw.of.i32
+        if raw.kind == WASMTIME_I32.value:
+            return int(raw.of.i32)
         else:
             return None
 
@@ -223,7 +215,7 @@ class Val:
         Get the 32-bit float value of this value, or `None` if it's not an f32
         """
         raw = self._unwrap_raw()
-        if raw.kind == WASM_F32.value:
+        if raw.kind == WASMTIME_F32.value:
             return raw.of.f32
         else:
             return None
@@ -233,21 +225,19 @@ class Val:
         Get the 64-bit float value of this value, or `None` if it's not an f64
         """
         raw = self._unwrap_raw()
-        if raw.kind == WASM_F64.value:
+        if raw.kind == WASMTIME_F64.value:
             return raw.of.f64
         else:
             return None
 
     @classmethod
-    def _as_externref(cls, raw: wasm_val_t) -> typing.Optional[typing.Any]:
-        if raw.kind != WASM_ANYREF.value:
+    def _as_externref(cls, raw: wasmtime_val_t) -> typing.Optional[typing.Any]:
+        if raw.kind != WASMTIME_EXTERNREF.value:
             return None
-        extern_id = ctypes.c_void_p(0)
-        wasmtime_externref_data(ctypes.byref(raw), ctypes.byref(extern_id))
-        if extern_id.value is None:
+        if not raw.of.externref:
             return None
-        with Val._pinned_refs_lock:
-            return Val._id_to_extern.get(extern_id.value)
+        extern_id = wasmtime_externref_data(raw.of.externref)
+        return _unintern(extern_id)
 
     def as_externref(self) -> typing.Optional[typing.Any]:
         """
@@ -257,14 +247,13 @@ class Val:
         return Val._as_externref(self._unwrap_raw())
 
     @classmethod
-    def _as_funcref(cls, raw: wasm_val_t) -> typing.Optional["wasmtime.Func"]:
-        if raw.kind != WASM_FUNCREF.value:
+    def _as_funcref(cls, raw: wasmtime_val_t) -> typing.Optional["wasmtime.Func"]:
+        if raw.kind != WASMTIME_FUNCREF.value:
             return None
-        ptr = wasmtime_funcref_as_func(ctypes.byref(raw))
-        if ptr:
-            return wasmtime.Func._from_ptr(ptr, None)
+        if raw.of.funcref.store_id == 0:
+            return None
         else:
-            return None
+            return wasmtime.Func._from_raw(raw.of.funcref)
 
     def as_funcref(self) -> typing.Optional["wasmtime.Func"]:
         """
@@ -278,8 +267,23 @@ class Val:
         """
         Returns the `ValType` corresponding to this `Val`
         """
-        ptr = dll.wasm_valtype_new(self._unwrap_raw().kind)
-        return ValType._from_ptr(ptr, None)
+        kind = self._unwrap_raw().kind
+        if kind == WASMTIME_I32.value:
+            return ValType.i32()
+        elif kind == WASMTIME_I64.value:
+            return ValType.i64()
+        elif kind == WASMTIME_F32.value:
+            return ValType.f32()
+        elif kind == WASMTIME_F64.value:
+            return ValType.f64()
+        elif kind == WASMTIME_V128.value:
+            raise Exception("unimplemented v128 type")
+        elif kind == WASMTIME_EXTERNREF.value:
+            return ValType.externref()
+        elif kind == WASMTIME_FUNCREF.value:
+            return ValType.funcref()
+        else:
+            raise Exception("unknown kind %d" % kind.value)
 
 
 IntoVal = typing.Union[

--- a/wasmtime/_wat2wasm.py
+++ b/wasmtime/_wat2wasm.py
@@ -24,10 +24,9 @@ def wat2wasm(wat: typing.Union[str, bytes]) -> bytearray:
 
     if isinstance(wat, str):
         wat = wat.encode('utf8')
-    wat_buffer = cast(create_string_buffer(wat), POINTER(c_uint8))
-    wat_bytes = ffi.wasm_byte_vec_t(len(wat), wat_buffer)
+    wat_buffer = create_string_buffer(wat)
     wasm = ffi.wasm_byte_vec_t()
-    error = ffi.wasmtime_wat2wasm(byref(wat_bytes), byref(wasm))
+    error = ffi.wasmtime_wat2wasm(wat_buffer, len(wat), byref(wasm))
     if error:
         raise WasmtimeError._from_ptr(error)
     else:


### PR DESCRIPTION
This commit updates wasmtime-py to account for [RFC 11] and the changes
in Wasmtime's own C API. Note that this is a breaking change for this
binding, notably requiring that `Store` is a uniquely-owned value now
which must be passed in as context to most methods that operate with a
store. More details are in the commit itself and updated tests and such.

[RFC 11]: https://github.com/bytecodealliance/rfcs/pull/11