### PR TITLE
Add `__main__` guards to examples

### DIFF
--- a/examples/gcd.py
+++ b/examples/gcd.py
@@ -2,9 +2,13 @@
 
 from wasmtime import Store, Module, Instance
 
-store = Store()
-module = Module.from_file(store.engine, './examples/gcd.wat')
-instance = Instance(store, module, [])
-gcd = instance.exports(store)["gcd"]
+def run():
+    store = Store()
+    module = Module.from_file(store.engine, './examples/gcd.wat')
+    instance = Instance(store, module, [])
+    gcd = instance.exports(store)["gcd"]
 
-print("gcd(6, 27) = %d" % gcd(store, 6, 27))
+    print("gcd(6, 27) = %d" % gcd(store, 6, 27))
+
+if __name__ == '__main__':
+    run()

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,22 +1,26 @@
 from wasmtime import Store, Module, Instance, Func, FuncType
 
-# Almost all operations in wasmtime require a contextual "store" argument to be
-# shared amongst objects
-store = Store()
+def run():
+    # Almost all operations in wasmtime require a contextual "store" argument to be
+    # shared amongst objects
+    store = Store()
 
-# Here we can compile a `Module` which is then ready for instantiation
-# afterwards
-module = Module.from_file(store.engine, './examples/hello.wat')
+    # Here we can compile a `Module` which is then ready for instantiation
+    # afterwards
+    module = Module.from_file(store.engine, './examples/hello.wat')
 
-# Our module needs one import, so we'll create that here.
-
-
-def say_hello():
-    print("Hello from Python!")
+    # Our module needs one import, so we'll create that here.
 
 
-hello = Func(store, FuncType([], []), say_hello)
+    def say_hello():
+        print("Hello from Python!")
 
-# And with all that we can instantiate our module and call the export!
-instance = Instance(store, module, [hello])
-instance.exports(store)["run"](store)
+
+    hello = Func(store, FuncType([], []), say_hello)
+
+    # And with all that we can instantiate our module and call the export!
+    instance = Instance(store, module, [hello])
+    instance.exports(store)["run"](store)
+
+if __name__ == '__main__':
+    run()

--- a/examples/linking.py
+++ b/examples/linking.py
@@ -2,29 +2,33 @@
 
 from wasmtime import Engine, Store, Module, Linker, WasiConfig
 
-engine = Engine()
+def run():
+    engine = Engine()
 
-# Load and compile our two modules
-linking1 = Module.from_file(engine, "examples/linking1.wat")
-linking2 = Module.from_file(engine, "examples/linking2.wat")
+    # Load and compile our two modules
+    linking1 = Module.from_file(engine, "examples/linking1.wat")
+    linking2 = Module.from_file(engine, "examples/linking2.wat")
 
-# Set up our linker which is going to be linking modules together. We
-# want our linker to have wasi available, so we set that up here as well.
-linker = Linker(engine)
-linker.define_wasi()
+    # Set up our linker which is going to be linking modules together. We
+    # want our linker to have wasi available, so we set that up here as well.
+    linker = Linker(engine)
+    linker.define_wasi()
 
-# Create a `Store` to hold instances, and configure wasi state
-store = Store(engine)
-wasi = WasiConfig()
-wasi.inherit_stdout()
-store.set_wasi(wasi)
+    # Create a `Store` to hold instances, and configure wasi state
+    store = Store(engine)
+    wasi = WasiConfig()
+    wasi.inherit_stdout()
+    store.set_wasi(wasi)
 
-# Instantiate our first module which only uses WASI, then register that
-# instance with the linker since the next linking will use it.
-linking2 = linker.instantiate(store, linking2)
-linker.define_instance(store, "linking2", linking2)
+    # Instantiate our first module which only uses WASI, then register that
+    # instance with the linker since the next linking will use it.
+    linking2 = linker.instantiate(store, linking2)
+    linker.define_instance(store, "linking2", linking2)
 
