### PR TITLE
Fix a warning from Cargo

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ['bindgen', 'wasi_snapshot_preview1']
+resolver = "2"
 
 [workspace.dependencies]
 wit-bindgen = { version = "0.10.0", default-features = false, features = ['macros'] }


### PR DESCRIPTION
Explicitly use `resolver = "2"` to use the latest-and-greatest semantics of this here.