### PR TITLE
Remove componentize-py dependency, no longer needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ testing = [
     "pycparser",
     "pytest-mypy",
     "pytest",
-    # componentize-py only support x86_64 builds on Windows
-    # platform.machine() on Windows returns 'AMD64' for x86_64
-    "componentize-py; platform_system != 'Windows' or platform_machine == 'AMD64'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Following deletion of wasmtime.loader and wasmtime.bindgen (93261d0d882a971bcb17aaab6472e936d3ef0c05) componentize-py is no longer used by any code or build steps.

Refs #310