-# And with that we can perform the final link and the execute the module.
-linking1 = linker.instantiate(store, linking1)
-run = linking1.exports(store)["run"]
-run(store)
+    # And with that we can perform the final link and the execute the module.
+    linking1 = linker.instantiate(store, linking1)
+    run = linking1.exports(store)["run"]
+    run(store)
+
+if __name__ == '__main__':
+    run()

--- a/examples/loader.py
+++ b/examples/loader.py
@@ -3,23 +3,27 @@
 
 import wasmtime.loader  # noqa: F401
 
-import loader_load_python  # type: ignore
-import loader_load_wasm  # type: ignore
-import loader_load_wasi  # type: ignore # noqa: F401
+def run():
+    import loader_load_python  # type: ignore
+    import loader_load_wasm  # type: ignore
+    import loader_load_wasi  # type: ignore # noqa: F401
 
-# This imports our `loader_add.wat` file next to this module
-import loader_add  # type: ignore
-assert(loader_add.add(1, 2) == 3)
+    # This imports our `loader_add.wat` file next to this module
+    import loader_add  # type: ignore
+    assert(loader_add.add(1, 2) == 3)
 
-# This imports our `loader_load_wasm.wat`, which in turn imports
-# `loader_load_wasm_target.wat`, which gives us the answer of 4
-assert(loader_load_wasm.call_dependency() == 4)
+    # This imports our `loader_load_wasm.wat`, which in turn imports
+    # `loader_load_wasm_target.wat`, which gives us the answer of 4
+    assert(loader_load_wasm.call_dependency() == 4)
 
-# This imports our `loader_load_python.wat` file which then imports its own
-# python file.
-assert(loader_load_python.call_python() == 42)
+    # This imports our `loader_load_python.wat` file which then imports its own
+    # python file.
+    assert(loader_load_python.call_python() == 42)
 
-# This imports our `loader_load_wasi.wat`, which in turn imports
-# the random_get functionality from the wasi runtime environment
-random_value = loader_load_wasi.wasi_random()
-assert(random_value >= 0 and random_value < 256)
+    # This imports our `loader_load_wasi.wat`, which in turn imports
+    # the random_get functionality from the wasi runtime environment
+    random_value = loader_load_wasi.wasi_random()
+    assert(random_value >= 0 and random_value < 256)
+
+if __name__ == '__main__':
+    run()

--- a/examples/loader_component.py
+++ b/examples/loader_component.py
@@ -3,9 +3,12 @@
 
 import wasmtime, wasmtime.loader
 
-import loader_component_add  # type: ignore
+def run():
+    import loader_component_add  # type: ignore
 
+    store = wasmtime.Store()
+    component = loader_component_add.Root(store)
+    assert component.add(store, 1, 2) == 3
 
-store = wasmtime.Store()
-component = loader_component_add.Root(store)
-assert component.add(store, 1, 2) == 3
+if __name__ == '__main__':
+    run()

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -6,79 +6,83 @@
 
 from wasmtime import Store, Module, Instance, Trap, MemoryType, Memory, Limits, WasmtimeError
 
-# Create our `Store` context and then compile a module and create an
-# instance from the compiled module all in one go.
-store = Store()
-module = Module.from_file(store.engine, "examples/memory.wat")
-instance = Instance(store, module, [])
+def run():
+    # Create our `Store` context and then compile a module and create an
+    # instance from the compiled module all in one go.
+    store = Store()
+    module = Module.from_file(store.engine, "examples/memory.wat")
+    instance = Instance(store, module, [])
 
-# Load up our exports from the instance
-exports = instance.exports(store)
-memory = exports["memory"]
-size_fn = exports["size"]
-load_fn = exports["load"]
-store_fn = exports["store"]
+    # Load up our exports from the instance
+    exports = instance.exports(store)
+    memory = exports["memory"]
+    size_fn = exports["size"]
+    load_fn = exports["load"]
+    store_fn = exports["store"]
 
-print("Checking memory...")
-assert(memory.size(store) == 2)
-assert(memory.data_len(store) == 0x20000)
+    print("Checking memory...")
+    assert(memory.size(store) == 2)
+    assert(memory.data_len(store) == 0x20000)
 
