### PR TITLE
Update to latest bindings

### DIFF
--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -10,7 +10,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-WASMTIME_VERSION = "v19.0.0"
+WASMTIME_VERSION = "dev"
 
 
 def main(platform, arch):

--- a/wasmtime/__init__.py
+++ b/wasmtime/__init__.py
@@ -22,7 +22,7 @@ from ._types import FuncType, GlobalType, MemoryType, TableType
 from ._types import ValType, Limits, ImportType, ExportType
 from ._wat2wasm import wat2wasm
 from ._module import Module
-from ._value import Val, IntoVal
+from ._value import Val
 from ._trap import Trap, Frame, TrapCode
 from ._func import Func, Caller
 from ._globals import Global
@@ -45,7 +45,6 @@ __all__ = [
     'Limits',
     'ImportType',
     'ExportType',
-    'IntoVal',
     'Val',
     'Func',
     'Caller',

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -1959,12 +1959,6 @@ _wasi_config_preopen_dir.argtypes = [POINTER(wasi_config_t), POINTER(c_char), PO
 def wasi_config_preopen_dir(config: Any, path: Any, guest_path: Any) -> bool:
     return _wasi_config_preopen_dir(config, path, guest_path)  # type: ignore
 
-_wasi_config_preopen_socket = dll.wasi_config_preopen_socket
-_wasi_config_preopen_socket.restype = c_bool
-_wasi_config_preopen_socket.argtypes = [POINTER(wasi_config_t), c_uint32, POINTER(c_char)]
-def wasi_config_preopen_socket(config: Any, fd_num: Any, host_port: Any) -> bool:
-    return _wasi_config_preopen_socket(config, fd_num, host_port)  # type: ignore
-
 class wasmtime_error(Structure):
     pass
 
@@ -2047,6 +2041,18 @@ _wasmtime_config_wasm_reference_types_set.restype = None
 _wasmtime_config_wasm_reference_types_set.argtypes = [POINTER(wasm_config_t), c_bool]
 def wasmtime_config_wasm_reference_types_set(arg0: Any, arg1: Any) -> None:
     return _wasmtime_config_wasm_reference_types_set(arg0, arg1)  # type: ignore
+
+_wasmtime_config_wasm_function_references_set = dll.wasmtime_config_wasm_function_references_set
+_wasmtime_config_wasm_function_references_set.restype = None
+_wasmtime_config_wasm_function_references_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_function_references_set(arg0: Any, arg1: Any) -> None:
+    return _wasmtime_config_wasm_function_references_set(arg0, arg1)  # type: ignore
+
+_wasmtime_config_wasm_gc_set = dll.wasmtime_config_wasm_gc_set
+_wasmtime_config_wasm_gc_set.restype = None
+_wasmtime_config_wasm_gc_set.argtypes = [POINTER(wasm_config_t), c_bool]
+def wasmtime_config_wasm_gc_set(arg0: Any, arg1: Any) -> None:
+    return _wasmtime_config_wasm_gc_set(arg0, arg1)  # type: ignore
 
 _wasmtime_config_wasm_simd_set = dll.wasmtime_config_wasm_simd_set
 _wasmtime_config_wasm_simd_set.restype = None
@@ -2307,6 +2313,59 @@ _wasmtime_module_image_range.argtypes = [POINTER(wasmtime_module_t), POINTER(c_v
 def wasmtime_module_image_range(module: Any, start: Any, end: Any) -> None:
     return _wasmtime_module_image_range(module, start, end)  # type: ignore
 
+class wasmtime_sharedmemory(Structure):
+    pass
+
+wasmtime_sharedmemory_t = wasmtime_sharedmemory
+
+_wasmtime_sharedmemory_new = dll.wasmtime_sharedmemory_new
+_wasmtime_sharedmemory_new.restype = POINTER(wasmtime_error_t)
+_wasmtime_sharedmemory_new.argtypes = [POINTER(wasm_engine_t), POINTER(wasm_memorytype_t), POINTER(POINTER(wasmtime_sharedmemory_t))]
+def wasmtime_sharedmemory_new(engine: Any, ty: Any, ret: Any) -> ctypes._Pointer:
+    return _wasmtime_sharedmemory_new(engine, ty, ret)  # type: ignore
+
+_wasmtime_sharedmemory_delete = dll.wasmtime_sharedmemory_delete
+_wasmtime_sharedmemory_delete.restype = None
+_wasmtime_sharedmemory_delete.argtypes = [POINTER(wasmtime_sharedmemory_t)]
+def wasmtime_sharedmemory_delete(memory: Any) -> None:
+    return _wasmtime_sharedmemory_delete(memory)  # type: ignore
+
+_wasmtime_sharedmemory_clone = dll.wasmtime_sharedmemory_clone
+_wasmtime_sharedmemory_clone.restype = POINTER(wasmtime_sharedmemory_t)
+_wasmtime_sharedmemory_clone.argtypes = [POINTER(wasmtime_sharedmemory_t)]
+def wasmtime_sharedmemory_clone(memory: Any) -> ctypes._Pointer:
+    return _wasmtime_sharedmemory_clone(memory)  # type: ignore
+
+_wasmtime_sharedmemory_type = dll.wasmtime_sharedmemory_type
+_wasmtime_sharedmemory_type.restype = POINTER(wasm_memorytype_t)
+_wasmtime_sharedmemory_type.argtypes = [POINTER(wasmtime_sharedmemory_t)]
+def wasmtime_sharedmemory_type(memory: Any) -> ctypes._Pointer:
+    return _wasmtime_sharedmemory_type(memory)  # type: ignore
+
+_wasmtime_sharedmemory_data = dll.wasmtime_sharedmemory_data
+_wasmtime_sharedmemory_data.restype = POINTER(c_uint8)
+_wasmtime_sharedmemory_data.argtypes = [POINTER(wasmtime_sharedmemory_t)]
+def wasmtime_sharedmemory_data(memory: Any) -> ctypes._Pointer:
+    return _wasmtime_sharedmemory_data(memory)  # type: ignore
+
+_wasmtime_sharedmemory_data_size = dll.wasmtime_sharedmemory_data_size
+_wasmtime_sharedmemory_data_size.restype = c_size_t
+_wasmtime_sharedmemory_data_size.argtypes = [POINTER(wasmtime_sharedmemory_t)]
+def wasmtime_sharedmemory_data_size(memory: Any) -> int:
+    return _wasmtime_sharedmemory_data_size(memory)  # type: ignore
+
+_wasmtime_sharedmemory_size = dll.wasmtime_sharedmemory_size
+_wasmtime_sharedmemory_size.restype = c_uint64
+_wasmtime_sharedmemory_size.argtypes = [POINTER(wasmtime_sharedmemory_t)]
+def wasmtime_sharedmemory_size(memory: Any) -> int:
+    return _wasmtime_sharedmemory_size(memory)  # type: ignore
+
+_wasmtime_sharedmemory_grow = dll.wasmtime_sharedmemory_grow
+_wasmtime_sharedmemory_grow.restype = POINTER(wasmtime_error_t)
+_wasmtime_sharedmemory_grow.argtypes = [POINTER(wasmtime_sharedmemory_t), c_uint64, POINTER(c_uint64)]
+def wasmtime_sharedmemory_grow(memory: Any, delta: Any, prev_size: Any) -> ctypes._Pointer:
+    return _wasmtime_sharedmemory_grow(memory, delta, prev_size)  # type: ignore
+
 class wasmtime_store(Structure):
     pass
 
@@ -2439,11 +2498,13 @@ class wasmtime_extern_union(Union):
         ("global_", wasmtime_global_t),
         ("table", wasmtime_table_t),
         ("memory", wasmtime_memory_t),
+        ("sharedmemory", POINTER(wasmtime_sharedmemory)),
     ]
     func: wasmtime_func_t
     global_: wasmtime_global_t
     table: wasmtime_table_t
     memory: wasmtime_memory_t
+    sharedmemory: ctypes._Pointer
 
 wasmtime_extern_union_t = wasmtime_extern_union
 
@@ -2469,6 +2530,53 @@ _wasmtime_extern_type.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_
 def wasmtime_extern_type(context: Any, val: Any) -> ctypes._Pointer:
     return _wasmtime_extern_type(context, val)  # type: ignore
 
+class wasmtime_anyref(Structure):
+    pass
+
+wasmtime_anyref_t = wasmtime_anyref
+
+_wasmtime_anyref_clone = dll.wasmtime_anyref_clone
+_wasmtime_anyref_clone.restype = POINTER(wasmtime_anyref_t)
+_wasmtime_anyref_clone.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_anyref_t)]
+def wasmtime_anyref_clone(context: Any, ref: Any) -> ctypes._Pointer:
+    return _wasmtime_anyref_clone(context, ref)  # type: ignore
+
+_wasmtime_anyref_delete = dll.wasmtime_anyref_delete
+_wasmtime_anyref_delete.restype = None
+_wasmtime_anyref_delete.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_anyref_t)]
+def wasmtime_anyref_delete(context: Any, ref: Any) -> None:
+    return _wasmtime_anyref_delete(context, ref)  # type: ignore
+
+_wasmtime_anyref_from_raw = dll.wasmtime_anyref_from_raw
+_wasmtime_anyref_from_raw.restype = POINTER(wasmtime_anyref_t)
+_wasmtime_anyref_from_raw.argtypes = [POINTER(wasmtime_context_t), c_uint32]
+def wasmtime_anyref_from_raw(context: Any, raw: Any) -> ctypes._Pointer:
+    return _wasmtime_anyref_from_raw(context, raw)  # type: ignore
+
+_wasmtime_anyref_to_raw = dll.wasmtime_anyref_to_raw
+_wasmtime_anyref_to_raw.restype = c_uint32
+_wasmtime_anyref_to_raw.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_anyref_t)]
+def wasmtime_anyref_to_raw(context: Any, ref: Any) -> int:
+    return _wasmtime_anyref_to_raw(context, ref)  # type: ignore
+
+_wasmtime_anyref_from_i31 = dll.wasmtime_anyref_from_i31
+_wasmtime_anyref_from_i31.restype = POINTER(wasmtime_anyref_t)
+_wasmtime_anyref_from_i31.argtypes = [POINTER(wasmtime_context_t), c_uint32]
+def wasmtime_anyref_from_i31(context: Any, i31val: Any) -> ctypes._Pointer:
+    return _wasmtime_anyref_from_i31(context, i31val)  # type: ignore
+
+_wasmtime_anyref_i31_get_u = dll.wasmtime_anyref_i31_get_u
+_wasmtime_anyref_i31_get_u.restype = c_bool
+_wasmtime_anyref_i31_get_u.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_anyref_t), POINTER(c_uint32)]
+def wasmtime_anyref_i31_get_u(context: Any, anyref: Any, dst: Any) -> bool:
+    return _wasmtime_anyref_i31_get_u(context, anyref, dst)  # type: ignore
+
+_wasmtime_anyref_i31_get_s = dll.wasmtime_anyref_i31_get_s
+_wasmtime_anyref_i31_get_s.restype = c_bool
+_wasmtime_anyref_i31_get_s.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_anyref_t), POINTER(c_int32)]
+def wasmtime_anyref_i31_get_s(context: Any, anyref: Any, dst: Any) -> bool:
+    return _wasmtime_anyref_i31_get_s(context, anyref, dst)  # type: ignore
+
 class wasmtime_externref(Structure):
     pass
 
