### PR TITLE
README: Eliminate rendered underlines between badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,12 @@
   <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
 
   <p>
-    <a href="https://github.com/bytecodealliance/wasmtime-py/actions?query=workflow%3ACI">
-      <img src="https://github.com/bytecodealliance/wasmtime-py/workflows/CI/badge.svg" alt="CI status"/>
-    </a>
-    <a href="https://pypi.org/project/wasmtime/">
-      <img src="https://img.shields.io/pypi/v/wasmtime.svg" alt="Latest Version"/>
-    </a>
-    <a href="https://pypi.org/project/wasmtime/">
-      <img src="https://img.shields.io/pypi/pyversions/wasmtime.svg" alt="Latest Version"/>
-    </a>
-    <a href="https://bytecodealliance.github.io/wasmtime-py/">
-      <img src="https://img.shields.io/badge/docs-main-green" alt="Documentation"/>
-    </a>
-    <a href="https://bytecodealliance.github.io/wasmtime-py/coverage/">
-      <img src="https://img.shields.io/badge/coverage-main-green" alt="Code Coverage"/>
-    </a>
+    <!-- Badge links contain no whitespace, to eliminate underlines in rendered page -->
+    <a href="https://github.com/bytecodealliance/wasmtime-py/actions?query=workflow%3ACI"><img src="https://github.com/bytecodealliance/wasmtime-py/workflows/CI/badge.svg" alt="CI status"/></a>
+    <a href="https://pypi.org/project/wasmtime/"><img src="https://img.shields.io/pypi/v/wasmtime.svg" alt="Latest Version"/></a>
+    <a href="https://pypi.org/project/wasmtime/"><img src="https://img.shields.io/pypi/pyversions/wasmtime.svg" alt="Latest Version"/></a>
+    <a href="https://bytecodealliance.github.io/wasmtime-py/"><img src="https://img.shields.io/badge/docs-main-green" alt="Documentation"/></a>
+    <a href="https://bytecodealliance.github.io/wasmtime-py/coverage/"><img src="https://img.shields.io/badge/coverage-main-green" alt="Code Coverage"/></a>
   </p>
 
 </div>


### PR DESCRIPTION
The README rendered by Github had a small hyperlink underline between each badge image. Eliminating the whitespace removes this.

Before
![image](https://github.com/user-attachments/assets/3634d96d-f80b-4d5b-87d0-2ad93040f0cc)

After
![image](https://github.com/user-attachments/assets/b9347de9-fa5e-4953-98e8-18f6bc78fad0)

Screenshots taken with Firefox 134.0.2 on macOS, dark theme.

Feel free to discard or reject this PR, with or without comment. I'm also happy to amend it as desired. I figured it was quicker to show, than to go though a few rounds of "would you be interested in?", "please clarify", ...