### PR TITLE
Enable explicit destruction of all resources

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import unittest
+from contextlib import closing
 
 from wasmtime import *
 
@@ -34,3 +35,14 @@ class TestConfig(unittest.TestCase):
         config.consume_fuel = True
         config.wasm_relaxed_simd = True
         config.wasm_relaxed_simd_deterministic = True
+
+        with closing(config) as config:
+            pass
+
+        config.close()
+
+        with self.assertRaises(ValueError):
+            Engine(config)
+
+        with self.assertRaises(ValueError):
+            config.cache = True

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,5 +13,5 @@ class TestEngine(unittest.TestCase):
             Engine(3)  # type: ignore
         config = Config()
         Engine(config)
-        with self.assertRaises(WasmtimeError):
+        with self.assertRaises(ValueError):
             Engine(config)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -8,6 +8,15 @@ class TestStore(unittest.TestCase):
         Store()
         Store(Engine())
 
+        with Store() as store:
+            pass
+
+        store = Store()
+        store.close()
+        store.close()
+        with self.assertRaises(ValueError):
+            store.set_epoch_deadline(1)
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             Store(3)  # type: ignore

--- a/wasmtime/__init__.py
+++ b/wasmtime/__init__.py
@@ -13,6 +13,7 @@ free to consult that documentation as well. While not exactly the same the two
 libraries are intended to be quite similar.
 """
 
+from ._managed import Managed
 from ._error import WasmtimeError, ExitTrap
 from ._config import Config
 from ._engine import Engine

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -1,7 +1,7 @@
 from . import _ffi as ffi
 from ctypes import *
 import ctypes
-from wasmtime import WasmtimeError
+from wasmtime import WasmtimeError, Managed
 import typing
 
 
@@ -13,7 +13,7 @@ def setter_property(fset: typing.Callable) -> property:
     return prop
 
 
-class Config:
+class Config(Managed["ctypes._Pointer[ffi.wasm_config_t]"]):
     """
     Global configuration, used to create an `Engine`.
 
@@ -21,10 +21,11 @@ class Config:
     code is compiled or generated.
     """
 
-    _ptr: "ctypes._Pointer[ffi.wasm_config_t]"
-
     def __init__(self) -> None:
-        self._ptr = ffi.wasm_config_new()
+        self._set_ptr(ffi.wasm_config_new())
+
+    def _delete(self, ptr: "ctypes._Pointer[ffi.wasm_config_t]") -> None:
+        ffi.wasm_config_delete(ptr)
 
     @setter_property
     def debug_info(self, enable: bool) -> None:
@@ -35,7 +36,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_debug_info_set(self._ptr, enable)
+        ffi.wasmtime_config_debug_info_set(self.ptr(), enable)
 
     @setter_property
     def wasm_threads(self, enable: bool) -> None:
@@ -47,7 +48,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_threads_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_threads_set(self.ptr(), enable)
 
     @setter_property
     def wasm_reference_types(self, enable: bool) -> None:
@@ -59,7 +60,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_reference_types_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_reference_types_set(self.ptr(), enable)
 
     @setter_property
     def wasm_simd(self, enable: bool) -> None:
@@ -71,7 +72,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_simd_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_simd_set(self.ptr(), enable)
 
     @setter_property
     def wasm_bulk_memory(self, enable: bool) -> None:
@@ -83,7 +84,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_bulk_memory_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_bulk_memory_set(self.ptr(), enable)
 
     @setter_property
     def wasm_multi_value(self, enable: bool) -> None:
@@ -95,7 +96,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_multi_value_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_multi_value_set(self.ptr(), enable)
 
     @setter_property
     def wasm_multi_memory(self, enable: bool) -> None:
@@ -107,7 +108,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_multi_memory_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_multi_memory_set(self.ptr(), enable)
 
     @setter_property
     def wasm_memory64(self, enable: bool) -> None:
@@ -119,7 +120,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_memory64_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_memory64_set(self.ptr(), enable)
 
     @setter_property
     def wasm_relaxed_simd(self, enable: bool) -> None:
@@ -131,7 +132,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_relaxed_simd_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_relaxed_simd_set(self.ptr(), enable)
 
     @setter_property
     def wasm_relaxed_simd_deterministic(self, enable: bool) -> None:
@@ -145,7 +146,7 @@ class Config:
 
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_wasm_relaxed_simd_deterministic_set(self._ptr, enable)
+        ffi.wasmtime_config_wasm_relaxed_simd_deterministic_set(self.ptr(), enable)
 
     @setter_property
     def strategy(self, strategy: str) -> None:
@@ -159,9 +160,9 @@ class Config:
         """
 
         if strategy == "auto":
