### PR TITLE
support configuring tail calls

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ class TestConfig(unittest.TestCase):
         config = Config()
         config.debug_info = True
         config.wasm_threads = True
+        config.wasm_tail_call = True
         config.wasm_reference_types = True
         config.wasm_simd = True
         config.wasm_bulk_memory = True

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -60,7 +60,7 @@ class Config(Managed["ctypes._Pointer[ffi.wasm_config_t]"]):
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_tail_call_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_tail_call_set(self.ptr(), enable)
 
     @setter_property
     def wasm_reference_types(self, enable: bool) -> None:

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -51,6 +51,18 @@ class Config(Managed["ctypes._Pointer[ffi.wasm_config_t]"]):
         ffi.wasmtime_config_wasm_threads_set(self.ptr(), enable)
 
     @setter_property
+    def wasm_tail_call(self, enable: bool) -> None:
+        """
+        Configures whether the wasm [tail call proposal] is enabled.
+
+        [tail call proposal]: https://github.com/WebAssembly/tail-call
+        """
+
+        if not isinstance(enable, bool):
+            raise TypeError('expected a bool')
+        ffi.wasmtime_config_wasm_tail_call_set(self._ptr, enable)
+
+    @setter_property
     def wasm_reference_types(self, enable: bool) -> None:
         """
         Configures whether the wasm [reference types proposal] is enabled.


### PR DESCRIPTION
This PR adds support for configuring tail calls (Closes https://github.com/bytecodealliance/wasmtime-py/issues/204),

it depends on the change to the C api here: https://github.com/bytecodealliance/wasmtime/pull/7811,


without the change, the CI fails as expected with: `[...] _libwasmtime.so: undefined symbol: wasmtime_config_wasm_tail_call_set.`