@@ -2476,36 +2584,36 @@ wasmtime_externref_t = wasmtime_externref
 
 _wasmtime_externref_new = dll.wasmtime_externref_new
 _wasmtime_externref_new.restype = POINTER(wasmtime_externref_t)
-_wasmtime_externref_new.argtypes = [c_void_p, CFUNCTYPE(None, c_void_p)]
-def wasmtime_externref_new(data: Any, finalizer: Any) -> ctypes._Pointer:
-    return _wasmtime_externref_new(data, finalizer)  # type: ignore
+_wasmtime_externref_new.argtypes = [POINTER(wasmtime_context_t), c_void_p, CFUNCTYPE(None, c_void_p)]
+def wasmtime_externref_new(context: Any, data: Any, finalizer: Any) -> ctypes._Pointer:
+    return _wasmtime_externref_new(context, data, finalizer)  # type: ignore
 
 _wasmtime_externref_data = dll.wasmtime_externref_data
 _wasmtime_externref_data.restype = c_void_p
-_wasmtime_externref_data.argtypes = [POINTER(wasmtime_externref_t)]
-def wasmtime_externref_data(data: Any) -> int:
-    return _wasmtime_externref_data(data)  # type: ignore
+_wasmtime_externref_data.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_externref_t)]
+def wasmtime_externref_data(context: Any, data: Any) -> int:
+    return _wasmtime_externref_data(context, data)  # type: ignore
 
 _wasmtime_externref_clone = dll.wasmtime_externref_clone
 _wasmtime_externref_clone.restype = POINTER(wasmtime_externref_t)
