### PR TITLE
Fix lookup of exports in worlds

### DIFF
--- a/tests/codegen/foo.wat
+++ b/tests/codegen/foo.wat
@@ -1,0 +1,17 @@
+
+    (component
+        (import "i" (instance $i
+          (export "f1" (func))
+          (export "f2" (func))
+        ))
+
+        (core func $f1 (canon lower (func $i "f1")))
+        (core func $f2 (canon lower (func $i "f2")))
+
+        (func $f1' (canon lift (core func $f1)))
+        (func $f2' (canon lift (core func $f2)))
+
+        (instance (export "i1")
+            (export "f1" (func $f1')))
+        ;;(export "i2" (instance (export "f2" (func $f2))))
+    )

--- a/tests/codegen/test_two_exports.py
+++ b/tests/codegen/test_two_exports.py
@@ -1,0 +1,42 @@
+from . import bindgen
+from wasmtime import Store
+
+module = """
+    (component
+        (import "i" (instance $i
+          (export "f1" (func))
+          (export "f2" (func))
+        ))
+
+        (core func $f1 (canon lower (func $i "f1")))
+        (core func $f2 (canon lower (func $i "f2")))
+
+        (func $f1' (canon lift (core func $f1)))
+        (func $f2' (canon lift (core func $f2)))
+
+        (instance (export "i1") (export "f1" (func $f1')))
+        (instance (export "i2") (export "f2" (func $f2')))
+    )
+"""
+bindgen('two_exports', module)
+
+from .generated.two_exports import Root, RootImports, imports
+
+
+class Host(imports.I):
+    def f1(self) -> None:
+        self.f1_hit = True
+
+    def f2(self) -> None:
+        self.f2_hit = True
+
+
+def test_bindings():
+    store = Store()
+    host = Host()
+    wasm = Root(store, RootImports(i=host))
+
+    wasm.i1().f1(store)
+    assert(host.f1_hit)
+    wasm.i2().f2(store)
+    assert(host.f2_hit)

--- a/wasmtime/bindgen/__init__.py
+++ b/wasmtime/bindgen/__init__.py
@@ -24,17 +24,17 @@ class WasiRandom(Random):
 
 class WasiStdin(Stdin):
     def get_stdin(self) -> streams.InputStream:
-        return sys.stdin.fileno()
+        return 0
 
 
 class WasiStdout(Stdout):
     def get_stdout(self) -> streams.OutputStream:
-        return sys.stdout.fileno()
+        return 1
 
 
 class WasiStderr(Stderr):
     def get_stderr(self) -> streams.OutputStream:
-        return sys.stderr.fileno()
+        return 2
 
 
 class WasiPreopens(Preopens):
@@ -47,12 +47,16 @@ class WasiStreams(streams.Streams):
         return None
 
     def write(self, this: streams.OutputStream, buf: bytes) -> core_types.Result[int, streams.StreamError]:
-        sys.stdout.buffer.write(buf)
+        if this == 1:
+            sys.stdout.buffer.write(buf)
+        elif this == 2:
+            sys.stderr.buffer.write(buf)
+        else:
+            raise NotImplementedError
         return core_types.Ok(len(buf))
 
     def blocking_write(self, this: streams.OutputStream, buf: bytes) -> core_types.Result[int, streams.StreamError]:
-        sys.stdout.buffer.write(buf)
-        return core_types.Ok(len(buf))
+        return self.write(this, buf)
 
     def drop_output_stream(self, this: streams.OutputStream) -> None:
         return None


### PR DESCRIPTION
This fixes an accidental regression from #159 where exports were looked up incorrectly in the target world by index rather than name. This fixes the bug by building a temporary map from string to item instead of `WorldKey` to item which is consulted.

Closes #161