### PR TITLE
Build source tar.gz (sdist) alongside wheels (bdist_wheel)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,10 @@ jobs:
     # If this is a tagged build use real version numbers
     - run: echo "PROD=true" >> $GITHUB_ENV
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    - name: Build source distribution
+      run: |
+        git clean -fdx wasmtime build
+        python setup.py sdist
     - run: |
         git clean -fdx wasmtime build
         python ci/download-wasmtime.py linux x86_64
@@ -115,6 +119,8 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        # Although the artifacts store is called "wheels", it now also
+        # contains other distribution packages (e.g. source tar.gz).
         name: wheels
         path: dist
 
@@ -164,7 +170,8 @@ jobs:
       with:
         path: generated-docs
 
-  upload_wheels:
+  upload_dists:
+    # Upload distribution packages (source tar.gz, wheels) to a package index
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -176,6 +183,8 @@ jobs:
     - uses: ./.github/actions/setup
     - uses: actions/download-artifact@v4
       with:
+        # Although the artifacts store is called "wheels", it now also
+        # contains other distribution packages (e.g. source tar.gz).
         name: wheels
         path: dist
     - run: find .

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# See also MANIFEST.in
+
 build
 html
 dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,25 @@
-recursive-include wasmtime *.py *.wasm *.so *.dll *.dylib
+# Specify files to be included in source distributions (source tar.gz).
+# Some files are included by default already (e.g. LICENSE, README*).
+# https://setuptools.pypa.io/en/stable/userguide/miscellaneous.html#controlling-files-in-the-distribution
+
+graft ci
+graft examples
+graft rust
+graft tests
+
+prune rust/target
+prune tests/bindgen/generated
+prune tests/codegen/generated
+prune wasmtime/bindgen/generated
+prune wasmtime/include
+
+include .flake8
+include CONTRIBUTING.md
+include mypy.ini
+include pytest.ini
+
+global-exclude *.dll
+global-exclude *.dylib
+global-exclude *.py[cod]
+global-exclude *.so
+global-exclude *~

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,23 @@ setuptools.setup(
         "Documentation": "https://bytecodealliance.github.io/wasmtime-py/",
         "Source Code": "https://github.com/bytecodealliance/wasmtime-py",
     },
-    packages=['wasmtime'],
+    packages=setuptools.find_packages(
+        include=['wasmtime*'],
+        exclude=['wasmtime.include'],
+    ),
     install_requires=['importlib_resources>=5.10'],
     include_package_data=True,
-    package_data={"wasmtime": ["py.typed"]},
+    package_data={
+        "wasmtime": [
+            "*-*/*.dll",
+            "*-*/*.dylib",
+            "*-*/*.so",
+            "py.typed",
+        ],
+        "wasmtime.bindgen.generated": [
+            "*.wasm",
+        ],
+    },
     python_requires='>=3.9',
     test_suite="tests",
     extras_require={


### PR DESCRIPTION
This is a first pass. Probably enough to build conda packages, but not enough for pip or uv to build from. I've tried to be minimally invasive

- Keep setuptools as the packaging backend
- Keep `setup.py` as the source of truth

A more complete overhaul might consider moving to a more recent/focused build library (e.g. PyO3, Maturin); and/or a more recent (e.g. `setup.cfg`, `pyproject.toml`).

A diff of file listings before and after show the wheel contents are unchanged, except for version specific paths

```console
$ diff -u \
  <(zipinfo -1 dist-before/wasmtime-33.0.0.dev362-py3-none-macosx_11_0_arm64.whl|sort) \
  <(zipinfo -1 dist.after/wasmtime-33.0.0.dev363-py3-none-macosx_11_0_arm64.whl|sort)
--- /dev/fd/11  2025-06-10 09:53:26
+++ /dev/fd/12  2025-06-10 09:53:26
@@ -1,8 +1,8 @@
-wasmtime-33.0.0.dev362.dist-info/LICENSE
-wasmtime-33.0.0.dev362.dist-info/METADATA
-wasmtime-33.0.0.dev362.dist-info/RECORD
-wasmtime-33.0.0.dev362.dist-info/top_level.txt
-wasmtime-33.0.0.dev362.dist-info/WHEEL
+wasmtime-33.0.0.dev363.dist-info/LICENSE
+wasmtime-33.0.0.dev363.dist-info/METADATA
+wasmtime-33.0.0.dev363.dist-info/RECORD
+wasmtime-33.0.0.dev363.dist-info/top_level.txt
+wasmtime-33.0.0.dev363.dist-info/WHEEL
 wasmtime/__init__.py
 wasmtime/_bindings.py
 wasmtime/_config.py
```

refs #231