### PR TITLE
Fix Global.value to use None check instead of truthy check

### DIFF
--- a/tests/test_global.py
+++ b/tests/test_global.py
@@ -17,6 +17,15 @@ class TestGlobal(unittest.TestCase):
         self.assertEqual(g.value(store), 2)
         self.assertTrue(isinstance(g.type(store), GlobalType))
 
+    def test_falsy(self):
+        store = Store()
+        ty = GlobalType(ValType.i64(), True)
+        g = Global(store, ty, Val.i64(0))
+        val = g.value(store)
+
+        self.assertEqual(val, 0)
+        self.assertTrue(isinstance(val, int))
+
     def test_errors(self):
         store = Store()
         ty = GlobalType(ValType.i32(), True)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -44,7 +44,7 @@ class Global:
         raw = ffi.wasmtime_val_t()
         ffi.wasmtime_global_get(store._context, byref(self._global), byref(raw))
         val = Val(raw)
-        if val.value:
+        if val.value is not None:
             return val.value
         else:
             return val


### PR DESCRIPTION
Implements the change suggested in #141.