### PR TITLE
API Make InstanceExports into a Mapping

### DIFF
--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -14,7 +14,7 @@ class TestInstance(unittest.TestCase):
         module = Module(store.engine, '(module (func (export "")))')
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports(store)), 1)
-        extern = instance.exports(store)[0]
+        extern = instance.exports(store).by_index[0]
         assert(isinstance(extern, Func))
         assert(isinstance(extern.type(store), FuncType))
 
@@ -24,9 +24,8 @@ class TestInstance(unittest.TestCase):
         with self.assertRaises(KeyError):
             instance.exports(store)['x']
         with self.assertRaises(IndexError):
-            instance.exports(store)[100]
+            instance.exports(store).by_index[100]
         assert(instance.exports(store).get('x') is None)
-        assert(instance.exports(store).get(2) is None)
 
     def test_export_global(self):
         store = Store()
@@ -34,7 +33,7 @@ class TestInstance(unittest.TestCase):
             store.engine, '(module (global (export "") i32 (i32.const 3)))')
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports(store)), 1)
-        extern = instance.exports(store)[0]
+        extern = instance.exports(store).by_index[0]
         assert(isinstance(extern, Global))
         self.assertEqual(extern.value(store), 3)
         assert(isinstance(extern.type(store), GlobalType))
@@ -44,7 +43,7 @@ class TestInstance(unittest.TestCase):
         module = Module(store.engine, '(module (memory (export "") 1))')
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports(store)), 1)
-        extern = instance.exports(store)[0]
+        extern = instance.exports(store).by_index[0]
         assert(isinstance(extern, Memory))
         self.assertEqual(extern.size(store), 1)
 
@@ -53,7 +52,7 @@ class TestInstance(unittest.TestCase):
         module = Module(store.engine, '(module (table (export "") 1 funcref))')
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports(store)), 1)
-        extern = instance.exports(store)[0]
+        extern = instance.exports(store).by_index[0]
         assert(isinstance(extern, Table))
 
     def test_multiple_exports(self):
@@ -67,9 +66,9 @@ class TestInstance(unittest.TestCase):
         """)
         instance = Instance(store, module, [])
         self.assertEqual(len(instance.exports(store)), 3)
-        assert(isinstance(instance.exports(store)[0], Func))
-        assert(isinstance(instance.exports(store)[1], Func))
-        assert(isinstance(instance.exports(store)[2], Global))
+        assert(isinstance(instance.exports(store).by_index[0], Func))
+        assert(isinstance(instance.exports(store).by_index[1], Func))
+        assert(isinstance(instance.exports(store).by_index[2], Global))
 
     def test_import_func(self):
         store = Store()
@@ -100,7 +99,7 @@ class TestInstance(unittest.TestCase):
         """)
         g = Global(store, GlobalType(ValType.i32(), True), 2)
         instance = Instance(store, module, [g])
-        f = instance.exports(store)[0]
+        f = instance.exports(store).by_index[0]
         assert(isinstance(f, Func))
 
         self.assertEqual(f(store), 2)
@@ -108,12 +107,12 @@ class TestInstance(unittest.TestCase):
         self.assertEqual(f(store), 4)
 
         instance2 = Instance(store, module, [g])
-        f2 = instance2.exports(store)[0]
+        f2 = instance2.exports(store).by_index[0]
         assert(isinstance(f2, Func))
         self.assertEqual(f(store), 4)
         self.assertEqual(f2(store), 4)
 
-        update = instance.exports(store)[1]
+        update = instance.exports(store).by_index[1]
         assert(isinstance(update, Func))
         update(store)
         self.assertEqual(f(store), 5)
@@ -136,7 +135,7 @@ class TestInstance(unittest.TestCase):
                 (table (export "") 1 funcref)
             )
         """)
-        table = Instance(store, module, []).exports(store)[0]
+        table = Instance(store, module, []).exports(store).by_index[0]
 
         module = Module(store.engine, """
             (module

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -65,10 +65,19 @@ class TestInstance(unittest.TestCase):
             )
         """)
         instance = Instance(store, module, [])
-        self.assertEqual(len(instance.exports(store)), 3)
-        assert(isinstance(instance.exports(store).by_index[0], Func))
-        assert(isinstance(instance.exports(store).by_index[1], Func))
-        assert(isinstance(instance.exports(store).by_index[2], Global))
+        exports = instance.exports(store)
+        self.assertEqual(len(exports), 3)
+        assert isinstance(exports.by_index[0], Func)
+        assert isinstance(exports.by_index[1], Func)
+        assert isinstance(exports.by_index[2], Global)
+        # Test that exports acts like a normal map
+        assert "a" in exports
+        assert "b" in exports
+        assert "d" not in exports
+        assert set(exports) == {"a", "b", "c"}
+        assert set(exports.values()) == set(exports.by_index)
+        assert exports.get("d", 7) == 7
+        assert isinstance(exports.get("b", 7), Func)
 
     def test_import_func(self):
         store = Store()

--- a/tests/test_linker.py
+++ b/tests/test_linker.py
@@ -21,7 +21,7 @@ class TestLinker(unittest.TestCase):
         module = Module(store.engine, """
             (module (table (export "") 1 funcref))
         """)
-        table = Instance(store, module, []).exports(store)[0]
+        table = Instance(store, module, []).exports(store).by_index[0]
         linker.define(store, "", "g", table)
 
         with self.assertRaises(WasmtimeError):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,7 +9,7 @@ class TestTable(unittest.TestCase):
         module = Module(store.engine, """
             (module (table (export "") 1 funcref))
         """)
-        table = Instance(store, module, []).exports(store)[0]
+        table = Instance(store, module, []).exports(store).by_index[0]
         assert(isinstance(table, Table))
         assert(isinstance(table.type(store), TableType))
         self.assertEqual(table.type(store).limits, Limits(1, None))

--- a/tests/test_trap.py
+++ b/tests/test_trap.py
@@ -22,7 +22,7 @@ class TestTrap(unittest.TestCase):
         """)
         i = Instance(store, module, [])
         with self.assertRaises(Trap) as exn:
-            e = i.exports(store)[0]
+            e = i.exports(store).by_index[0]
             assert(isinstance(e, Func))
             e(store)
         trap = exn.exception
@@ -61,7 +61,7 @@ Caused by:
         """)
         i = Instance(store, module, [])
         with self.assertRaises(Trap) as exn:
-            e = i.exports(store)[0]
+            e = i.exports(store).by_index[0]
             assert(isinstance(e, Func))
             e(store)
         trap = exn.exception

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -81,7 +81,7 @@ class _WasmtimeLoader(Loader):
         res = linker.instantiate(store, wasm_module)
         exports = res.exports(store)
         for i, export in enumerate(wasm_module.exports):
-            item = exports[i]
+            item = exports.by_index[i]
             # Calling a function requires a `Store`, so bind the first argument
             # to our loader's store
             if isinstance(item, Func):


### PR DESCRIPTION
This is a breaking API change. I expected `InstanceExports` to be a subclass of `Mapping`. This PR includes a few changes:

1. `__iter__` should return an iterator over the **keys** of the map, not over the values.
2. we are expected to implement `__getitem__`, a `.get` method is derived automatically.
3. It's a bit unexpected that you can index both by the keys and by the index. It makes it hard to satisfy mypy, and it makes it hard to satisfy the invariants of `Mapping` (for instance, that `val in map` iff `val in list(map)`). I think it's reasonably natural to expose directly a tuple, typed as a `Sequence`, with the exports if we want to index them. I called this field `by_index`. For good measure, I made it a getter so that attempts to assign to it fail.