-# Note that usage of `data_ptr` is unsafe! This is a raw C pointer which is not
-# bounds checked at all. We checked our `data_len` above but you'll want to be
-# very careful when accessing data through `data_ptr()`
-assert(memory.data_ptr(store)[0] == 0)
-assert(memory.data_ptr(store)[0x1000] == 1)
-assert(memory.data_ptr(store)[0x1003] == 4)
+    # Note that usage of `data_ptr` is unsafe! This is a raw C pointer which is not
+    # bounds checked at all. We checked our `data_len` above but you'll want to be
+    # very careful when accessing data through `data_ptr()`
+    assert(memory.data_ptr(store)[0] == 0)
+    assert(memory.data_ptr(store)[0x1000] == 1)
+    assert(memory.data_ptr(store)[0x1003] == 4)
 
-assert(size_fn(store) == 2)
-assert(load_fn(store, 0) == 0)
-assert(load_fn(store, 0x1000) == 1)
-assert(load_fn(store, 0x1003) == 4)
-assert(load_fn(store, 0x1ffff) == 0)
-
-
-def assert_traps(func):
-    try:
-        func()
-        assert(False)
-    except Trap:
-        pass
-    except WasmtimeError:
-        pass
+    assert(size_fn(store) == 2)
+    assert(load_fn(store, 0) == 0)
+    assert(load_fn(store, 0x1000) == 1)
+    assert(load_fn(store, 0x1003) == 4)
+    assert(load_fn(store, 0x1ffff) == 0)
 
 
-# out of bounds trap
-assert_traps(lambda: load_fn(store, 0x20000))
+    def assert_traps(func):
+        try:
+            func()
+            assert(False)
+        except Trap:
+            pass
+        except WasmtimeError:
+            pass
 
-print("Mutating memory...")
-memory.data_ptr(store)[0x1003] = 5
-store_fn(store, 0x1002, 6)
-# out of bounds trap
-assert_traps(lambda: store_fn(store, 0x20000, 0))
 
-assert(memory.data_ptr(store)[0x1002] == 6)
-assert(memory.data_ptr(store)[0x1003] == 5)
-assert(load_fn(store, 0x1002) == 6)
-assert(load_fn(store, 0x1003) == 5)
+    # out of bounds trap
+    assert_traps(lambda: load_fn(store, 0x20000))
 
-# Grow memory.
-print("Growing memory...")
-assert(memory.grow(store, 1))
-assert(memory.size(store) == 3)
-assert(memory.data_len(store) == 0x30000)
+    print("Mutating memory...")
+    memory.data_ptr(store)[0x1003] = 5
+    store_fn(store, 0x1002, 6)
+    # out of bounds trap
+    assert_traps(lambda: store_fn(store, 0x20000, 0))
 
-assert(load_fn(store, 0x20000) == 0)
-store_fn(store, 0x20000, 0)
-assert_traps(lambda: load_fn(store, 0x30000))
-assert_traps(lambda: store_fn(store, 0x30000, 0))
+    assert(memory.data_ptr(store)[0x1002] == 6)
+    assert(memory.data_ptr(store)[0x1003] == 5)
+    assert(load_fn(store, 0x1002) == 6)
+    assert(load_fn(store, 0x1003) == 5)
 
-# Memory can fail to grow
-assert_traps(lambda: memory.grow(store, 1))
-assert(memory.grow(store, 0))
+    # Grow memory.
+    print("Growing memory...")
+    assert(memory.grow(store, 1))
+    assert(memory.size(store) == 3)
+    assert(memory.data_len(store) == 0x30000)
 
