### PR TITLE
loader: do not prepend cwd to path as it is a security issue

### DIFF
--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -32,9 +32,8 @@ linker.allow_shadowing = True
 
 class _WasmtimeMetaFinder(MetaPathFinder):
     def find_spec(self, fullname, path, target=None):  # type: ignore
-        if path is None or path == "":
-            path = [Path.cwd()]  # top level import --
-            path.extend(sys.path)
+        if not path:
+            path = sys.path
         if "." in fullname:
             *parents, name = fullname.split(".")
         else:


### PR DESCRIPTION
Python does have cwd on `sys.path` by default:

    >>> import sys; sys.path[0]
    ''

However, having cwd on `sys.path` is potentially a security issue (see [safepath]) and the custom loader should absolutely not add it itself since this circumvents `PYTHONSAFEPATH=1`, `-P` and other knobs that Python provides to fixes the default-unsafe behavior.

Before this commit, any application using `wasmtime.loader` can be subverted if it is ran in a cwd controlled by an attacker so that it runs a completely different Wasm module. Since WASI is enabled by default this means arbitrary code execution, even with `PYTHONSAFEPATH` set.

[safepath]: https://docs.python.org/3/using/cmdline.html#cmdoption-P