-_wasmtime_externref_clone.argtypes = [POINTER(wasmtime_externref_t)]
-def wasmtime_externref_clone(ref: Any) -> ctypes._Pointer:
-    return _wasmtime_externref_clone(ref)  # type: ignore
+_wasmtime_externref_clone.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_externref_t)]
+def wasmtime_externref_clone(context: Any, ref: Any) -> ctypes._Pointer:
+    return _wasmtime_externref_clone(context, ref)  # type: ignore
 
 _wasmtime_externref_delete = dll.wasmtime_externref_delete
 _wasmtime_externref_delete.restype = None
-_wasmtime_externref_delete.argtypes = [POINTER(wasmtime_externref_t)]
-def wasmtime_externref_delete(ref: Any) -> None:
-    return _wasmtime_externref_delete(ref)  # type: ignore
+_wasmtime_externref_delete.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_externref_t)]
+def wasmtime_externref_delete(context: Any, ref: Any) -> None:
+    return _wasmtime_externref_delete(context, ref)  # type: ignore
 
 _wasmtime_externref_from_raw = dll.wasmtime_externref_from_raw
 _wasmtime_externref_from_raw.restype = POINTER(wasmtime_externref_t)
-_wasmtime_externref_from_raw.argtypes = [POINTER(wasmtime_context_t), c_void_p]
+_wasmtime_externref_from_raw.argtypes = [POINTER(wasmtime_context_t), c_uint32]
 def wasmtime_externref_from_raw(context: Any, raw: Any) -> ctypes._Pointer:
     return _wasmtime_externref_from_raw(context, raw)  # type: ignore
 
 _wasmtime_externref_to_raw = dll.wasmtime_externref_to_raw
