### PR TITLE
Added exported function to the loader wasi wat

### DIFF
--- a/examples/loader.py
+++ b/examples/loader.py
@@ -18,3 +18,8 @@ assert(loader_load_wasm.call_dependency() == 4)
 # This imports our `loader_load_python.wat` file which then imports its own
 # python file.
 assert(loader_load_python.call_python() == 42)
+
+# This imports our `loader_load_wasi.wat`, which in turn imports
+# the random_get functionality from the wasi runtime environment
+random_value = loader_load_wasi.wasi_random()
+assert(random_value >= 0 and random_value < 256)

--- a/examples/loader_load_wasi.wat
+++ b/examples/loader_load_wasi.wat
@@ -1,3 +1,13 @@
 (module
-    (import "wasi_snapshot_preview1" "random_get" (func (param i32 i32) (result i32)))
-)
+    (import "wasi_snapshot_preview1" "random_get" (func $random_get (param i32 i32) (result i32)))
+    (memory 1)
+    (export "memory" (memory 0))
+    (func $wasi_random (export "wasi_random")
+      (result i32)
+      (call $random_get
+        (i32.const 0) ;; buffer start position
+	(i32.const 1)) ;; buffer length 1 bytes
+      ;; this bounds our random between 0-255
+      drop ;; random_get returns an error code
+      (i32.const 0)
+      i32.load))


### PR DESCRIPTION
The loader imports the `loader_load_wasi.wat` file which imports `random_get` from WASI. This PR extends the example to export a function which we can call in the host environment that leverages the `random_get` function.