### PR TITLE
 Add defaults for preopen_dir arguments 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import subprocess
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = "27.0.0"
+version = "27.0.1"
 
 # Give unique version numbers to all commits so our publication-on-each commit
 # works on main

--- a/tests/test_wasi.py
+++ b/tests/test_wasi.py
@@ -31,6 +31,7 @@ class TestWasi(unittest.TestCase):
         with self.assertRaises(WasmtimeError):
             config.stderr_file = 'some-directory/without-a-rainbow'
         config.preopen_dir('wasmtime', 'other', DirPerms.READ_WRITE, FilePerms.READ_WRITE)
+        config.preopen_dir('wasmtime', 'other2')
 
     def test_preview1(self):
         linker = Linker(Engine())

--- a/wasmtime/_wasi.py
+++ b/wasmtime/_wasi.py
@@ -154,7 +154,7 @@ class WasiConfig(Managed["ctypes._Pointer[ffi.wasi_config_t]"]):
         """
         ffi.wasi_config_inherit_stderr(self.ptr())
 
-    def preopen_dir(self, path: str, guest_path: str, dir_perms: DirPerms, file_perms: FilePerms) -> None:
+    def preopen_dir(self, path: str, guest_path: str, dir_perms: DirPerms = DirPerms.READ_WRITE, file_perms: FilePerms = FilePerms.READ_WRITE) -> None:
         """
         Allows the WASI program to access the directory at `path` using the
         path `guest_path` within the WASI program.


### PR DESCRIPTION
Keeps this the same way it was before in terms of defaults, but new
behavior can be opted-in to as well.

Closes #259