-_wasmtime_externref_to_raw.restype = c_void_p
+_wasmtime_externref_to_raw.restype = c_uint32
 _wasmtime_externref_to_raw.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_externref_t)]
 def wasmtime_externref_to_raw(context: Any, ref: Any) -> int:
     return _wasmtime_externref_to_raw(context, ref)  # type: ignore
@@ -2520,16 +2628,18 @@ class wasmtime_valunion(Union):
         ("i64", c_int64),
         ("f32", c_float),
         ("f64", c_double),
-        ("funcref", wasmtime_func_t),
+        ("anyref", POINTER(wasmtime_anyref_t)),
         ("externref", POINTER(wasmtime_externref_t)),
+        ("funcref", wasmtime_func_t),
         ("v128", wasmtime_v128),
     ]
     i32: int
     i64: int
     f32: float
     f64: float
-    funcref: wasmtime_func_t
+    anyref: ctypes._Pointer
     externref: ctypes._Pointer
+    funcref: wasmtime_func_t
     v128: wasmtime_v128  # type: ignore
 
 wasmtime_valunion_t = wasmtime_valunion
@@ -2541,16 +2651,18 @@ class wasmtime_val_raw(Union):
         ("f32", c_float),
         ("f64", c_double),
         ("v128", wasmtime_v128),
+        ("anyref", c_uint32),
+        ("externref", c_uint32),
         ("funcref", c_void_p),
-        ("externref", c_void_p),
     ]
     i32: int
     i64: int
     f32: float
     f64: float
     v128: wasmtime_v128  # type: ignore
+    anyref: int
+    externref: int
     funcref: ctypes._Pointer
-    externref: ctypes._Pointer
 
 wasmtime_val_raw_t = wasmtime_val_raw
 
@@ -2566,15 +2678,15 @@ wasmtime_val_t = wasmtime_val
 
 _wasmtime_val_delete = dll.wasmtime_val_delete
 _wasmtime_val_delete.restype = None
-_wasmtime_val_delete.argtypes = [POINTER(wasmtime_val_t)]
-def wasmtime_val_delete(val: Any) -> None:
-    return _wasmtime_val_delete(val)  # type: ignore
+_wasmtime_val_delete.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_val_t)]
+def wasmtime_val_delete(context: Any, val: Any) -> None:
+    return _wasmtime_val_delete(context, val)  # type: ignore
 
 _wasmtime_val_copy = dll.wasmtime_val_copy
 _wasmtime_val_copy.restype = None
-_wasmtime_val_copy.argtypes = [POINTER(wasmtime_val_t), POINTER(wasmtime_val_t)]
-def wasmtime_val_copy(dst: Any, src: Any) -> None:
-    return _wasmtime_val_copy(dst, src)  # type: ignore
+_wasmtime_val_copy.argtypes = [POINTER(wasmtime_context_t), POINTER(wasmtime_val_t), POINTER(wasmtime_val_t)]
+def wasmtime_val_copy(context: Any, dst: Any, src: Any) -> None:
+    return _wasmtime_val_copy(context, dst, src)  # type: ignore
 
 class wasmtime_caller(Structure):
     pass
@@ -2725,6 +2837,12 @@ _wasmtime_linker_new.argtypes = [POINTER(wasm_engine_t)]
 def wasmtime_linker_new(engine: Any) -> ctypes._Pointer:
     return _wasmtime_linker_new(engine)  # type: ignore
 
