### PR TITLE
Fix defining fields of forward-declared structures

### DIFF
--- a/ci/cbindgen.py
+++ b/ci/cbindgen.py
@@ -53,7 +53,7 @@ class Visitor(c_ast.NodeVisitor):
                 decl.name = '_anon_' + str(anon_decl)
 
         if node.name in self.forward_declared:
-            self.ret += "{}._fields = [ # type: ignore\n".format(node.name)
+            self.ret += "{}._fields_ = [\n".format(node.name)
         else:
             self.ret += "class {}(Structure):\n".format(node.name)
             self.ret += "    _fields_ = [\n"

--- a/wasmtime/_bindings.py
+++ b/wasmtime/_bindings.py
@@ -3942,14 +3942,14 @@ class wasmtime_component_valunion(Union):
 
 wasmtime_component_valunion_t = wasmtime_component_valunion
 
-wasmtime_component_val._fields = [ # type: ignore
+wasmtime_component_val._fields_ = [
         ("kind", wasmtime_component_valkind_t),
         ("of", wasmtime_component_valunion_t),
     ]
 
 wasmtime_component_val_t = wasmtime_component_val
 
-wasmtime_component_valrecord_entry._fields = [ # type: ignore
+wasmtime_component_valrecord_entry._fields_ = [
         ("name", wasm_name_t),
         ("val", wasmtime_component_val_t),
     ]


### PR DESCRIPTION
This fixes a typo in the bindings generation script which set the `_fields` field rather than `_fields_`