### PR TITLE
Fix `wasmtime.loader` with multiple functions

### DIFF
--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -86,7 +86,7 @@ class _WasmtimeLoader(Loader):
             # to our loader's store
             if isinstance(item, Func):
                 func = item
-                item = lambda *args: func(store, *args)  # noqa
+                item = lambda *args,func=func: func(store, *args)  # noqa
             module.__dict__[export.name] = item
 
 


### PR DESCRIPTION
This is showing off how I'm not exactly a Python expert, but the
previous iteration didn't work because lambda closure captures didn't
work as I expected!

Closes #65