+_wasmtime_linker_clone = dll.wasmtime_linker_clone
+_wasmtime_linker_clone.restype = POINTER(wasmtime_linker_t)
+_wasmtime_linker_clone.argtypes = [POINTER(wasmtime_linker_t)]
+def wasmtime_linker_clone(linker: Any) -> ctypes._Pointer:
+    return _wasmtime_linker_clone(linker)  # type: ignore
+
 _wasmtime_linker_delete = dll.wasmtime_linker_delete
 _wasmtime_linker_delete.restype = None
 _wasmtime_linker_delete.argtypes = [POINTER(wasmtime_linker_t)]
@@ -2820,6 +2938,12 @@ _wasmtime_memorytype_is64.restype = c_bool
 _wasmtime_memorytype_is64.argtypes = [POINTER(wasm_memorytype_t)]
 def wasmtime_memorytype_is64(ty: Any) -> bool:
     return _wasmtime_memorytype_is64(ty)  # type: ignore
+
+_wasmtime_memorytype_isshared = dll.wasmtime_memorytype_isshared
+_wasmtime_memorytype_isshared.restype = c_bool
+_wasmtime_memorytype_isshared.argtypes = [POINTER(wasm_memorytype_t)]
+def wasmtime_memorytype_isshared(ty: Any) -> bool:
+    return _wasmtime_memorytype_isshared(ty)  # type: ignore
 
 _wasmtime_memory_new = dll.wasmtime_memory_new
 _wasmtime_memory_new.restype = POINTER(wasmtime_error_t)

--- a/wasmtime/_globals.py
+++ b/wasmtime/_globals.py
@@ -1,22 +1,24 @@
 from . import _ffi as ffi
 from ctypes import *
-from wasmtime import GlobalType, Val, WasmtimeError, IntoVal
+from wasmtime import GlobalType, Val, WasmtimeError
+from typing import Any
 from ._store import Storelike
 
 
 class Global:
     _global: ffi.wasmtime_global_t
 
-    def __init__(self, store: Storelike, ty: GlobalType, val: IntoVal):
+    def __init__(self, store: Storelike, ty: GlobalType, val: Any):
         if not isinstance(ty, GlobalType):
             raise TypeError("expected a GlobalType")
-        val = Val._convert(ty.content, val)
+        val = Val._convert_to_raw(store, ty.content, val)
         global_ = ffi.wasmtime_global_t()
         error = ffi.wasmtime_global_new(
             store._context(),
             ty.ptr(),
-            byref(val._unwrap_raw()),
+            byref(val),
             byref(global_))
+        ffi.wasmtime_val_delete(store._context(), byref(val))
         if error:
             raise WasmtimeError._from_ptr(error)
         self._global = global_
@@ -35,7 +37,7 @@ class Global:
         ptr = ffi.wasmtime_global_type(store._context(), byref(self._global))
         return GlobalType._from_ptr(ptr, None)
 
-    def value(self, store: Storelike) -> IntoVal:
+    def value(self, store: Storelike) -> Any:
         """
         Gets the current value of this global
 
@@ -43,18 +45,19 @@ class Global:
         """
         raw = ffi.wasmtime_val_t()
         ffi.wasmtime_global_get(store._context(), byref(self._global), byref(raw))
-        val = Val(raw)
+        val = Val._from_raw(store, raw)
         if val.value is not None:
             return val.value
         else:
             return val
 
-    def set_value(self, store: Storelike, val: IntoVal) -> None:
+    def set_value(self, store: Storelike, val: Any) -> None:
         """
         Sets the value of this global to a new value
         """
-        val = Val._convert(self.type(store).content, val)
-        error = ffi.wasmtime_global_set(store._context(), byref(self._global), byref(val._unwrap_raw()))
+        val = Val._convert_to_raw(store, self.type(store).content, val)
+        error = ffi.wasmtime_global_set(store._context(), byref(self._global), byref(val))
+        ffi.wasmtime_val_delete(store._context(), byref(val))
         if error:
             raise WasmtimeError._from_ptr(error)
 

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -5,6 +5,10 @@ import ctypes
 import typing
 
 
+if typing.TYPE_CHECKING:
+    from ._store import Storelike
+
+
 @ctypes.CFUNCTYPE(None, c_void_p)
 def _externref_finalizer(extern_id: int) -> None:
     Val._id_to_ref_count[extern_id] -= 1
@@ -34,7 +38,8 @@ class Val:
     _id_to_extern: typing.Dict[int, typing.Any] = {}
     _id_to_ref_count: typing.Dict[int, int] = {}
 
-    _raw: typing.Optional[wasmtime_val_t]
+    _kind: wasmtime_valkind_t
+    _val: typing.Any
 
     @classmethod
     def i32(cls, val: int) -> "Val":