-            ffi.wasmtime_config_strategy_set(self._ptr, 0)
+            ffi.wasmtime_config_strategy_set(self.ptr(), 0)
         elif strategy == "cranelift":
-            ffi.wasmtime_config_strategy_set(self._ptr, 1)
+            ffi.wasmtime_config_strategy_set(self.ptr(), 1)
         else:
             raise WasmtimeError("unknown strategy: " + str(strategy))
 
@@ -169,25 +170,25 @@ class Config:
     def cranelift_debug_verifier(self, enable: bool) -> None:
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_cranelift_debug_verifier_set(self._ptr, enable)
+        ffi.wasmtime_config_cranelift_debug_verifier_set(self.ptr(), enable)
 
     @setter_property
     def cranelift_opt_level(self, opt_level: str) -> None:
         if opt_level == "none":
-            ffi.wasmtime_config_cranelift_opt_level_set(self._ptr, 0)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.ptr(), 0)
         elif opt_level == "speed":
-            ffi.wasmtime_config_cranelift_opt_level_set(self._ptr, 1)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.ptr(), 1)
         elif opt_level == "speed_and_size":
-            ffi.wasmtime_config_cranelift_opt_level_set(self._ptr, 2)
+            ffi.wasmtime_config_cranelift_opt_level_set(self.ptr(), 2)
         else:
             raise WasmtimeError("unknown opt level: " + str(opt_level))
 
     @setter_property
     def profiler(self, profiler: str) -> None:
         if profiler == "none":
-            ffi.wasmtime_config_profiler_set(self._ptr, 0)
+            ffi.wasmtime_config_profiler_set(self.ptr(), 0)
         elif profiler == "jitdump":
-            ffi.wasmtime_config_profiler_set(self._ptr, 1)
+            ffi.wasmtime_config_profiler_set(self.ptr(), 1)
         else:
             raise WasmtimeError("unknown profiler: " + str(profiler))
 
@@ -207,9 +208,9 @@ class Config:
         if isinstance(enabled, bool):
             if not enabled:
                 raise WasmtimeError("caching cannot be explicitly disabled")
-            error = ffi.wasmtime_config_cache_config_load(self._ptr, None)
+            error = ffi.wasmtime_config_cache_config_load(self.ptr(), None)
         elif isinstance(enabled, str):
