### PR TITLE
Add support for exceptions configuration

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ class TestConfig(unittest.TestCase):
         config.wasm_multi_value = True
         config.wasm_multi_memory = True
         config.wasm_memory64 = True
+        config.wasm_exceptions = True
         config.cranelift_debug_verifier = True
         config.strategy = "cranelift"
         config.strategy = "auto"

--- a/wasmtime/_config.py
+++ b/wasmtime/_config.py
@@ -161,6 +161,18 @@ class Config(Managed["ctypes._Pointer[ffi.wasm_config_t]"]):
         ffi.wasmtime_config_wasm_relaxed_simd_deterministic_set(self.ptr(), enable)
 
     @setter_property
+    def wasm_exceptions(self, enable: bool) -> None:
+        """
+        Configures whether the wasm [exceptions proposal] is enabled.
+
+        [exceptions proposal]: https://github.com/WebAssembly/exception-handling
+        """
+
+        if not isinstance(enable, bool):
+            raise TypeError('expected a bool')
+        ffi.wasmtime_config_wasm_exceptions_set(self.ptr(), enable)
+
+    @setter_property
     def strategy(self, strategy: str) -> None:
         """
         Configures the compilation strategy used for wasm code.


### PR DESCRIPTION
This PR makes exceptions configuration available on `Config`.
It depends on [wasmtime#11861](https://github.com/bytecodealliance/wasmtime/pull/11861) changes.

Yeah... I also mocked [this PR](https://github.com/bytecodealliance/wasmtime-py/pull/205). Thank you womeier 😆 