### PR TITLE
Do not fail GitHub Actions on push to test PyPI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,7 @@ jobs:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+        skip-existing: true
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
Do not fail pull requests that do not upgrade the version of wasmtime-py as discussed at:
https://github.com/pypa/gh-action-pypi-publish#tolerating-release-package-file-duplicates