### PR TITLE
Add module name to missing assignment

### DIFF
--- a/tests/codegen/test_external_types.py
+++ b/tests/codegen/test_external_types.py
@@ -1,0 +1,85 @@
+from . import bindgen, REALLOC
+from wasmtime import Store
+
+module = """
+(component $OuterComp
+
+   (type $types
+        (instance
+            (type $runtime-value (variant
+                (case "id" string) (case "id2" string)))
+            (export $runtime-value-export "runtime-value"
+                (type (eq $runtime-value)))
+        )
+    )
+    (import "types" (instance $types (type $types)))
+    (alias export $types "runtime-value" (type $runtime-value-export))
+
+    (import "host" (instance $inst
+        (alias outer $OuterComp 1 (type $runtime-value))
+        (export $export "runtime-value" (type (eq $runtime-value)))
+        (export "some-fn" (func (param "v" $export) (result $export)))
+    ))
+
+    (core module $libc
+        (memory (export "mem") 1)
+        {}
+    )
+    (core instance $libc (instantiate $libc))
+
+    (core module $mod
+        (import "libc" "mem" (memory 1))
+        (import "" "lowered-fn-import"
+            (func $lowered-fn (param i32 i32 i32 i32)))
+
+        (func (export "core-fn") (param i32 i32 i32) (result i32)
+            (call $lowered-fn
+                (local.get 0) (local.get 1) (local.get 2) (local.get 2))
+            (local.get 2))
+    )
+
+    (core func $lowered-fn
+        (canon lower (func $inst "some-fn") (memory $libc "mem")
+            (realloc (func $libc "realloc"))))
+
+    (core instance $inst
+        (instantiate $mod
+            (with "libc" (instance $libc))
+            (with "" (instance
+                (export "lowered-fn-import" (func $lowered-fn))
+             ))
+        )
+    )
+
+    (type $runtime-value (variant (case "id" string) (case "id2" string)))
+    (func $lifted-core-fn (param "a" $runtime-value) (result $runtime-value)
+        (canon lift (core func $inst "core-fn") (memory $libc "mem")
+            (realloc (func $libc "realloc"))))
+
+    (instance (export "e")
+        (export "runtime-value" (type $runtime-value))
+        (export "some-fn" (func $lifted-core-fn))
+    )
+
+)
+""".format(REALLOC)
+bindgen('external_types', module)
+
+from .generated.external_types import ExternalTypes, ExternalTypesImports, imports
+from .generated.external_types.imports import host
+from .generated.external_types import e
+
+
+class Host(imports.Host):
+
+    def some_fn(self, v: host.RuntimeValue) -> host.RuntimeValue:
+        return v
+
+
+def test_bindings(tmp_path):
+    store = Store()
+    wasm = ExternalTypes(store, ExternalTypesImports(None, host=Host()))
+
+    exports = wasm.e()
+    rt_id = exports.some_fn(store, e.RuntimeValueId('1234'))
+    assert rt_id == e.RuntimeValueId('1234')


### PR DESCRIPTION
This commit adds the qualified module name to assignement that are imported from a separate modules.

The motivation for this is that currently this will cause a NameError. For example, if we have types defined in a Python module named demo_types, the variant assignement generated by bindgen will be:
```python
from ..imports import demo_types
variant = RuntimeValueString(list)
```
Which will generate the following error:
```console
Traceback (most recent call last):
  File "/wasmtime-py/demo-module/demo.py", line 12, in <module>
    main()
  File "wasmtime-py/demo-module/demo.py", line 8, in main
    ret = wit.something(store)
          ^^^^^^^^^^^^^^^^^^^^
  File "wasmtime-py/demo-module/dist/exports/wit.py", line 27,
  in something
    variant = RuntimeValueString(list)
              ^^^^^^^^^^^^^^^^^^
NameError: name 'RuntimeValueString' is not defined
```

With this commit, the generated assignement will instead be:
```python
from ..imports import demo_types
variant = demo_types.RuntimeValueString(list)
```

Fixes: https://github.com/bytecodealliance/wasmtime-py/issues/155