@@ -43,8 +48,8 @@ class Val:
         """
         if not isinstance(val, int):
             raise TypeError("expected an integer")
-        ffi = wasmtime_val_t(WASMTIME_I32, wasmtime_valunion(i32=val))
-        return Val(ffi)
+        val = wasmtime_valunion_t(i32=val).i32
+        return Val(WASMTIME_I32, val)
 
     @classmethod
     def i64(cls, val: int) -> "Val":
@@ -53,8 +58,8 @@ class Val:
         """
         if not isinstance(val, int):
             raise TypeError("expected an integer")
-        ffi = wasmtime_val_t(WASMTIME_I64, wasmtime_valunion(i64=val))
-        return Val(ffi)
+        val = wasmtime_valunion_t(i64=val).i64
+        return Val(WASMTIME_I64, val)
 
     @classmethod
     def f32(cls, val: float) -> "Val":
@@ -63,8 +68,8 @@ class Val:
         """
         if not isinstance(val, float):
             raise TypeError("expected a float")
-        ffi = wasmtime_val_t(WASMTIME_F32, wasmtime_valunion(f32=val))
-        return Val(ffi)
+        val = wasmtime_valunion_t(f32=val).f32
+        return Val(WASMTIME_F32, val)
 
     @classmethod
     def f64(cls, val: float) -> "Val":
@@ -73,25 +78,16 @@ class Val:
         """
         if not isinstance(val, float):
             raise TypeError("expected a float")
-        ffi = wasmtime_val_t(WASMTIME_F64, wasmtime_valunion(f64=val))
-        return Val(ffi)
+        val = wasmtime_valunion_t(f64=val).f64
+        return Val(WASMTIME_F64, val)
 
     @classmethod
     def externref(cls, extern: typing.Optional[typing.Any]) -> "Val":
-        ffi = wasmtime_val_t(WASMTIME_EXTERNREF)
-        ffi.of.externref = POINTER(wasmtime_externref_t)()
-        if extern is not None:
-            extern_id = _intern(extern)
-            ptr = wasmtime_externref_new(extern_id, _externref_finalizer)
-            ffi.of.externref = ptr
-        return Val(ffi)
+        return Val(WASMTIME_EXTERNREF, extern)
 
     @classmethod
     def funcref(cls, f: "typing.Optional[wasmtime.Func]") -> "Val":
-        ffi = wasmtime_val_t(WASMTIME_FUNCREF)
-        if f:
-            ffi.of.funcref = f._func
-        return Val(ffi)
+        return Val(WASMTIME_FUNCREF, f)
 
     @classmethod
     def ref_null(cls, ty: ValType) -> "Val":
@@ -106,97 +102,106 @@ class Val:
             return Val.funcref(None)
         raise WasmtimeError("Invalid reference type for `ref_null`: %s" % ty)
 
-    def __init__(self, raw: wasmtime_val_t):
-        self._raw = raw
+    def __init__(self, kind: wasmtime_valkind_t, val: typing.Any):
+        self._kind = kind
+        self._val = val
 
     def __eq__(self, rhs: typing.Any) -> typing.Any:
         if isinstance(rhs, Val):
-            return self._unwrap_raw().kind == rhs._unwrap_raw().kind and self.value == rhs.value
-        return self.value == rhs
-
-    def __del__(self) -> None:
-        if hasattr(self, "_raw") and self._raw is not None:
-            wasmtime_val_delete(ctypes.byref(self._raw))
-
-    def _clone(self) -> "Val":
-        raw = self._unwrap_raw()
-        if raw.kind == WASMTIME_EXTERNREF and raw.of.externref:
-            externref = wasmtime_externref_clone(raw.of.externref)
-            raw = wasmtime_val_t(WASMTIME_EXTERNREF)
-            raw.of.externref = externref
-        return Val(raw)
+            return self._kind == rhs._kind and self._val == rhs._val
+        return self._val == rhs
 
     @classmethod
-    def _convert(cls, ty: ValType, val: "IntoVal") -> "Val":
+    def _convert_to_raw(cls, store: 'Storelike', ty: ValType, val: Any) -> wasmtime_val_t:
         if isinstance(val, Val):
             if ty != val.type:
                 raise TypeError("wrong type of `Val` provided")
-            return val
+            return val._new_raw(store)
         if ty == ValType.externref():
-            return Val.externref(val)
-        if isinstance(val, int):
+            print('convert to externref', val);
+            return Val.externref(val)._new_raw(store)
+        elif isinstance(val, int):
             if ty == ValType.i32():
-                return Val.i32(val)
+                return Val.i32(val)._new_raw(store)
             if ty == ValType.i64():