-            error = ffi.wasmtime_config_cache_config_load(self._ptr,
+            error = ffi.wasmtime_config_cache_config_load(self.ptr(),
                                                           c_char_p(enabled.encode('utf-8')))
         else:
             raise TypeError("expected string or bool")
@@ -227,7 +228,7 @@ class Config:
             val = 1
         else:
             val = 0
-        ffi.wasmtime_config_epoch_interruption_set(self._ptr, val)
+        ffi.wasmtime_config_epoch_interruption_set(self.ptr(), val)
 
     @setter_property
     def consume_fuel(self, instances: bool) -> None:
@@ -240,7 +241,7 @@ class Config:
         """
         if not isinstance(instances, bool):
             raise TypeError('expected an bool')
-        ffi.wasmtime_config_consume_fuel_set(self._ptr, instances)
+        ffi.wasmtime_config_consume_fuel_set(self.ptr(), instances)
 
     @setter_property
     def parallel_compilation(self, enable: bool) -> None:
@@ -252,8 +253,4 @@ class Config:
         """
         if not isinstance(enable, bool):
             raise TypeError('expected a bool')
-        ffi.wasmtime_config_parallel_compilation_set(self._ptr, enable)
-
-    def __del__(self) -> None:
-        if hasattr(self, '_ptr'):
-            ffi.wasm_config_delete(self._ptr)
+        ffi.wasmtime_config_parallel_compilation_set(self.ptr(), enable)

--- a/wasmtime/_engine.py
+++ b/wasmtime/_engine.py
@@ -1,27 +1,22 @@
 from . import _ffi as ffi
-from wasmtime import Config, WasmtimeError
+from wasmtime import Config, WasmtimeError, Managed
 from typing import Optional
 import ctypes
 
 
-class Engine:
-    _ptr: "ctypes._Pointer[ffi.wasm_engine_t]"
+class Engine(Managed["ctypes._Pointer[ffi.wasm_engine_t]"]):
 
     def __init__(self, config: Optional[Config] = None):
         if config is None:
-            self._ptr = ffi.wasm_engine_new()
+            self._set_ptr(ffi.wasm_engine_new())
         elif not isinstance(config, Config):
             raise TypeError("expected Config")
-        elif not hasattr(config, '_ptr'):
-            raise WasmtimeError("Config already used")
         else:
-            ptr = config._ptr
-            delattr(config, '_ptr')
-            self._ptr = ffi.wasm_engine_new_with_config(ptr)
+            ptr = config._consume()
+            self._set_ptr(ffi.wasm_engine_new_with_config(ptr))
+
+    def _delete(self, ptr: "ctypes._Pointer[ffi.wasm_engine_t]") -> None:
+        ffi.wasm_engine_delete(ptr)
 
     def increment_epoch(self) -> None:
-        ffi.wasmtime_engine_increment_epoch(self._ptr)
-
-    def __del__(self) -> None:
-        if hasattr(self, '_ptr'):
-            ffi.wasm_engine_delete(self._ptr)
+        ffi.wasmtime_engine_increment_epoch(self.ptr())

--- a/wasmtime/_extern.py
+++ b/wasmtime/_extern.py
@@ -1,7 +1,7 @@
 from . import _ffi as ffi
 import ctypes
 from ._exportable import AsExtern
-from wasmtime import WasmtimeError
+from wasmtime import WasmtimeError, Managed
 
 
 def wrap_extern(ptr: ffi.wasmtime_extern_t) -> AsExtern:
@@ -41,9 +41,9 @@ def get_extern_ptr(item: AsExtern) -> ffi.wasmtime_extern_t:
         raise TypeError("expected a Func, Global, Memory, Table, Module, or Instance")
 
 
-class Extern:
+class Extern(Managed["ctypes._Pointer[ffi.wasm_extern_t]"]):
     def __init__(self, ptr: "ctypes._Pointer[ffi.wasm_extern_t]"):
-        self.ptr = ptr
+        self._set_ptr(ptr)
 
-    def __del__(self) -> None:
-        ffi.wasm_extern_delete(self.ptr)
+    def _delete(self, ptr: "ctypes._Pointer[ffi.wasm_extern_t]") -> None:
+        ffi.wasm_extern_delete(ptr)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -13,8 +13,8 @@ class Global:
         val = Val._convert(ty.content, val)
         global_ = ffi.wasmtime_global_t()
         error = ffi.wasmtime_global_new(
-            store._context,
-            ty._ptr,
+            store._context(),
+            ty.ptr(),
             byref(val._unwrap_raw()),
             byref(global_))
         if error:
@@ -32,7 +32,7 @@ class Global:
         Gets the type of this global as a `GlobalType`
         """
 
-        ptr = ffi.wasmtime_global_type(store._context, byref(self._global))
+        ptr = ffi.wasmtime_global_type(store._context(), byref(self._global))
         return GlobalType._from_ptr(ptr, None)
 
     def value(self, store: Storelike) -> IntoVal:
@@ -42,7 +42,7 @@ class Global:
         Returns a native python type
         """
         raw = ffi.wasmtime_val_t()
-        ffi.wasmtime_global_get(store._context, byref(self._global), byref(raw))
+        ffi.wasmtime_global_get(store._context(), byref(self._global), byref(raw))
         val = Val(raw)
         if val.value is not None:
             return val.value
@@ -54,7 +54,7 @@ class Global:
         Sets the value of this global to a new value
         """
         val = Val._convert(self.type(store).content, val)
-        error = ffi.wasmtime_global_set(store._context, byref(self._global), byref(val._unwrap_raw()))
+        error = ffi.wasmtime_global_set(store._context(), byref(self._global), byref(val._unwrap_raw()))
         if error:
             raise WasmtimeError._from_ptr(error)
 

--- a/wasmtime/_instance.py
+++ b/wasmtime/_instance.py
@@ -30,11 +30,10 @@ class Instance:
             imports_ptr[i] = get_extern_ptr(val)
 
         instance = ffi.wasmtime_instance_t()
-        trap = POINTER(ffi.wasm_trap_t)()
         with enter_wasm(store) as trap:
             error = ffi.wasmtime_instance_new(
-                store._context,
-                module._ptr,
+                store._context(),
+                module.ptr(),
                 imports_ptr,
                 len(imports),
                 byref(instance),
@@ -80,7 +79,7 @@ class InstanceExports(Mapping[str, AsExtern]):
         name_ptr = POINTER(ffi.c_char)()
         name_len = ffi.c_size_t(0)
         while ffi.wasmtime_instance_export_nth(
-                store._context,
+                store._context(),
                 byref(instance._instance),
                 i,
                 byref(name_ptr),

--- a/wasmtime/_managed.py
+++ b/wasmtime/_managed.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar, Generic, Any
+from typing import TypeVar, Generic, Any, Optional
 
 T = TypeVar('T')
 
@@ -10,7 +10,7 @@ class Managed(Generic[T]):
 
     Not exported directly from this package.
     """
-    __ptr: T | None
+    __ptr: Optional[T]
 
     @abstractmethod
     def _delete(self, ptr: T) -> None:

--- a/wasmtime/_managed.py
+++ b/wasmtime/_managed.py
@@ -1,0 +1,95 @@
+from abc import abstractmethod
+from typing import TypeVar, Generic, Any
+
+T = TypeVar('T')
+
+class Managed(Generic[T]):
+    """
+    Abstract base class for types which contain an owned pointer in the C FFI
+    layer.
+
+    Not exported directly from this package.
+    """
+    __ptr: T | None
+
+    @abstractmethod
+    def _delete(self, ptr: T) -> None:
+        """
+        Runs the FFI destructor for the `ptr` specified.
+
+        Must be implemented by classes that inherit from this class.
+        """
+        pass
+
+    def _set_ptr(self, ptr: T) -> None:
+        if hasattr(self, '__ptr'):
+            raise ValueError('already initialized')
+        self.__ptr = ptr
+
+    def close(self) -> None:
+        """
+        Closes this object, or deallocates it. Further usage of this object
+        will raise a `ValueError`.
+        """
+
+        # Get the pointer's value but don't worry if it was never set.
+        try:
+            ptr = self.__ptr
+        except AttributeError:
+            return
+
+        # If it wasn't previously deallocated then do so here, otherwise ignore
+        # this repeated call to `close`
+        if ptr is not None:
+            self._delete(ptr)
+            self.__ptr = None
+
+    def ptr(self) -> T:
+        """
+        Returns the underlying pointer for this FFI object, or a `ValueError`
+        if it's already been closed.
+        """
+
+        # Fail with a `ValueError` if the pointer was never set
+        try:
+            ptr = self.__ptr
+        except AttributeError:
+            raise ValueError('never initialized')
+
+        # Check to see if this object is already deallocated, and if so raise
+        # a specific exception
+        if ptr is not None:
+            return ptr
+        else:
+            raise ValueError('already closed')
+
+    def _consume(self) -> T:
+        """
+        Internal method to take ownership of the internal pointer without
+        destroying it.
+        """
+        ret = self.ptr()
+        self.__ptr = None
+        return ret
+
+    def __enter__(self) -> Any:
+        """
+        Entry part of the contextlib protocol to enable using this object with
+        `with`.
+
+        Returns `self` to bind to use within a `with` block.
+        """
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        """
+        Exit part of the contextlib protocol to call `close`.
+        """
+        self.close()
+
+    def __del__(self) -> None:
+        """
+        Automatic destruction of the internal FFI object if it's still alive by
+        this point.
+        """
+        self.close()

--- a/wasmtime/_memory.py
+++ b/wasmtime/_memory.py
@@ -15,7 +15,7 @@ class Memory:
         """
 
         mem = ffi.wasmtime_memory_t()
-        error = ffi.wasmtime_memory_new(store._context, ty._ptr, byref(mem))
+        error = ffi.wasmtime_memory_new(store._context(), ty.ptr(), byref(mem))
         if error:
             raise WasmtimeError._from_ptr(error)
         self._memory = mem
@@ -31,7 +31,7 @@ class Memory:
         Gets the type of this memory as a `MemoryType`
         """
 
-        ptr = ffi.wasmtime_memory_type(store._context, byref(self._memory))
+        ptr = ffi.wasmtime_memory_type(store._context(), byref(self._memory))
         return MemoryType._from_ptr(ptr, None)
 
     def grow(self, store: Storelike, delta: int) -> int:
@@ -42,7 +42,7 @@ class Memory:
         if delta < 0:
             raise WasmtimeError("cannot grow by negative amount")
         prev = ffi.c_uint64(0)
-        error = ffi.wasmtime_memory_grow(store._context, byref(self._memory), delta, byref(prev))
+        error = ffi.wasmtime_memory_grow(store._context(), byref(self._memory), delta, byref(prev))
         if error:
             raise WasmtimeError._from_ptr(error)
         return prev.value
@@ -52,7 +52,7 @@ class Memory:
         Returns the size, in WebAssembly pages, of this memory.
         """
 
-        return ffi.wasmtime_memory_size(store._context, byref(self._memory))
+        return ffi.wasmtime_memory_size(store._context(), byref(self._memory))
 
     def data_ptr(self, store: Storelike) -> "ctypes._Pointer[c_ubyte]":
         """
@@ -61,7 +61,7 @@ class Memory:
         Remember that all accesses to wasm memory should be bounds-checked
         against the `data_len` method.
         """
-        return ffi.wasmtime_memory_data(store._context, byref(self._memory))
+        return ffi.wasmtime_memory_data(store._context(), byref(self._memory))
 
     def get_buffer_ptr(self, store: Storelike,
                        size: typing.Optional[int] = None,
@@ -140,7 +140,7 @@ class Memory:
         Returns the raw byte length of this memory.
         """
 
-        return ffi.wasmtime_memory_data_size(store._context, byref(self._memory))
+        return ffi.wasmtime_memory_data_size(store._context(), byref(self._memory))
 
     def _as_extern(self) -> ffi.wasmtime_extern_t:
         union = ffi.wasmtime_extern_union(memory=self._memory)

--- a/wasmtime/_table.py
+++ b/wasmtime/_table.py
@@ -16,7 +16,7 @@ class Table:
         init_val = Val._convert(ty.element, init)
 
         table = ffi.wasmtime_table_t()
-        error = ffi.wasmtime_table_new(store._context, ty._ptr, byref(init_val._unwrap_raw()), byref(table))
+        error = ffi.wasmtime_table_new(store._context(), ty.ptr(), byref(init_val._unwrap_raw()), byref(table))
         if error:
             raise WasmtimeError._from_ptr(error)
         self._table = table
@@ -32,14 +32,14 @@ class Table:
         Gets the type of this table as a `TableType`
         """
 
-        ptr = ffi.wasmtime_table_type(store._context, byref(self._table))
+        ptr = ffi.wasmtime_table_type(store._context(), byref(self._table))
         return TableType._from_ptr(ptr, None)
 
     def size(self, store: Storelike) -> int:
         """
         Gets the size, in elements, of this table
         """
-        return ffi.wasmtime_table_size(store._context, byref(self._table))
+        return ffi.wasmtime_table_size(store._context(), byref(self._table))
 
     def grow(self, store: Storelike, amt: int, init: IntoVal) -> int:
         """
@@ -51,7 +51,7 @@ class Table:
         """
         init_val = Val._convert(self.type(store).element, init)
         prev = c_uint32(0)
-        error = ffi.wasmtime_table_grow(store._context, byref(self._table), c_uint32(amt), byref(init_val._unwrap_raw()), byref(prev))
+        error = ffi.wasmtime_table_grow(store._context(), byref(self._table), c_uint32(amt), byref(init_val._unwrap_raw()), byref(prev))
         if error:
             raise WasmtimeError._from_ptr(error)
         return prev.value
@@ -70,7 +70,7 @@ class Table:
         Returns `None` if `idx` is out of bounds.
         """
         raw = ffi.wasmtime_val_t()
-        ok = ffi.wasmtime_table_get(store._context, byref(self._table), idx, byref(raw))
+        ok = ffi.wasmtime_table_get(store._context(), byref(self._table), idx, byref(raw))
         if not ok:
             return None
         val = Val(raw)
@@ -93,7 +93,7 @@ class Table:
         Raises a `WasmtimeError` if `idx` is out of bounds.
         """
         value = Val._convert(self.type(store).element, val)
-        error = ffi.wasmtime_table_set(store._context, byref(self._table), idx, byref(value._unwrap_raw()))
+        error = ffi.wasmtime_table_set(store._context(), byref(self._table), idx, byref(value._unwrap_raw()))
         if error:
             raise WasmtimeError._from_ptr(error)
 


### PR DESCRIPTION
This commit adds a suite of methods to most of the types in this package to enable explicit destruction of resources as necessary. Specifically most classes which own a pointer internally now sport some new methods:

* `__enter__` and `__exit__` enable using the objects in `with` blocks.
* `close` enables explicitly deallocating the object.

All objects internally now validate that they have not been closed before operating, raising a `ValueError` if a closed object is operated on.