### PR TITLE
Add Nox configuration, to run tests locally across Python versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ recursive-exclude wasmtime/bindgen/generated *.py *.wasm
 include .flake8
 include CONTRIBUTING.md
 include mypy.ini
+include noxfile.py
 include pytest.ini
 include VERSION
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,18 @@
+import nox
+
+PYPROJECT = nox.project.load_toml('pyproject.toml')
+
+PYTHONS = [
+    # Reads versions from Trove classifiers
+    *nox.project.python_versions(PYPROJECT),
+]
+
+# Prefer uv to create virtual environments, fall back to virtualenv.
+# Overriden by $NOX_DEFAULT_VENV_BACKEND=... or nox --default-venv-backend ...
+# https://nox.thea.codes/en/stable/usage.html#changing-the-sessions-default-backend
+nox.options.default_venv_backend = 'uv|virtualenv'
+
+@nox.session(python=PYTHONS, tags=["test"])
+def tests(session):
+    session.install('.[testing]')
+    session.run('coverage', 'run', '-m', 'pytest')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
-addopts = --doctest-modules --mypy --ignore-glob=tests/bindgen/*/app.py
+addopts =
+    --doctest-modules
+    --ignore-glob=tests/bindgen/*/app.py
+    --ignore-glob=noxfile.py
+    --mypy
 norecursedirs = 
     .*
     *.egg


### PR DESCRIPTION
Currently it's awkward to run the testsuite locally across all supported Python versions, so version specific errors are only found in Github CI jobs.

This change allows the wasmtime-py test suite to be run across all supported CPython versions 3.9 - 3.14 at time of writing. It uses [Nox](https://nox.thea.codes/en/stable/index.html) a Python CLI tool for running tests or other build/project management tasks. It's invoked as
- `nox` or `python3 -m nox` - run every session defined in noxfile.py
- `nox --list` - list sessions defined
- `nox -s <session>` - Run a particular session
- `nox -p <python,...>` - Run sessions the use the given python version(s)

If desired checks such as MyPy or style can also be included.