### PR TITLE
add support for macOS arm64, build wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,10 @@ jobs:
         python setup.py bdist_wheel --plat-name macosx-10-13-x86_64
     - run: |
         git clean -fdx wasmtime build
+        python download-wasmtime.py darwin arm64
+        python setup.py bdist_wheel --plat-name macosx-11-0-arm64
+    - run: |
+        git clean -fdx wasmtime build
         python download-wasmtime.py win32 x86_64
         python setup.py bdist_wheel --plat-name win-amd64
 

--- a/download-wasmtime.py
+++ b/download-wasmtime.py
@@ -17,6 +17,8 @@ def main(platform, arch):
         version = fh.read().strip()
     if arch == 'AMD64':
         arch = 'x86_64'
+    if arch == 'arm64':
+        arch = 'aarch64'
     if platform == 'linux':
         filename = 'wasmtime-v{}-{}-linux-c-api.tar.xz'.format(version, arch)
         libname = '_libwasmtime.so'

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setuptools.setup(
     extras_require={
         'testing': [
             'coverage',
+            # remove flake8 once https://github.com/tholo/pytest-flake8/issues/87 is fixed
+            # and the new version of pytest-flake8 is released
+            'flake8==4.0.1',
             'pytest',
             'pycparser',
             'pytest-flake8',

--- a/wasmtime/_ffi.py
+++ b/wasmtime/_ffi.py
@@ -21,6 +21,8 @@ else:
 machine = platform.machine()
 if machine == 'AMD64':
     machine = 'x86_64'
+if machine == 'arm64':
+    machine = 'aarch64'
 if machine != 'x86_64' and machine != 'aarch64':
     raise RuntimeError("unsupported architecture for wasmtime: {}".format(machine))
 


### PR DESCRIPTION
This PR adds support for macOS arm64 platforms. Changes are as follows:

1. Handle platform.machine() == arm64 for macOS.
    
    Upstream wasmtime releases use aarch64-macos as part of the file name. On aarch64 macOS, platform.machine() returns 'arm64' instead. With this change, download-wasmtime.py correctly downloads aarch64-macos binaries and _ffi.py correctly loads them.

2. Build wheels for macOS arm64 in CI. This should close #79.



I ran tests on macOS-arm64 with python 3.8.9 using `pytest`, and two failures were reported:
```
FAILED tests/test_trap.py::TestTrap::test_frames - AssertionError: 1 != 3
FAILED tests/test_trap.py::TestTrap::test_frames_no_module - AssertionError: 0 != 1
```
(The PR is "draft" because of this failure.)

I have also tested a relatively simple project (`astyle` code formatter compiled to WebAssembly) with this branch, and it worked correctly.