-print("Creating stand-alone memory...")
-memorytype = MemoryType(Limits(5, 5))
-memory2 = Memory(store, memorytype)
-assert(memory2.size(store) == 5)
-assert_traps(lambda: memory2.grow(store, 1))
-assert(memory2.grow(store, 0))
+    assert(load_fn(store, 0x20000) == 0)
+    store_fn(store, 0x20000, 0)
+    assert_traps(lambda: load_fn(store, 0x30000))
+    assert_traps(lambda: store_fn(store, 0x30000, 0))
+
+    # Memory can fail to grow
+    assert_traps(lambda: memory.grow(store, 1))
+    assert(memory.grow(store, 0))
+
+    print("Creating stand-alone memory...")
+    memorytype = MemoryType(Limits(5, 5))
+    memory2 = Memory(store, memorytype)
+    assert(memory2.size(store) == 5)
+    assert_traps(lambda: memory2.grow(store, 1))
+    assert(memory2.grow(store, 0))
+
+if __name__ == '__main__':
+    run()

--- a/examples/multi.py
+++ b/examples/multi.py
@@ -3,47 +3,51 @@
 
 from wasmtime import Config, Store, Engine, Module, FuncType, Func, ValType, Instance
 
-# Configure our `Store`, but be sure to use a `Config` that enables the
-# wasm multi-value feature since it's not stable yet.
-print("Initializing...")
-config = Config()
-config.wasm_multi_value = True
-store = Store(Engine(config))
+def run():
+    # Configure our `Store`, but be sure to use a `Config` that enables the
+    # wasm multi-value feature since it's not stable yet.
+    print("Initializing...")
+    config = Config()
+    config.wasm_multi_value = True
+    store = Store(Engine(config))
 
-print("Compiling module...")
-module = Module.from_file(store.engine, "examples/multi.wat")
+    print("Compiling module...")
+    module = Module.from_file(store.engine, "examples/multi.wat")
 
-print("Creating callback...")
-callback_type = FuncType([ValType.i32(), ValType.i64()], [ValType.i64(), ValType.i32()])
-
-
-def callback(a, b):
-    return [b + 1, a + 1]
+    print("Creating callback...")
+    callback_type = FuncType([ValType.i32(), ValType.i64()], [ValType.i64(), ValType.i32()])
 
 
-callback_func = Func(store, callback_type, callback)
+    def callback(a, b):
+        return [b + 1, a + 1]
 
-print("Instantiating module...")
-instance = Instance(store, module, [callback_func])
 
-print("Extracting export...")
-g = instance.exports(store)["g"]
+    callback_func = Func(store, callback_type, callback)
 
-print("Calling export \"g\"...")
-results = g(store, 1, 3)
-print("> {} {}".format(results[0], results[1]))
+    print("Instantiating module...")
+    instance = Instance(store, module, [callback_func])
 
-assert(results[0] == 4)
-assert(results[1] == 2)
+    print("Extracting export...")
+    g = instance.exports(store)["g"]
 
-print("Calling export \"round_trip_many\"...")
-round_trip_many = instance.exports(store)["round_trip_many"]
-results = round_trip_many(store, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    print("Calling export \"g\"...")
+    results = g(store, 1, 3)
+    print("> {} {}".format(results[0], results[1]))
 
-print("Printing result...")
-print(">")
-for r in results:
-    print("  %d" % r)
-assert(len(results) == 10)
-for i, r in enumerate(results):
-    assert(i == r)
+    assert(results[0] == 4)
+    assert(results[1] == 2)
+
+    print("Calling export \"round_trip_many\"...")
+    round_trip_many = instance.exports(store)["round_trip_many"]
+    results = round_trip_many(store, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+    print("Printing result...")
+    print(">")
+    for r in results:
+        print("  %d" % r)
+    assert(len(results) == 10)
+    for i, r in enumerate(results):
+        assert(i == r)
+
+if __name__ == '__main__':
+    run()

--- a/wasmtime/_value.py
+++ b/wasmtime/_value.py
@@ -118,7 +118,6 @@ class Val:
                 raise TypeError("wrong type of `Val` provided")
             return val._new_raw(store)
         if ty == ValType.externref():
-            print('convert to externref', val);
             return Val.externref(val)._new_raw(store)
         elif isinstance(val, int):
             if ty == ValType.i32():


### PR DESCRIPTION
Avoids unnecessarily compiling/running things when testing for example.