### PR TITLE
Fix ResourceReader ImportError exception on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Rust",

--- a/wasmtime/loader.py
+++ b/wasmtime/loader.py
@@ -14,8 +14,12 @@ import sys
 import struct
 from pathlib import Path
 from importlib import import_module
-from importlib.abc import Loader, MetaPathFinder, ResourceReader
+from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
+if sys.version_info[:2] >= (3, 11):
+    from importlib.resources.abc import ResourceReader
+else:
+    from importlib.abc import ResourceReader
 
 from wasmtime import Module, Linker, Store, WasiConfig
 from wasmtime import Func, Table, Global, Memory


### PR DESCRIPTION
`importlib.abc.ResourceReader` moved to `importlib.resources.abc.ResourceReader` in Python 3.11. The old location was deprecated in 3.11 and removed in 3.14.

TraversableResources is now the preferred API, but AIUI ResourceReader has no formal deprecation at the new location. I've chosen an if/else block because it is interpretted by MyPy, as opposed to try/except ImportError which MyPy cannot type check on Python <= 3.10.

fixes #298