### PR TITLE
Fix WIT declaration in the component example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ example with this core wasm module at `demo.wat`:
 and with this [`*.wit`] interface at `demo.wit`:
 
 ```text
-package my:demo
+package my:demo;
 
 world demo {
   import python: interface {
-    print: func(s: string)
+    print: func(s: string);
   }
 
-  export run: func()
+  export run: func();
 }
 ```
 


### PR DESCRIPTION
wasm-tools component embed -w demo demo.wit demo.wat -o demo.wasm error: expected '{', found keyword `world`
     --> demo.wit:3:1
      |
    3 | world demo {

wasm-tools --version
    wasm-tools 1.222.0