### PR TITLE
Remove importlib_resources dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ authors = [
     {name="The Wasmtime Project Developers", email="hello@bytecodealliance.org"},
 ]
 requires-python=">=3.9"
-dependencies = [
-    "importlib_resources>=5.10",
-]
 classifiers=[
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/rust/src/bindgen.rs
+++ b/rust/src/bindgen.rs
@@ -752,11 +752,11 @@ impl<'a> Instantiator<'a> {
         let i = self.instances.push(idx);
         let core_file_name = self.gen.core_file_name(&self.name, idx.as_u32());
         self.gen.init.pyimport("pathlib", None);
-        self.gen.init.pyimport("importlib_resources", None);
+        self.gen.init.pyimport("importlib.resources", None);
 
         uwriteln!(
             self.gen.init,
-            "file = importlib_resources.files() / ('{}')",
+            "file = importlib.resources.files() / ('{}')",
             core_file_name,
         );
         uwriteln!(self.gen.init, "if isinstance(file, pathlib.Path):");


### PR DESCRIPTION
This replaces a single use of importlib_resources.files() with importlib.resources.files() which was introduced in Python 3.9. Now that wasmtime-py requires Python >= 3.9 the compatibility shim should no longer be necessary.

importlib_resources (with an underscore) is a Python package that backports newer parts of importlib.resources (with a .) to older Python releases.

This PR will fail until #299 or another fix for #298 is merged (of course it may also fail after that).