-                return Val.i64(val)
+                return Val.i64(val)._new_raw(store)
         elif isinstance(val, float):
             if ty == ValType.f32():
-                return Val.f32(val)
+                return Val.f32(val)._new_raw(store)
             if ty == ValType.f64():
-                return Val.f64(val)
+                return Val.f64(val)._new_raw(store)
         elif isinstance(val, wasmtime.Func):
-            return Val.funcref(val)
+            return Val.funcref(val)._new_raw(store)
         elif val is None:
             if ty == ValType.externref():
-                return Val.externref(None)
+                return Val.externref(None)._new_raw(store)
             if ty == ValType.funcref():
-                return Val.funcref(None)
+                return Val.funcref(None)._new_raw(store)
         raise TypeError("don't know how to convert %r to %s" % (val, ty))
 
-    def _into_raw(self) -> wasmtime_val_t:
-        raw = self._unwrap_raw()
-        self._raw = None
-        return raw
-
-    def _unwrap_raw(self) -> wasmtime_val_t:
-        if isinstance(self._raw, wasmtime_val_t):
-            return self._raw
+    def _new_raw(self, store: 'Storelike') -> wasmtime_val_t:
+        ret = wasmtime_val_t(kind = self._kind)
+        if ret.kind == WASMTIME_I32.value:
+            ret.of.i32 = self._val
+        elif ret.kind == WASMTIME_I64.value:
+            ret.of.i64 = self._val
+        elif ret.kind == WASMTIME_F32.value:
+            ret.of.f32 = self._val
+        elif ret.kind == WASMTIME_F64.value:
+            ret.of.f64 = self._val
+        elif ret.kind == WASMTIME_EXTERNREF.value:
+            if self._val is not None:
+                extern_id = _intern(self._val)
+                ret.of.externref = wasmtime_externref_new(store._context(), extern_id, _externref_finalizer)
+            else:
+                ret.of.externref = POINTER(wasmtime_externref_t)()
+        elif ret.kind == WASMTIME_FUNCREF.value:
+            if self._val is not None:
+                ret.of.funcref = self._val._func
         else:
-            raise WasmtimeError("use of moved `Val`")
+            raise RuntimeError("unknown kind")
+        return ret
 
     @classmethod
-    def _value(cls, raw: wasmtime_val_t) -> typing.Union[int, float, "wasmtime.Func", typing.Any]:
+    def _from_raw(cls, store: 'Storelike', raw: wasmtime_val_t, owned: bool = True) -> 'Val':
+        val: typing.Any = None
         if raw.kind == WASMTIME_I32.value:
-            return raw.of.i32
-        if raw.kind == WASMTIME_I64.value:
-            return raw.of.i64
-        if raw.kind == WASMTIME_F32.value:
-            return raw.of.f32
-        if raw.kind == WASMTIME_F64.value:
-            return raw.of.f64
-        if raw.kind == WASMTIME_EXTERNREF.value:
-            return Val._as_externref(raw)
-        if raw.kind == WASMTIME_FUNCREF.value:
-            return Val._as_funcref(raw)
-        raise WasmtimeError("Unkown `wasmtime_valkind_t`: {}".format(raw.kind))
+            val = raw.of.i32
+        elif raw.kind == WASMTIME_I64.value:
+            val = raw.of.i64
+        elif raw.kind == WASMTIME_F32.value:
+            val = raw.of.f32
+        elif raw.kind == WASMTIME_F64.value:
+            val = raw.of.f64
+        elif raw.kind == WASMTIME_EXTERNREF.value:
+            if raw.of.externref:
+                extern_id = wasmtime_externref_data(store._context(), raw.of.externref)
+                val = _unintern(extern_id)
+        elif raw.kind == WASMTIME_FUNCREF.value:
+            if raw.of.funcref.store_id != 0:
+                val = wasmtime.Func._from_raw(raw.of.funcref)
+        else:
+            raise WasmtimeError("Unkown `wasmtime_valkind_t`: {}".format(raw.kind))
+
+        if owned:
+            wasmtime_val_delete(store._context(), byref(raw))
+
+        return Val(raw.kind, val)
 
     @property
-    def value(self) -> typing.Union[int, float, "wasmtime.Func", typing.Any]:
+    def value(self) -> typing.Any:
         """
         Get the the underlying value as a python value
-
-        Returns `None` if the value can't be represented in Python, or if the
-        value is a null reference type.
         """
-        return Val._value(self._unwrap_raw())
+        return self._val
 
     def as_i32(self) -> typing.Optional[int]:
         """
         Get the 32-bit integer value of this value, or `None` if it's not an i32
         """
