### PR TITLE
Add a wheel for `musllinux_1_2_x86_64`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,25 +38,9 @@ runs:
 
   # Install the `wasm-tools` binary with the `component` subcommand that is all
   # that's needed here.
-  - run: |
-      echo WASM_TOOLS=wasm-tools-1.0.53 >> $GITHUB_ENV
-      mkdir -p '${{ runner.tool_cache }}/wasm-tools'
-      echo '${{ runner.tool_cache }}/wasm-tools' >> $GITHUB_PATH
-    shell: bash
-  - run: |
-      curl -L https://github.com/bytecodealliance/wasm-tools/releases/download/$WASM_TOOLS/$WASM_TOOLS-x86_64-linux.tar.gz | tar xzv -C ${{ runner.tool_cache }}/wasm-tools --strip-components 1
-    if: runner.os == 'Linux'
-    shell: bash
-  - run: |
-      curl -L https://github.com/bytecodealliance/wasm-tools/releases/download/$WASM_TOOLS/$WASM_TOOLS-x86_64-macos.tar.gz | tar xzv -C ${{ runner.tool_cache }}/wasm-tools --strip-components 1
-    if: runner.os == 'macOS'
-    shell: bash
-  - run: |
-      path='${{ runner.tool_cache }}/wasm-tools'
-      curl -o "$path/bins.zip" -L https://github.com/bytecodealliance/wasm-tools/releases/download/$WASM_TOOLS/$WASM_TOOLS-x86_64-windows.zip
-      7z e "$path/bins.zip" -o"$path"
-    if: runner.os == 'Windows'
-    shell: bash
+  - uses: bytecodealliance/actions/wasm-tools/setup@v1
+    with:
+      version: "1.208.1"
 
   # Build the bindgen wasm blob with some extra Rust targets.
   - run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,12 +27,6 @@ runs:
       echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
 
   # Ensure the Rust lockfile is up-to-date
-  - uses: actions/cache@v3
-    with:
-      path: |
-        ~/.cargo/registry/index
-        ~/.cargo/git/db
-      key: cargo-registry-${{ hashFiles('rust/Cargo.lock') }}
   - run: cargo fetch --manifest-path rust/Cargo.toml --locked
     shell: bash
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
   # Setup Python and the Python dependencies of this project
-  - uses: actions/setup-python@v4
+  - uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
   - run: pip install -e ".[testing]"
@@ -43,7 +43,7 @@ runs:
       echo CARGO_PROFILE_DEV_DEBUG=0 >> $GITHUB_ENV
       echo RUSTC_VERSION=`rustc --version` >> $GITHUB_ENV
     shell: bash
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     with:
       path: rust/target
       key: rust-target-${{ env.RUSTC_VERSION }}-${{ runner.os }}-${{ hashFiles('rust/Cargo.lock') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,11 @@ jobs:
         python ci/download-wasmtime.py win32 x86_64
         python ci/build-rust.py
         python setup.py bdist_wheel --plat-name win-amd64
+    - run: |
+        git clean -fdx wasmtime build
+        python ci/download-wasmtime.py musl x86_64
+        python ci/build-rust.py
+        python setup.py bdist_wheel --plat-name musllinux_1_2_x86_64
 
     # Build an "any" wheel with:
     #

--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -16,8 +16,11 @@ WASMTIME_VERSION = "v21.0.0"
 def main(platform, arch):
     is_zip = False
     version = WASMTIME_VERSION
+
+    # Temporarily use `dev` artifacts for musl until Wasmtime 22 is released.
     if platform == 'musl':
         version = 'dev'
+
     if arch == 'AMD64':
         arch = 'x86_64'
     if arch == 'arm64':

--- a/ci/download-wasmtime.py
+++ b/ci/download-wasmtime.py
@@ -16,13 +16,13 @@ WASMTIME_VERSION = "v21.0.0"
 def main(platform, arch):
     is_zip = False
     version = WASMTIME_VERSION
-    dirname = '{}-{}'.format(platform, arch)
     if platform == 'musl':
         version = 'dev'
     if arch == 'AMD64':
         arch = 'x86_64'
     if arch == 'arm64':
         arch = 'aarch64'
+    dirname = '{}-{}'.format(platform, arch)
     if platform == 'linux' or platform == 'musl':
         filename = 'wasmtime-{}-{}-{}-c-api.tar.xz'.format(version, arch, platform)
         libname = '_libwasmtime.so'


### PR DESCRIPTION
Use binaries from bytecodealliance/wasmtime#8668 to add a musl wheel.

cc #237