### PR TITLE
Fix BaseException escape from host callback trampoline (#336)

### DIFF
--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -85,6 +85,39 @@ class TestFunc(unittest.TestCase):
         with self.assertRaises(Exception, msg="hello"):
             func(store)
 
+    def test_host_base_exception(self):
+        # Regression test for #336: a BaseException subclass raised from a
+        # host callback (KeyboardInterrupt, SystemExit, custom BaseException
+        # subclasses) used to escape the trampoline's `except Exception`
+        # handler and abort the process inside Rust's array_call_trampoline
+        # with a libmalloc SIGABRT. It must propagate cleanly to the caller.
+        store = Store()
+        ty = FuncType([], [])
+
+        def raise_keyboard_interrupt():
+            raise KeyboardInterrupt
+
+        func = Func(store, ty, raise_keyboard_interrupt)
+        with self.assertRaises(KeyboardInterrupt):
+            func(store)
+
+        def raise_system_exit():
+            raise SystemExit(0)
+
+        func = Func(store, ty, raise_system_exit)
+        with self.assertRaises(SystemExit):
+            func(store)
+
+        class CustomBaseException(BaseException):
+            pass
+
+        def raise_custom():
+            raise CustomBaseException("custom")
+
+        func = Func(store, ty, raise_custom)
+        with self.assertRaises(CustomBaseException):
+            func(store)
+
     def test_type(self):
         store = Store()
         i32 = ValType.i32()

--- a/wasmtime/_func.py
+++ b/wasmtime/_func.py
@@ -209,7 +209,7 @@ def trampoline(idx, caller, params, nparams, results, nresults):  # type: ignore
             for i, result in enumerate(pyresults):
                 results[i] = Val._convert_to_raw(caller, result_tys[i], result)
         return 0
-    except Exception as e:
+    except BaseException as e:
         global LAST_EXCEPTION
         LAST_EXCEPTION = e
         trap = Trap("python exception")._consume()


### PR DESCRIPTION
## Summary

Fixes #336.

The host-callback trampoline in `wasmtime/_func.py` caught `Exception` rather than `BaseException`, so `BaseException` subclasses (`KeyboardInterrupt`, `SystemExit`, custom `BaseException` subclasses) escaped the handler and caused the Python process to SIGABRT inside Rust's `HostFunc::array_call_trampoline` (libmalloc "pointer being freed was not allocated") rather than propagating to the Python caller.

The fix broadens the catch to `BaseException`. The existing `LAST_EXCEPTION` / `Trap("python exception")` machinery already handles re-raising on the Python side, so no other code changes are needed.

This is **Option A** from the issue — the minimum diff that closes the abort. Today, the original Python exception is re-raised at the call boundary via `maybe_raise_last_exn`, so after this fix `KeyboardInterrupt` from a host callback comes back as `KeyboardInterrupt` and `^C` feels like `^C`. **Option B** (catch `BaseException` but explicitly preserve `KeyboardInterrupt`/`SystemExit` semantics in some other way, or re-shape propagation) would be a behavioural decision; happy to send a follow-up PR if you'd prefer something different here. Flagging the choice for maintainer preference.

## Test plan

- [x] Existing test suite passes (`uv run pytest`)
- [x] New regression test `test_host_base_exception` covers `KeyboardInterrupt`, `SystemExit`, and a custom `BaseException` subclass from host callbacks
- [x] Verified reproducer from #336 propagates cleanly after the fix
- [x] Verified the new test aborts (`Fatal Python error: Aborted`) before the fix, proving the test exercises the bug

## Notes

- Reproducer in #336 was on macOS 15.7.3 + Python 3.14.3 + wasmtime-py 44.0.0. The bug is in pure-Python code and the C ABI contract, so it's platform-independent — macOS just gives the loudest crash because of libmalloc's poison-page guard. Linux glibc would also abort but the exact symptom may differ.
- The annotation `LAST_EXCEPTION: Optional[Exception]` is now technically narrower than what we may store. Project mypy settings don't flag it; left untouched to keep the diff minimal, but happy to widen it if preferred.
