### PR TITLE
Add wasi:http support

### DIFF
--- a/tests/component/test_linker.py
+++ b/tests/component/test_linker.py
@@ -1,6 +1,6 @@
 import unittest
 
-from wasmtime import Engine, WasmtimeError, Module, Store
+from wasmtime import Engine, WasiConfig, WasmtimeError, Module, Store
 from wasmtime.component import Linker, Component, LinkerInstance
 
 
@@ -142,6 +142,34 @@ class TestLinker(unittest.TestCase):
         linker.allow_shadowing = True
         with linker.root() as l:
             l.add_func('x', lambda: None)
+
+    def test_add_wasi_http(self):
+        engine = Engine()
+        linker = Linker(engine)
+        linker.add_wasip2()
+        linker.add_wasi_http()
+
+        with linker.root():
+            with self.assertRaises(WasmtimeError):
+                linker.add_wasi_http()
+
+        linker.close()
+
+        with Linker(engine) as l2:
+            l2.add_wasip2()
+            l2.add_wasi_http()
+            with self.assertRaises(WasmtimeError):
+                l2.add_wasi_http()
+            l2.allow_shadowing = True
+            l2.add_wasi_http()
+
+    def test_set_wasi_http(self):
+        engine = Engine()
+        store = Store(engine)
+        wasi = WasiConfig()
+        wasi.inherit_stdout()
+        store.set_wasi(wasi)
+        store.set_wasi_http()
 
     def test_define_unknown_imports_as_traps(self):
         engine = Engine()

--- a/wasmtime/_store.py
+++ b/wasmtime/_store.py
@@ -97,6 +97,15 @@ class Store(Managed["ctypes._Pointer[ffi.wasmtime_store_t]"]):
         if error:
             raise WasmtimeError._from_ptr(error)
 
+    def set_wasi_http(self) -> None:
+        """
+        Initializes the WASI HTTP context for this store.
+
+        Must be called before instantiating a component that uses `wasi:http`.
+        Requires WASI to be configured first via `set_wasi()`.
+        """
+        ffi.wasmtime_context_set_wasi_http(self._context())
+
     def set_epoch_deadline(self, ticks_after_current: int) -> None:
         """
         Configures the relative epoch deadline, after the current engine's

--- a/wasmtime/component/_linker.py
+++ b/wasmtime/component/_linker.py
@@ -73,6 +73,18 @@ class Linker(Managed["ctypes._Pointer[ffi.wasmtime_component_linker_t]"]):
         if err:
             raise WasmtimeError._from_ptr(err)
 
+    def add_wasi_http(self) -> None:
+        """
+        Adds the WASI HTTP API definitions to this linker.
+
+        This adds `wasi:http/types` and `wasi:http/outgoing-handler`.
+        Requires WASIp2 to be added first via `add_wasip2()`.
+        """
+        self._assert_not_locked()
+        err = ffi.wasmtime_component_linker_add_wasi_http(self.ptr())
+        if err:
+            raise WasmtimeError._from_ptr(err)
+
     def instantiate(self, store: Storelike, component: Component) -> Instance:
         """
         Instantiates the given component using this linker within the provided


### PR DESCRIPTION
Depends on bytecodealliance/wasmtime#12950 which adds wasmtime_component_linker_add_wasi_http and wasmtime_context_set_wasi_http to the C API.

Adds linker.add_wasi_http() and store.set_wasi_http() following the same pattern as add_wasip2 and set_wasi. _bindings.py was regenerated with cbindgen.py against the updated C headers.