-        raw = self._unwrap_raw()
-        if raw.kind == WASMTIME_I32.value:
-            return int(raw.of.i32)
+        if self._kind == WASMTIME_I32:
+            assert(isinstance(self._val, int))
+            return self._val
         else:
             return None
 
@@ -204,9 +209,9 @@ class Val:
         """
         Get the 64-bit integer value of this value, or `None` if it's not an i64
         """
-        raw = self._unwrap_raw()
-        if raw.kind == WASM_I64.value:
-            return raw.of.i64
+        if self._kind == WASMTIME_I64:
+            assert(isinstance(self._val, int))
+            return self._val
         else:
             return None
 
@@ -214,9 +219,9 @@ class Val:
         """
         Get the 32-bit float value of this value, or `None` if it's not an f32
         """
-        raw = self._unwrap_raw()
-        if raw.kind == WASMTIME_F32.value:
-            return raw.of.f32
+        if self._kind == WASMTIME_F32:
+            assert(isinstance(self._val, float))
+            return self._val
         else:
             return None
 
@@ -224,87 +229,55 @@ class Val:
         """
         Get the 64-bit float value of this value, or `None` if it's not an f64
         """
-        raw = self._unwrap_raw()
-        if raw.kind == WASMTIME_F64.value:
-            return raw.of.f64
+        if self._kind == WASMTIME_F64:
+            assert(isinstance(self._val, float))
+            return self._val
         else:
             return None
-
-    @classmethod
-    def _as_externref(cls, raw: wasmtime_val_t) -> typing.Optional[typing.Any]:
-        if raw.kind != WASMTIME_EXTERNREF.value:
-            return None
-        if not raw.of.externref:
-            return None
-        extern_id = wasmtime_externref_data(raw.of.externref)
-        return _unintern(extern_id)
 
     def as_externref(self) -> typing.Optional[typing.Any]:
         """
         Get the extern data referenced by this `externref` value, or `None` if
         it's not an `externref`.
         """
-        return Val._as_externref(self._unwrap_raw())
-
-    @classmethod
-    def _as_funcref(cls, raw: wasmtime_val_t) -> typing.Optional["wasmtime.Func"]:
-        if raw.kind != WASMTIME_FUNCREF.value:
-            return None
-        if raw.of.funcref.store_id == 0:
-            return None
+        if self._kind == WASMTIME_EXTERNREF:
+            return self._val
         else:
-            return wasmtime.Func._from_raw(raw.of.funcref)
+            return None
 
     def as_funcref(self) -> typing.Optional["wasmtime.Func"]:
         """
         Get the function that this `funcref` value is referencing, or `None` if
         this is not a `funcref` value, or is a null reference.
         """
-        return Val._as_funcref(self._unwrap_raw())
+        if self._kind == WASMTIME_FUNCREF:
+            assert(isinstance(self._val, wasmtime.Func))
+            return self._val
+        else:
+            return None
 
     @property
     def type(self) -> ValType:
         """
         Returns the `ValType` corresponding to this `Val`
         """
-        kind = self._unwrap_raw().kind
-        if kind == WASMTIME_I32.value:
+        kind = self._kind
+        if kind == WASMTIME_I32:
             return ValType.i32()
-        elif kind == WASMTIME_I64.value:
+        elif kind == WASMTIME_I64:
             return ValType.i64()
-        elif kind == WASMTIME_F32.value:
+        elif kind == WASMTIME_F32:
             return ValType.f32()
-        elif kind == WASMTIME_F64.value:
+        elif kind == WASMTIME_F64:
             return ValType.f64()
-        elif kind == WASMTIME_V128.value:
+        elif kind == WASMTIME_V128:
             raise Exception("unimplemented v128 type")
-        elif kind == WASMTIME_EXTERNREF.value:
+        elif kind == WASMTIME_EXTERNREF:
             return ValType.externref()
-        elif kind == WASMTIME_FUNCREF.value:
+        elif kind == WASMTIME_FUNCREF:
             return ValType.funcref()
         else:
             raise Exception("unknown kind %d" % kind.value)
-
-
-IntoVal = typing.Union[
-    # Id.
-    Val,
-
-    # `i32` and `i64`
-    int,
-
-    # `f32` and `f64`
-    float,
-
-    # Null reference types
-    None,
-
-    # `funcref`
-    "wasmtime.Func",
-
-    # `externref`
-    typing.Any
-]
 
 
 # This needs to be imported so that mypy understands `wasmtime.Func` in typings,


### PR DESCRIPTION
Handle some updates related to externref and change how `Val` works by making it no longer store `wasmtime_val_t` but instead store the raw value itself which is converted to `wasmtime_val_t` on-the-fly.