### PR TITLE
Fix MRO shadowing of VariantLikeType.add_classes

### DIFF
--- a/tests/component/test_func.py
+++ b/tests/component/test_func.py
@@ -432,6 +432,12 @@ class TestFunc(unittest.TestCase):
         self.roundtrip_simple('(result)', 'i32', [Variant('ok'), Variant('err')])
 
 
+    def test_variant_add_classes(self):
+        from wasmtime.component._types import VariantType, OptionType, ResultType, VariantLikeType
+        for cls in [VariantType, OptionType, ResultType]:
+            self.assertTrue(issubclass(cls, VariantLikeType))
+            self.assertEqual(cls.add_classes, VariantLikeType.add_classes)
+
     # TODO: roundtrip future
     # TODO: roundtrip stream
     # TODO: roundtrip error-context

--- a/wasmtime/component/_types.py
+++ b/wasmtime/component/_types.py
@@ -701,7 +701,7 @@ class Variant:
 case_test_cache: Set[type] = set()
 
 
-class VariantLikeType:
+class VariantLikeType(ValType):
     @abstractmethod
     def _cases(self) -> List[Tuple[str, Optional['ValType']]]:
         pass
@@ -776,7 +776,7 @@ class VariantLikeType:
         raise ValueError(f"tag {tag} not found in variant cases")
 
 
-class VariantType(Managed["ctypes._Pointer[ffi.wasmtime_component_variant_type_t]"], ValType, VariantLikeType):
+class VariantType(Managed["ctypes._Pointer[ffi.wasmtime_component_variant_type_t]"], VariantLikeType):
     def _delete(self, ptr: "ctypes._Pointer[ffi.wasmtime_component_variant_type_t]") -> None:
         ffi.wasmtime_component_variant_type_delete(ptr)
 
@@ -903,7 +903,7 @@ class EnumType(Managed["ctypes._Pointer[ffi.wasmtime_component_enum_type_t]"], V
         return ret
 
 
-class OptionType(Managed["ctypes._Pointer[ffi.wasmtime_component_option_type_t]"], ValType, VariantLikeType):
+class OptionType(Managed["ctypes._Pointer[ffi.wasmtime_component_option_type_t]"], VariantLikeType):
     def _delete(self, ptr: "ctypes._Pointer[ffi.wasmtime_component_option_type_t]") -> None:
         ffi.wasmtime_component_option_type_delete(ptr)
 
@@ -947,7 +947,7 @@ class OptionType(Managed["ctypes._Pointer[ffi.wasmtime_component_option_type_t]"
 
 
 
-class ResultType(Managed["ctypes._Pointer[ffi.wasmtime_component_result_type_t]"], ValType, VariantLikeType):
+class ResultType(Managed["ctypes._Pointer[ffi.wasmtime_component_result_type_t]"], VariantLikeType):
     def _delete(self, ptr: "ctypes._Pointer[ffi.wasmtime_component_result_type_t]") -> None:
         ffi.wasmtime_component_result_type_delete(ptr)
 


### PR DESCRIPTION
VariantLikeType.add_classes is shadowed by ValType.add_classes in the MRO for VariantType, OptionType, and ResultType. ValType defines add_classes as abstract (no-op), and because it comes before VariantLikeType in C3 linearization, the real implementation never runs. This means tagged variants can't be passed as function arguments since add_classes returns an empty set, so the isinstance check in _lower always fails with "value not valid for this variant".

For example, passing a Variant("blah", Record(...)) into an option<model-config> field always fails because the option's "some" case can't match the value.

The fix makes VariantLikeType inherit from ValType, then drops the now-redundant ValType from classes that get it through VariantLikeType. This puts VariantLikeType.add_classes before ValType.add_classes in the MRO. No other method resolution is affected since convert_to_c and convert_from_c are defined directly on the concrete classes.