### PR TITLE
FIX Make it possible to convert a Python int/float to externref

### DIFF
--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -58,6 +58,25 @@ class TestExternRef(unittest.TestCase):
             result = f(store, ref)
             self.assertEqual(result, extern)
 
+    def test_int_to_externref(self):
+        wat = """
+            (module
+                 (import "env" "int_to_ref" (func $int_to_ref (param $a i32) (result externref)))
+                 (export "test" (func $int_to_ref))
+            )
+            """
+        config = Config()
+        config.wasm_reference_types = True
+        engine = Engine(config)
+        store = Store(engine)
+        module = Module(store.engine, wat)
+        linker = Linker(engine)
+        ftype = FuncType([ValType.i32()], [ValType.externref()])
+        linker.define_func("env", "int_to_ref", ftype, lambda x:x)
+        instance = linker.instantiate(store, module)
+        instance.exports(store).get("test")(store, 5)
+        instance.exports(store).get("test")(store, 5.7)
+
     def test_externref_tables(self):
         store = ref_types_store()
         ty = TableType(ValType.externref(), Limits(10, None))

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -132,7 +132,9 @@ class Val:
             if ty != val.type:
                 raise TypeError("wrong type of `Val` provided")
             return val
-        elif isinstance(val, int):
+        if ty == ValType.externref():
+            return Val.externref(val)
+        if isinstance(val, int):
             if ty == ValType.i32():
                 return Val.i32(val)
             if ty == ValType.i64():
@@ -149,8 +151,6 @@ class Val:
                 return Val.externref(None)
             if ty == ValType.funcref():
                 return Val.funcref(None)
-        elif ty == ValType.externref():
-            return Val.externref(val)
         raise TypeError("don't know how to convert %r to %s" % (val, ty))
 
     def _into_raw(self) -> wasmtime_val_t:


### PR DESCRIPTION
Before this PR the added test fails with:
```
TypeError: don't know how to convert 5 to anyref
```