### PR TITLE
Fix 404s in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ All commits/PRs run the full test suite, and check for code style
 and other errors using [flake8](https://flake8.pycqa.org/).
 
 [Bytecode Alliance]: https://bytecodealliance.org/
-[Code of Conduct]: CODE_OF_CONDUCT.md
-[Organizational Code of Conduct]: ORG_CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
+[Organizational Code of Conduct]: https://github.com/bytecodealliance/wasmtime/blob/main/ORG_CODE_OF_CONDUCT.md
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 [apidoc]: https://bytecodealliance.github.io/wasmtime-py/


### PR DESCRIPTION
I was looking at wasmtime-py's `CONTRIBUTING.md` for inspiration for wasmitme-rb and found 2 dead links for markdown files:
- `CODE_OF_CONDUCT.md`
- `ORG_CODE_OF_CONDUCT.md`

I'm fixing these by linking to wasmtime's.

There's another dead link for test coverage (https://bytecodealliance.github.io/wasmtime-py/coverage/), but wasn't sure how to fix that one.